### PR TITLE
Test that `__rust_probestack` can be linked

### DIFF
--- a/drivers/char/rust_example.rs
+++ b/drivers/char/rust_example.rs
@@ -52,6 +52,13 @@ impl KernelModule for RustExample {
         println!("  my_bool:  {}", my_bool.read());
         println!("  my_i32:   {}", my_i32.read());
 
+        // Including this large variable on the stack will trigger a call to
+        // `compiler_builtins::probestack::__rust_probestack` on x86_64.
+        // This will verify that we are able to link modules which call
+        // `__rust_probestack`.
+        let x: [u64; 1028] = [5; 1028];
+        println!("Large array has length: {}", x.len());
+
         Ok(RustExample {
             message: "on the heap!".to_owned(),
             _dev: miscdev::Registration::new_pinned::<RustFile>(cstr!("rust_miscdev"), None)?,

--- a/drivers/char/rust_example_2.rs
+++ b/drivers/char/rust_example_2.rs
@@ -36,6 +36,14 @@ impl KernelModule for RustExample2 {
         println!("[2] Parameters:");
         println!("[2]   my_bool:  {}", my_bool.read());
         println!("[2]   my_i32:   {}", my_i32.read());
+
+        // Including this large variable on the stack will trigger a call to
+        // `compiler_builtins::probestack::__rust_probestack` on x86_64.
+        // This will verify that we are able to link modules which call
+        // `__rust_probestack`.
+        let x: [u64; 1028] = [5; 1028];
+        println!("Large array has length: {}", x.len());
+
         Ok(RustExample2 {
             message: "on the heap!".to_owned(),
         })

--- a/drivers/char/rust_example_3.rs
+++ b/drivers/char/rust_example_3.rs
@@ -36,6 +36,14 @@ impl KernelModule for RustExample3 {
         println!("[3] Parameters:");
         println!("[3]   my_bool:  {}", my_bool.read());
         println!("[3]   my_i32:   {}", my_i32.read());
+
+        // Including this large variable on the stack will trigger a call to 
+        // `compiler_builtins::probestack::__rust_probestack` on x86_64.
+        // This will verify that we are able to link modules which call
+        // `__rust_probestack`.
+        let x: [u64; 1028] = [5; 1028];
+        println!("Large array has length: {}", x.len());
+
         Ok(RustExample3 {
             message: "on the heap!".to_owned(),
         })

--- a/drivers/char/rust_example_3.rs
+++ b/drivers/char/rust_example_3.rs
@@ -37,7 +37,7 @@ impl KernelModule for RustExample3 {
         println!("[3]   my_bool:  {}", my_bool.read());
         println!("[3]   my_i32:   {}", my_i32.read());
 
-        // Including this large variable on the stack will trigger a call to 
+        // Including this large variable on the stack will trigger a call to
         // `compiler_builtins::probestack::__rust_probestack` on x86_64.
         // This will verify that we are able to link modules which call
         // `__rust_probestack`.

--- a/drivers/char/rust_example_4.rs
+++ b/drivers/char/rust_example_4.rs
@@ -36,6 +36,14 @@ impl KernelModule for RustExample4 {
         println!("[4] Parameters:");
         println!("[4]   my_bool:  {}", my_bool.read());
         println!("[4]   my_i32:   {}", my_i32.read());
+
+        // Including this large variable on the stack will trigger a call to
+        // `compiler_builtins::probestack::__rust_probestack` on x86_64.
+        // This will verify that we are able to link modules which call
+        // `__rust_probestack`.
+        let x: [u64; 1028] = [5; 1028];
+        println!("Large array has length: {}", x.len());
+
         Ok(RustExample4 {
             message: "on the heap!".to_owned(),
         })

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -5,7 +5,6 @@ obj-$(CONFIG_RUST) += core.o compiler_builtins.o alloc.o kernel.o
 extra-$(CONFIG_RUST) += bindings_generated.rs libmodule.so
 extra-$(CONFIG_RUST) += exports_core_generated.h exports_alloc_generated.h
 extra-$(CONFIG_RUST) += exports_kernel_generated.h
-extra-$(CONFIG_RUST) += exports_compiler_builtins_generated.h
 
 ifdef CONFIG_CC_IS_CLANG
 bindgen_c_flags = $(c_flags)
@@ -61,10 +60,6 @@ $(objtree)/rust/exports_alloc_generated.h: $(objtree)/rust/alloc.o FORCE
 
 $(objtree)/rust/exports_kernel_generated.h: exports_target_type := _RUST_GPL
 $(objtree)/rust/exports_kernel_generated.h: $(objtree)/rust/kernel.o FORCE
-	$(call if_changed,exports)
-
-$(objtree)/rust/exports_compiler_builtins_generated.h: exports_target_type := _RUST
-$(objtree)/rust/exports_compiler_builtins_generated.h: $(objtree)/rust/compiler_builtins.o FORCE
 	$(call if_changed,exports)
 
 quiet_cmd_rustc_procmacro = RUSTC P $@

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -5,6 +5,7 @@ obj-$(CONFIG_RUST) += core.o compiler_builtins.o alloc.o kernel.o
 extra-$(CONFIG_RUST) += bindings_generated.rs libmodule.so
 extra-$(CONFIG_RUST) += exports_core_generated.h exports_alloc_generated.h
 extra-$(CONFIG_RUST) += exports_kernel_generated.h
+extra-$(CONFIG_RUST) += exports_compiler_builtins_generated.h
 
 ifdef CONFIG_CC_IS_CLANG
 bindgen_c_flags = $(c_flags)
@@ -60,6 +61,10 @@ $(objtree)/rust/exports_alloc_generated.h: $(objtree)/rust/alloc.o FORCE
 
 $(objtree)/rust/exports_kernel_generated.h: exports_target_type := _RUST_GPL
 $(objtree)/rust/exports_kernel_generated.h: $(objtree)/rust/kernel.o FORCE
+	$(call if_changed,exports)
+
+$(objtree)/rust/exports_compiler_builtins_generated.h: exports_target_type := _RUST
+$(objtree)/rust/exports_compiler_builtins_generated.h: $(objtree)/rust/compiler_builtins.o FORCE
 	$(call if_changed,exports)
 
 quiet_cmd_rustc_procmacro = RUSTC P $@

--- a/rust/exports.c
+++ b/rust/exports.c
@@ -16,3 +16,4 @@
 #include "exports_core_generated.h"
 #include "exports_alloc_generated.h"
 #include "exports_kernel_generated.h"
+#include "exports_compiler_builtins_generated.h"

--- a/rust/exports.c
+++ b/rust/exports.c
@@ -16,4 +16,3 @@
 #include "exports_core_generated.h"
 #include "exports_alloc_generated.h"
 #include "exports_kernel_generated.h"
-#include "exports_compiler_builtins_generated.h"


### PR DESCRIPTION
Addresses https://github.com/Rust-for-Linux/linux/issues/73.

We need to export the symbols from `compiler_builtins` so that modules can reference `__rust_probestack`.