### PR TITLE
Ensure we don't break conditional compilation

### DIFF
--- a/rust/kernel/src/lib.rs
+++ b/rust/kernel/src/lib.rs
@@ -5,6 +5,11 @@
 #![no_std]
 #![feature(allocator_api, alloc_error_handler)]
 
+// Ensure conditional compilation based on the kernel configuration works;
+// otherwise we may silently break things like initcall handling.
+#[cfg(not(CONFIG_HAS_RUST))]
+compile_error!("Missing kernel configuration for conditional compilation");
+
 extern crate alloc;
 
 use core::panic::PanicInfo;


### PR DESCRIPTION
At the moment, any mistake passing the kernel configuration
for conditional compilation means we break things silently,
like initcall handling which implies panics or memory
corruption [1].

Let's prevent that from happening again.

[1] https://github.com/Rust-for-Linux/linux/pull/23

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>