### PR TITLE
Provide a From<AllocError> impl for KernelError

### DIFF
--- a/drivers/char/rust_example/src/lib.rs
+++ b/drivers/char/rust_example/src/lib.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #![no_std]
-#![feature(global_asm)]
+#![feature(allocator_api, global_asm)]
 
 extern crate alloc;
 
 use alloc::boxed::Box;
 use core::pin::Pin;
 use kernel::prelude::*;
-use kernel::{cstr, file_operations::FileOperations, miscdev, try_alloc};
+use kernel::{cstr, file_operations::FileOperations, miscdev};
 
 module! {
     type: RustExample,
@@ -37,7 +37,7 @@ impl FileOperations for RustFile {
 
     fn open() -> KernelResult<Self::Wrapper> {
         println!("rust file was opened!");
-        try_alloc(Self)
+        Ok(Box::try_new(Self)?)
     }
 }
 

--- a/rust/kernel/src/error.rs
+++ b/rust/kernel/src/error.rs
@@ -2,6 +2,8 @@
 
 use core::num::TryFromIntError;
 
+use alloc::alloc::AllocError;
+
 use crate::bindings;
 use crate::c_types;
 
@@ -30,3 +32,9 @@ impl From<TryFromIntError> for Error {
 }
 
 pub type KernelResult<T> = Result<T, Error>;
+
+impl From<AllocError> for Error {
+    fn from(_: AllocError) -> Error {
+        Error::ENOMEM
+    }
+}

--- a/rust/kernel/src/lib.rs
+++ b/rust/kernel/src/lib.rs
@@ -12,9 +12,7 @@ compile_error!("Missing kernel configuration for conditional compilation");
 
 extern crate alloc;
 
-use alloc::boxed::Box;
 use core::panic::PanicInfo;
-use core::pin::Pin;
 
 mod allocator;
 pub mod bindings;
@@ -59,15 +57,3 @@ fn panic(_info: &PanicInfo) -> ! {
 
 #[global_allocator]
 static ALLOCATOR: allocator::KernelAllocator = allocator::KernelAllocator;
-
-/// Attempts to allocate memory for `value` using the global allocator. On success, `value` is
-/// moved into it and returned to the caller wrapped in a `Box`.
-pub fn try_alloc<T>(value: T) -> KernelResult<Box<T>> {
-    Box::try_new(value).map_err(|_| Error::ENOMEM)
-}
-
-/// Attempts to allocate memory for `value` using the global allocator. On success, `value` is
-/// moved into it and returned to the caller wrapped in a pinned `Box`.
-pub fn try_alloc_pinned<T>(value: T) -> KernelResult<Pin<Box<T>>> {
-    Ok(Pin::from(try_alloc(value)?))
-}

--- a/rust/kernel/src/miscdev.rs
+++ b/rust/kernel/src/miscdev.rs
@@ -28,7 +28,7 @@ impl Registration {
         name: CStr<'static>,
         minor: Option<i32>,
     ) -> KernelResult<Pin<Box<Self>>> {
-        let mut r = crate::try_alloc_pinned(Self::new())?;
+        let mut r = Pin::from(Box::try_new(Self::new())?);
         r.as_mut().register::<T>(name, minor)?;
         Ok(r)
     }

--- a/rust/kernel/src/sysctl.rs
+++ b/rust/kernel/src/sysctl.rs
@@ -9,7 +9,6 @@ use core::sync::atomic;
 use crate::bindings;
 use crate::c_types;
 use crate::error;
-use crate::try_alloc;
 use crate::types;
 use crate::user_ptr::{UserSlicePtr, UserSlicePtrWriter};
 
@@ -130,7 +129,7 @@ impl<T: SysctlStorage> Sysctl<T> {
             return Err(error::Error::EINVAL);
         }
 
-        let storage = try_alloc(storage)?;
+        let storage = Box::try_new(storage)?;
         let mut table = vec![
             bindings::ctl_table {
                 procname: name.as_ptr() as *const i8,


### PR DESCRIPTION
This makes the try_alloc functions trivial, so we inline them.