### PR TITLE
Integrate `compiler_builtins`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,9 +131,6 @@ jobs:
           git checkout $(rustc -vV | grep -F 'commit-hash' | awk '{print $2}')
           git submodule update --init library
 
-      # Setup: compiler-builtins source
-      - run: git clone --depth 1 -b 0.1.39 https://github.com/rust-lang/compiler-builtins.git $(rustc ${{ env.RUSTC_SYSROOT }} --print sysroot)/lib/rustlib/src/compiler-builtins
-
       # Setup: bindgen
       - run: cargo install --version 0.56.0 bindgen
 

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -49,18 +49,6 @@ repository into the installation folder of your nightly toolchain::
     git clone --recurse-submodules https://github.com/rust-lang/rust $(rustc --print sysroot)/lib/rustlib/src/rust
 
 
-compiler-builtins source
-************************
-
-The source for ``compiler-builtins`` (a Rust port of LLVM's ``compiler-rt``)
-is required.
-
-The build system expects the sources alongside the Rust ones we just installed,
-so you can clone it into the installation folder of your nightly toolchain::
-
-    git clone https://github.com/rust-lang/compiler-builtins $(rustc --print sysroot)/lib/rustlib/src/compiler-builtins
-
-
 bindgen
 *******
 

--- a/Makefile
+++ b/Makefile
@@ -502,10 +502,10 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -Werror=return-type -Wno-format-security \
 		   -std=gnu89
 KBUILD_CPPFLAGS := -D__KERNEL__
-KBUILD_RUSTCFLAGS := --emit=dep-info,obj,metadata -Zbinary_dep_depinfo=y \
+KBUILD_RUSTCFLAGS := --emit=dep-info,obj,metadata --edition=2018 \
 		     -Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
 		     -Cforce-unwind-tables=n -Ccodegen-units=1 \
-		     -Zsymbol-mangling-version=v0
+		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
 KBUILD_RUSTCFLAGS_KERNEL :=

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -64,7 +64,7 @@ $(objtree)/rust/exports_kernel_generated.h: $(objtree)/rust/kernel.o FORCE
 
 quiet_cmd_rustc_procmacro = RUSTC P $@
       cmd_rustc_procmacro = \
-	$(RUSTC) $(rustc_flags) --emit=dep-info,link --edition 2018 --extern proc_macro \
+	$(RUSTC) $(rustc_flags) --emit=dep-info,link --extern proc_macro \
 		--crate-type proc-macro --out-dir $(objtree)/rust/ \
 		--crate-name $(patsubst lib%.so,%,$(notdir $@)) $<; \
 	mv $(objtree)/rust/$(patsubst lib%.so,%,$(notdir $@)).d $(depfile); \
@@ -86,27 +86,22 @@ quiet_cmd_rustc_library = RUSTC L $@
 # `$(rustc_flags)` is passed in case the user added `--sysroot`.
 rustc_sysroot = $(shell $(RUSTC) $(rustc_flags) --print sysroot)
 rustc_src = $(rustc_sysroot)/lib/rustlib/src/rust
-compiler_builtins_src = $(rustc_sysroot)/lib/rustlib/src/compiler-builtins
 
 .SECONDEXPANSION:
-$(objtree)/rust/core.o: rustc_target_flags = --edition 2018
 $(objtree)/rust/core.o: $$(rustc_src)/library/core/src/lib.rs FORCE
 	$(call if_changed_dep,rustc_library)
 
-$(objtree)/rust/compiler_builtins.o: rustc_objcopy = -w -W '__*' -W '!__rust*'
-$(objtree)/rust/compiler_builtins.o: rustc_target_flags = --edition 2015 \
-	--cfg 'feature="compiler-builtins"' --cfg 'feature="default"'
-$(objtree)/rust/compiler_builtins.o: $$(compiler_builtins_src)/src/lib.rs \
+$(objtree)/rust/compiler_builtins.o: rustc_objcopy = -w -W '__*'
+$(objtree)/rust/compiler_builtins.o: $(srctree)/rust/compiler_builtins.rs \
     $(objtree)/rust/core.o FORCE
 	$(call if_changed_dep,rustc_library)
 
-$(objtree)/rust/alloc.o: rustc_target_flags = --edition 2018
 $(objtree)/rust/alloc.o: $$(rustc_src)/library/alloc/src/lib.rs \
     $(objtree)/rust/compiler_builtins.o FORCE
 	$(call if_changed_dep,rustc_library)
 
 # ICE on `--extern module`: https://github.com/rust-lang/rust/issues/56935
-$(objtree)/rust/kernel.o: rustc_target_flags = --edition 2018 --extern alloc \
+$(objtree)/rust/kernel.o: rustc_target_flags = --extern alloc \
     --extern module=$(objtree)/rust/libmodule.so
 $(objtree)/rust/kernel.o: $(srctree)/rust/kernel/lib.rs $(objtree)/rust/alloc.o \
     $(objtree)/rust/libmodule.so $(objtree)/rust/bindings_generated.rs FORCE

--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Our `compiler_builtins`.
+//!
+//! Rust provides `compiler_builtins` as a port of LLVM's `compiler-rt`.
+//! Since we don't need the vast majority of them, we avoid the dependency
+//! by providing this file.
+//!
+//! At the moment, some builtins are required that shouldn't be. For instance,
+//! `core` has floating-point functionality which we shouldn't be compiling in.
+//! For the moment, we define them to `panic!` at runtime for simplicity.
+//! These are actually a superset of the ones we actually need to define,
+//! but it seems simpler to ban entire categories at once. In the future,
+//! we might be able to remove all this by providing our own custom `core` etc.,
+//! or perhaps `core` itself might provide `cfg` options to disable enough
+//! functionality to avoid requiring some of these.
+//!
+//! In any case, all these symbols are weakened to ensure we don't override
+//! those that may be provided by the rest of the kernel.
+
+#![feature(compiler_builtins)]
+#![compiler_builtins]
+
+#![no_builtins]
+#![no_std]
+
+macro_rules! define_panicking_intrinsics(
+    ($reason: tt, { $($ident: ident, )* }) => {
+        $(
+            #[no_mangle]
+            pub extern "C" fn $ident() {
+                panic!($reason);
+            }
+        )*
+    }
+);
+
+define_panicking_intrinsics!("non-inline stack probes should not be used", {
+    __rust_probestack,
+});
+
+define_panicking_intrinsics!("`f32` should not be used", {
+    __addsf3,
+    __addsf3vfp,
+    __divsf3,
+    __divsf3vfp,
+    __eqsf2,
+    __eqsf2vfp,
+    __fixsfdi,
+    __fixsfsi,
+    __fixsfti,
+    __fixunssfdi,
+    __fixunssfsi,
+    __fixunssfti,
+    __floatdisf,
+    __floatsisf,
+    __floattisf,
+    __floatundisf,
+    __floatunsisf,
+    __floatuntisf,
+    __gesf2,
+    __gesf2vfp,
+    __gtsf2,
+    __gtsf2vfp,
+    __lesf2,
+    __lesf2vfp,
+    __ltsf2,
+    __ltsf2vfp,
+    __mulsf3,
+    __mulsf3vfp,
+    __nesf2,
+    __nesf2vfp,
+    __powisf2,
+    __subsf3,
+    __subsf3vfp,
+    __unordsf2,
+});
+
+define_panicking_intrinsics!("`f64` should not be used", {
+    __adddf3,
+    __adddf3vfp,
+    __divdf3,
+    __divdf3vfp,
+    __eqdf2,
+    __eqdf2vfp,
+    __fixdfdi,
+    __fixdfsi,
+    __fixdfti,
+    __fixunsdfdi,
+    __fixunsdfsi,
+    __fixunsdfti,
+    __floatdidf,
+    __floatsidf,
+    __floattidf,
+    __floatundidf,
+    __floatunsidf,
+    __floatuntidf,
+    __gedf2,
+    __gedf2vfp,
+    __gtdf2,
+    __gtdf2vfp,
+    __ledf2,
+    __ledf2vfp,
+    __ltdf2,
+    __ltdf2vfp,
+    __muldf3,
+    __muldf3vfp,
+    __nedf2,
+    __nedf2vfp,
+    __powidf2,
+    __subdf3,
+    __subdf3vfp,
+    __unorddf2,
+});
+
+define_panicking_intrinsics!("`i128` should not be used", {
+    __ashrti3,
+    __muloti4,
+    __multi3,
+});
+
+define_panicking_intrinsics!("`u128` should not be used", {
+    __ashlti3,
+    __lshrti3,
+    __udivmodti4,
+    __udivti3,
+    __umodti3,
+});

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -304,7 +304,7 @@ rustc_cross_flags := --target=$(srctree)/arch/$(SRCARCH)/rust/target.json
 quiet_cmd_rustc_o_rs = RUSTC $(quiet_modtag) $@
       cmd_rustc_o_rs = \
 	RUST_MODFILE=$(modfile) \
-	$(RUSTC) $(rustc_flags) $(rustc_cross_flags) --edition 2018 \
+	$(RUSTC) $(rustc_flags) $(rustc_cross_flags) \
 		--extern alloc --extern kernel \
 		--crate-type rlib --out-dir $(obj) -L $(objtree)/rust/ \
 		--crate-name $(patsubst %.o,%,$(notdir $@)) $<; \


### PR DESCRIPTION
This simplifies onboarding, it is smaller, faster to compile and it is one less dependency to worry about.

It also simplifies the build system a tiny bit since now everything uses the 2018 edition.

Fixes #69.