### PR TITLE
Bindings: #include sysctl (some configs need it)

### DIFF
--- a/rust/kernel/src/bindings_helper.h
+++ b/rust/kernel/src/bindings_helper.h
@@ -5,6 +5,7 @@
 #include <linux/module.h>
 #include <linux/random.h>
 #include <linux/slab.h>
+#include <linux/sysctl.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
 


### PR DESCRIPTION
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>