### PR TITLE
Emit `metadata` instead of `link`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         arch: [x86_64, arm64]
         toolchain: [gcc, clang, llvm]
         config: [debug, release]
-        rustc: [2021-01-02]
+        rustc: [2021-01-21]
         output: [src] # [src, build]
         install: [rustup] # [rustup, standalone]
         sysroot: [common] # [common, custom]
@@ -27,7 +27,7 @@ jobs:
           - arch: x86_64
             toolchain: gcc
             config: debug
-            rustc: 2021-01-09
+            rustc: 2021-01-21
             output: build
             install: rustup
             sysroot: custom
@@ -35,7 +35,7 @@ jobs:
           - arch: arm64
             toolchain: clang
             config: release
-            rustc: 2021-01-16
+            rustc: 2021-01-21
             output: build
             install: standalone
             sysroot: common
@@ -43,7 +43,7 @@ jobs:
           - arch: x86_64
             toolchain: llvm
             config: debug
-            rustc: 2021-01-19
+            rustc: 2021-01-21
             output: build
             install: standalone
             sysroot: custom

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@
 *.o
 *.o.*
 *.patch
-*.rlib
+*.rmeta
 *.s
 *.so
 *.so.dbg

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -21,7 +21,7 @@ rustc
 *****
 
 A recent *nightly* Rust toolchain (with, at least, ``rustc``) is required,
-e.g. ``nightly-2021-01-02``. Our goal is to use a stable toolchain as soon
+e.g. ``nightly-2021-01-21``. Our goal is to use a stable toolchain as soon
 as possible, but for the moment we depend on a handful of nightly features.
 
 If you are using ``rustup``, run::

--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -Werror=return-type -Wno-format-security \
 		   -std=gnu89
 KBUILD_CPPFLAGS := -D__KERNEL__
-KBUILD_RUSTCFLAGS := --emit=dep-info,obj,link -Zbinary_dep_depinfo=y \
+KBUILD_RUSTCFLAGS := --emit=dep-info,obj,metadata -Zbinary_dep_depinfo=y \
 		     -Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
 		     -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		     -Zsymbol-mangling-version=v0
@@ -1874,7 +1874,7 @@ clean: $(clean-dirs)
 	$(call cmd,rmfiles)
 	@find $(if $(KBUILD_EXTMOD), $(KBUILD_EXTMOD), .) $(RCS_FIND_IGNORE) \
 		\( -name '*.[aios]' -o -name '*.ko' -o -name '.*.cmd' \
-		-o -name '*.rlib' \
+		-o -name '*.rmeta' \
 		-o -name '*.ko.*' \
 		-o -name '*.dtb' -o -name '*.dtb.S' -o -name '*.dt.yaml' \
 		-o -name '*.dwo' -o -name '*.lst' \

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -64,7 +64,7 @@ $(objtree)/rust/exports_kernel_generated.h: $(objtree)/rust/kernel.o FORCE
 
 quiet_cmd_rustc_procmacro = RUSTC P $@
       cmd_rustc_procmacro = \
-	$(RUSTC) $(rustc_flags) --edition 2018 --extern proc_macro \
+	$(RUSTC) $(rustc_flags) --emit=dep-info,link --edition 2018 --extern proc_macro \
 		--crate-type proc-macro --out-dir $(objtree)/rust/ \
 		--crate-name $(patsubst lib%.so,%,$(notdir $@)) $<; \
 	mv $(objtree)/rust/$(patsubst lib%.so,%,$(notdir $@)).d $(depfile); \


### PR DESCRIPTION
It allows us to save a bit of space, ignore the duplicate object files, and the archiving steps; e.g.:

      643544 libcompiler_builtins.rlib
    64171752 libcore.rlib

vs.

      530004 libcompiler_builtins.rmeta
    63679866 libcore.rmeta

We couldn't do it right away in [1] because `rustc` required a fix [2,3]. The fix is now in [4] and available since the 2021-01-21 nightly, so now we can go ahead and make the change.

Fixes #75.

[1] https://github.com/Rust-for-Linux/linux/pull/52
[2] https://github.com/rust-lang/rust/issues/81117
[3] https://github.com/rust-lang/rust/pull/81118
[4] https://github.com/rust-lang/rust/commit/f9275e1092232fcb8ec117fc4acca990f57cba15

Suggested-by: bjorn3
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>