### PR TITLE
Add fsync file operation

### DIFF
--- a/rust/kernel/src/file_operations.rs
+++ b/rust/kernel/src/file_operations.rs
@@ -158,7 +158,7 @@ unsafe extern "C" fn fsync_callback<T: FileOperations>(
     let fsync = T::FSYNC.unwrap();
     let f = &*((*file).private_data as *const T);
     match fsync(f, &File::from_ptr(file), start, end, datasync) {
-        Ok(result) => result as c_types::c_int,
+        Ok(result) => result.try_into().unwrap(),
         Err(e) => e.to_kernel_errno(),
     }
 }


### PR DESCRIPTION
Adding support for `fsync`. These changes are copied over from https://github.com/fishinabarrel/linux-kernel-module-rust/pull/276. It looks like the test suite isn't included here though - what's the recommended way to do testing?