### PR TITLE
Pin dependencies exactly

### DIFF
--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-bitflags = "1"
+bitflags = "=1.2.1"
 module = { path = "../module" }
 
 [build-dependencies]
-bindgen = "0.54"
+bindgen = "=0.54.0"
 shlex = { path = "../shlex" }
 


### PR DESCRIPTION
See #12 

This ensures reproducible builds and no unintended updates even if a developer runs `cargo` on their own without one of the locking flags. We will explicitly manage them.

It is likely that we will change how we manage the dependencies, but for the moment, it is good to have the semantics we will anyway want.