### PR TITLE
Allow implementations to choose how to allocate memory for file objects.

### DIFF
--- a/drivers/char/rust_example/src/lib.rs
+++ b/drivers/char/rust_example/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::pin::Pin;
 use kernel::prelude::*;
-use kernel::{cstr, file_operations::FileOperations, miscdev};
+use kernel::{cstr, file_operations::FileOperations, miscdev, try_alloc};
 
 module! {
     type: RustExample,
@@ -33,9 +33,11 @@ module! {
 struct RustFile;
 
 impl FileOperations for RustFile {
-    fn open() -> KernelResult<Self> {
+    type Wrapper = Box<Self>;
+
+    fn open() -> KernelResult<Self::Wrapper> {
         println!("rust file was opened!");
-        Ok(Self)
+        try_alloc(Self)
     }
 }
 


### PR DESCRIPTION
This patch allows implementations of the FileOperations trait to decide
how the file objects created by the `open` function are allocated. This
allows them to choose, for example, `Arc` instead of `Box` if they need
reference couting; it also allows them to know the address of the file
object before returning it, so they can initialise any state that cannot
be moved after initialisation.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>