### PR TITLE
CI: only run tests on rust branch and PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,7 @@
-on: [pull_request, push]
+on:
+  pull_request: {}
+  push:
+    branches: [rust]
 
 jobs:
   ci:


### PR DESCRIPTION
This avoids running the tests 2x on PRs that exist on this repo (as opposed to forks).