### PR TITLE
Fix missing removal of `mod filesystem`

### DIFF
--- a/rust/kernel/src/lib.rs
+++ b/rust/kernel/src/lib.rs
@@ -15,7 +15,6 @@ pub mod c_types;
 pub mod chrdev;
 mod error;
 pub mod file_operations;
-pub mod filesystem;
 pub mod prelude;
 pub mod printk;
 pub mod random;


### PR DESCRIPTION
In PR #5 we missed the import removal (let's get some CI)