### PR TITLE
Use new nightly function for fallible allocation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - run: sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y clang-11 libelf-dev qemu-system-x86 busybox-static
-      - run: rustup default nightly-2020-08-27
+      - run: rustup default nightly-2021-01-02
       - run: rustup component add rustfmt
       - run: rustup component add rust-src
 

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -13,7 +13,7 @@ rustc and cargo
 ***************
 
 A recent nightly Rust toolchain (with, at least, ``rustc`` and ``cargo``)
-is required, e.g. ``nightly-2020-08-27``. In the future, this restriction
+is required, e.g. ``nightly-2021-01-02``. In the future, this restriction
 will be lifted.
 
 If you are using ``rustup``, run::

--- a/rust/kernel/src/lib.rs
+++ b/rust/kernel/src/lib.rs
@@ -13,11 +13,8 @@ compile_error!("Missing kernel configuration for conditional compilation");
 extern crate alloc;
 
 use alloc::boxed::Box;
-use core::alloc::Layout;
-use core::mem::MaybeUninit;
 use core::panic::PanicInfo;
 use core::pin::Pin;
-use core::ptr::NonNull;
 
 mod allocator;
 pub mod bindings;
@@ -66,25 +63,7 @@ static ALLOCATOR: allocator::KernelAllocator = allocator::KernelAllocator;
 /// Attempts to allocate memory for `value` using the global allocator. On success, `value` is
 /// moved into it and returned to the caller wrapped in a `Box`.
 pub fn try_alloc<T>(value: T) -> KernelResult<Box<T>> {
-    let layout = Layout::new::<MaybeUninit<T>>();
-    let ptr: NonNull<MaybeUninit<T>> = if layout.size() == 0 {
-        NonNull::dangling()
-    // SAFETY: We checked that the layout size is nonzero.
-    } else if let Some(nn) = NonNull::new(unsafe { alloc::alloc::alloc(layout) }) {
-        nn.cast()
-    } else {
-        return Err(Error::ENOMEM);
-    };
-
-    unsafe {
-        // SAFETY: `ptr` was just allocated and isn't used afterwards.
-        let mut b = Box::from_raw(ptr.as_ptr());
-        // SAFETY: The pointer is valid for write and is properly aligned. The dangling pointer
-        // case is only when the size of the value is zero; writing zero bytes to it is allowed.
-        b.as_mut_ptr().write(value);
-        // SAFETY: The value was initialised in the call above.
-        Ok(Box::from_raw(Box::into_raw(b) as *mut T))
-    }
+    Box::try_new(value).map_err(|_| Error::ENOMEM)
 }
 
 /// Attempts to allocate memory for `value` using the global allocator. On success, `value` is


### PR DESCRIPTION
Let's us delete a bunch of subtle unsafe code.

I considered removing `try_alloc` entirely, and just inlining it into callers, but decided not to... for now