### PR TITLE
CI: test O= builds too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         mode: [debug, release]
         module: [builtin, loadable]
+        outputdir: [src, build]
 
     steps:
       # Setup
@@ -24,15 +25,34 @@ jobs:
 
       # Build
       - run: cp .github/workflows/kernel-${{ matrix.mode }}.config .config
+
       - if: matrix.module == 'loadable'
         run: sed -i -E 's/^(CONFIG_RUST_EXAMPLE=)(y)$/\1m/g' .config
-      - run: make CC=clang-10 LLVM_CONFIG_PATH=llvm-config-10 -j3
+
+      - if: matrix.outputdir == 'build'
+        run: mkdir build && mv .config build/.config
+
+      - if: matrix.outputdir == 'src'
+        run: make         CC=clang-10 LLVM_CONFIG_PATH=llvm-config-10 -j3
+      - if: matrix.outputdir == 'build'
+        run: make O=build CC=clang-10 LLVM_CONFIG_PATH=llvm-config-10 -j3
 
       # Run
       - if: matrix.module == 'builtin'
         run: sed -i '/rust_example/d' .github/workflows/qemu-initramfs.desc
-      - run: usr/gen_init_cpio .github/workflows/qemu-initramfs.desc > qemu-initramfs.img
-      - run: qemu-system-x86_64 -kernel arch/x86/boot/bzImage -initrd qemu-initramfs.img -cpu Cascadelake-Server -smp 2 -append "console=ttyS0 ${{ matrix.module == 'builtin' && 'rust_example.my_i32=123321' || '' }}" -nographic -no-reboot | tee qemu-stdout.log
+
+      - if: matrix.outputdir == 'build'
+        run: sed -i 's:drivers/:build/drivers/:' .github/workflows/qemu-initramfs.desc
+
+      - if: matrix.outputdir == 'src'
+        run:       usr/gen_init_cpio .github/workflows/qemu-initramfs.desc > qemu-initramfs.img
+      - if: matrix.outputdir == 'build'
+        run: build/usr/gen_init_cpio .github/workflows/qemu-initramfs.desc > qemu-initramfs.img
+
+      - if: matrix.outputdir == 'src'
+        run: qemu-system-x86_64 -kernel       arch/x86/boot/bzImage -initrd qemu-initramfs.img -cpu Cascadelake-Server -smp 2 -nographic -no-reboot -append "console=ttyS0 ${{ matrix.module == 'builtin' && 'rust_example.my_i32=123321' || '' }}" | tee qemu-stdout.log
+      - if: matrix.outputdir == 'build'
+        run: qemu-system-x86_64 -kernel build/arch/x86/boot/bzImage -initrd qemu-initramfs.img -cpu Cascadelake-Server -smp 2 -nographic -no-reboot -append "console=ttyS0 ${{ matrix.module == 'builtin' && 'rust_example.my_i32=123321' || '' }}" | tee qemu-stdout.log
 
       # Check
       - run: grep -F 'Rust Example (init)' qemu-stdout.log


### PR DESCRIPTION
O= builds do not work at the moment, but we will fix them soon.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>