### PR TITLE
Implement THIS_MODULE equivalent

### DIFF
--- a/rust/kernel/src/chrdev.rs
+++ b/rust/kernel/src/chrdev.rs
@@ -38,7 +38,7 @@ impl Builder {
         self
     }
 
-    pub fn build(self) -> KernelResult<Registration> {
+    pub fn build(self, this_module: *mut bindings::module) -> KernelResult<Registration> {
         let mut dev: bindings::dev_t = 0;
         let res = unsafe {
             bindings::alloc_chrdev_region(
@@ -58,8 +58,7 @@ impl Builder {
         for (i, file_op) in self.file_ops.iter().enumerate() {
             unsafe {
                 bindings::cdev_init(&mut cdevs[i], *file_op);
-                // TODO: proper `THIS_MODULE` handling
-                cdevs[i].owner = core::ptr::null_mut();
+                cdevs[i].owner = this_module;
                 let rc = bindings::cdev_add(&mut cdevs[i], dev + i as bindings::dev_t, 1);
                 if rc != 0 {
                     // Clean up the ones that were allocated.

--- a/rust/module/src/lib.rs
+++ b/rust/module/src/lib.rs
@@ -273,6 +273,8 @@ pub fn module(ts: TokenStream) -> TokenStream {
             unsafe impl Sync for __THIS_MODULE {{
             }}
 
+            // TODO: provide a better abstraction to avoid passing around
+            // `THIS_MODULE.0`, i.e. `this_module: *mut bindings::module` parameters.
             #[cfg(MODULE)]
             static THIS_MODULE: __THIS_MODULE = __THIS_MODULE(unsafe {{ &kernel::bindings::__this_module }} as *const _ as *mut kernel::bindings::module);
 


### PR DESCRIPTION
Not sure what is the best/cleanest interface to give users -- currently they need to pass others `THIS_MODULE.0`, which does not look that good. Perhaps giving them a `get_this_module()` that returns that is better. Also we could consider having a `struct ThisModule`. Anyway, this gives us access to the address.