### PR TITLE
Add charp and some primitive param types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,7 +153,7 @@ jobs:
       # Run
       - run: ${{ env.BUILD_DIR }}usr/gen_init_cpio .github/workflows/qemu-initramfs.desc > qemu-initramfs.img
 
-      - run: qemu-system-${{ env.QEMU_ARCH }} -kernel ${{ env.BUILD_DIR }}${{ env.IMAGE_PATH }} -initrd qemu-initramfs.img -M ${{ env.QEMU_MACHINE }} -cpu ${{ env.QEMU_CPU }} -smp 2 -nographic -no-reboot -append '${{ env.QEMU_APPEND }} rust_example.my_i32=123321 rust_example_2.my_i32=234432' | tee qemu-stdout.log
+      - run: qemu-system-${{ env.QEMU_ARCH }} -kernel ${{ env.BUILD_DIR }}${{ env.IMAGE_PATH }} -initrd qemu-initramfs.img -M ${{ env.QEMU_MACHINE }} -cpu ${{ env.QEMU_CPU }} -smp 2 -nographic -no-reboot -append '${{ env.QEMU_APPEND }} rust_example.my_i32=123321 rust_example.my_str=🦀mod rust_example.my_invbool=y rust_example_2.my_i32=234432' | tee qemu-stdout.log
 
       # Check
       - run: grep -F     '] Rust Example (init)' qemu-stdout.log
@@ -161,10 +161,15 @@ jobs:
       - run: grep -F '] [3] Rust Example (init)' qemu-stdout.log
       - run: grep -F '] [4] Rust Example (init)' qemu-stdout.log
 
-      - run: "grep -F     ']   my_i32:   123321' qemu-stdout.log"
-      - run: "grep -F '] [2]   my_i32:   234432' qemu-stdout.log"
-      - run: "grep -F '] [3]   my_i32:   345543' qemu-stdout.log"
-      - run: "grep -F '] [4]   my_i32:   456654' qemu-stdout.log"
+      - run: "grep -F     ']   my_i32:     123321' qemu-stdout.log"
+      - run: "grep -F '] [2]   my_i32:     234432' qemu-stdout.log"
+      - run: "grep -F '] [3]   my_i32:     345543' qemu-stdout.log"
+      - run: "grep -F '] [4]   my_i32:     456654' qemu-stdout.log"
+
+      - run: "grep            '\\]   my_str:     🦀mod\\s*$'           qemu-stdout.log"
+      - run: "grep    '\\] \\[2\\]   my_str:     default str val\\s*$' qemu-stdout.log"
+      - run: "grep    '\\] \\[3\\]   my_str:     🦀mod\\s*$'           qemu-stdout.log"
+      - run: "grep    '\\] \\[4\\]   my_str:     default str val\\s*$' qemu-stdout.log"
 
       - run: grep -F '] [3] Rust Example (exit)' qemu-stdout.log
       - run: grep -F '] [4] Rust Example (exit)' qemu-stdout.log

--- a/.github/workflows/qemu-init.sh
+++ b/.github/workflows/qemu-init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-busybox insmod rust_example_3.ko my_i32=345543
+busybox insmod rust_example_3.ko my_i32=345543 my_str=🦀mod
 busybox insmod rust_example_4.ko my_i32=456654
 busybox  rmmod rust_example_3.ko
 busybox  rmmod rust_example_4.ko

--- a/drivers/char/rust_example.rs
+++ b/drivers/char/rust_example.rs
@@ -26,6 +26,11 @@ module! {
             permissions: 0o644,
             description: b"Example of i32",
         },
+        my_str: str {
+            default: b"default str val",
+            permissions: 0o644,
+            description: b"Example of a string param",
+        },
     },
 }
 
@@ -49,9 +54,16 @@ impl KernelModule for RustExample {
     fn init() -> KernelResult<Self> {
         println!("Rust Example (init)");
         println!("Am I built-in? {}", !cfg!(MODULE));
-        println!("Parameters:");
-        println!("  my_bool:  {}", my_bool.read());
-        println!("  my_i32:   {}", my_i32.read());
+        {
+            let lock = THIS_MODULE.kernel_param_lock();
+            println!("Parameters:");
+            println!("  my_bool:    {}", my_bool.read());
+            println!("  my_i32:     {}", my_i32.read(&lock));
+            println!(
+                "  my_str:     {}",
+                core::str::from_utf8(my_str.read(&lock))?
+            );
+        }
 
         // Including this large variable on the stack will trigger
         // stack probing on the supported archs.

--- a/drivers/char/rust_example_2.rs
+++ b/drivers/char/rust_example_2.rs
@@ -23,6 +23,11 @@ module! {
             permissions: 0o644,
             description: b"Example of i32",
         },
+        my_str: str {
+            default: b"default str val",
+            permissions: 0o644,
+            description: b"Example of a string param",
+        },
     },
 }
 
@@ -34,9 +39,16 @@ impl KernelModule for RustExample2 {
     fn init() -> KernelResult<Self> {
         println!("[2] Rust Example (init)");
         println!("[2] Am I built-in? {}", !cfg!(MODULE));
-        println!("[2] Parameters:");
-        println!("[2]   my_bool:  {}", my_bool.read());
-        println!("[2]   my_i32:   {}", my_i32.read());
+        {
+            let lock = THIS_MODULE.kernel_param_lock();
+            println!("[2] Parameters:");
+            println!("[2]   my_bool:    {}", my_bool.read());
+            println!("[2]   my_i32:     {}", my_i32.read(&lock));
+            println!(
+                "[2]   my_str:     {}",
+                core::str::from_utf8(my_str.read(&lock))?
+            );
+        }
 
         // Including this large variable on the stack will trigger
         // stack probing on the supported archs.

--- a/drivers/char/rust_example_3.rs
+++ b/drivers/char/rust_example_3.rs
@@ -23,6 +23,11 @@ module! {
             permissions: 0o644,
             description: b"Example of i32",
         },
+        my_str: str {
+            default: b"default str val",
+            permissions: 0o644,
+            description: b"Example of a string param",
+        },
     },
 }
 
@@ -34,9 +39,16 @@ impl KernelModule for RustExample3 {
     fn init() -> KernelResult<Self> {
         println!("[3] Rust Example (init)");
         println!("[3] Am I built-in? {}", !cfg!(MODULE));
-        println!("[3] Parameters:");
-        println!("[3]   my_bool:  {}", my_bool.read());
-        println!("[3]   my_i32:   {}", my_i32.read());
+        {
+            let lock = THIS_MODULE.kernel_param_lock();
+            println!("[3] Parameters:");
+            println!("[3]   my_bool:    {}", my_bool.read());
+            println!("[3]   my_i32:     {}", my_i32.read(&lock));
+            println!(
+                "[3]   my_str:     {}",
+                core::str::from_utf8(my_str.read(&lock))?
+            );
+        }
 
         // Including this large variable on the stack will trigger
         // stack probing on the supported archs.

--- a/drivers/char/rust_example_4.rs
+++ b/drivers/char/rust_example_4.rs
@@ -23,6 +23,11 @@ module! {
             permissions: 0o644,
             description: b"Example of i32",
         },
+        my_str: str {
+            default: b"default str val",
+            permissions: 0o644,
+            description: b"Example of a string param",
+        },
     },
 }
 
@@ -34,9 +39,16 @@ impl KernelModule for RustExample4 {
     fn init() -> KernelResult<Self> {
         println!("[4] Rust Example (init)");
         println!("[4] Am I built-in? {}", !cfg!(MODULE));
-        println!("[4] Parameters:");
-        println!("[4]   my_bool:  {}", my_bool.read());
-        println!("[4]   my_i32:   {}", my_i32.read());
+        {
+            let lock = THIS_MODULE.kernel_param_lock();
+            println!("[4] Parameters:");
+            println!("[4]   my_bool:    {}", my_bool.read());
+            println!("[4]   my_i32:     {}", my_i32.read(&lock));
+            println!(
+                "[4]   my_str:     {}",
+                core::str::from_utf8(my_str.read(&lock))?
+            );
+        }
 
         // Including this large variable on the stack will trigger
         // stack probing on the supported archs.

--- a/rust/kernel/c_types.rs
+++ b/rust/kernel/c_types.rs
@@ -54,10 +54,14 @@ pub use c::*;
 
 /// Reads string until null byte is reached and returns slice excluding the terminating null.
 ///
-/// SAFETY: The data from the pointer until the null terminator must be valid for reads and
-/// not mutated for all of `'a`. The length of the string must also be less than `isize::MAX`.
-/// See the documentation on [`from_raw_parts`](https://doc.rust-lang.org/core/slice/fn.from_raw_parts.html)
-/// for further details on safety of converting a pointer to a slice.
+/// # Safety
+///
+/// The data from the pointer until the null terminator must be valid for reads
+/// and not mutated for all of `'a`. The length of the string must also be less
+/// than `isize::MAX`. See the documentation on [`from_raw_parts`] for further
+/// details on safety of converting a pointer to a slice.
+///
+/// [`from_raw_parts`]: https://doc.rust-lang.org/core/slice/fn.from_raw_parts.html
 pub unsafe fn c_string_bytes<'a>(ptr: *const crate::c_types::c_char) -> &'a [u8] {
     let length = crate::bindings::strlen(ptr) as usize;
     &core::slice::from_raw_parts(ptr as *const u8, length)

--- a/rust/kernel/c_types.rs
+++ b/rust/kernel/c_types.rs
@@ -51,3 +51,14 @@ mod c {
 }
 
 pub use c::*;
+
+/// Reads string until null byte is reached and returns slice excluding the terminating null.
+///
+/// SAFETY: The data from the pointer until the null terminator must be valid for reads and
+/// not mutated for all of `'a`. The length of the string must also be less than `isize::MAX`.
+/// See the documentation on [`from_raw_parts`](https://doc.rust-lang.org/core/slice/fn.from_raw_parts.html)
+/// for further details on safety of converting a pointer to a slice.
+pub unsafe fn c_string_bytes<'a>(ptr: *const crate::c_types::c_char) -> &'a [u8] {
+    let length = crate::bindings::strlen(ptr) as usize;
+    &core::slice::from_raw_parts(ptr as *const u8, length)
+}

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 
 use core::num::TryFromIntError;
+use core::str::Utf8Error;
 
 use alloc::alloc::AllocError;
 
@@ -27,6 +28,12 @@ impl Error {
 
 impl From<TryFromIntError> for Error {
     fn from(_: TryFromIntError) -> Error {
+        Error::EINVAL
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(_: Utf8Error) -> Error {
         Error::EINVAL
     }
 }

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -229,6 +229,9 @@ fn permissions_are_readonly(perms: &str) -> bool {
 /// - `u64`     - Corresponds to C `ullong` param type.
 /// - `str`     - Corresponds to C `charp` param type.
 ///               Reading the param returns a `&[u8]`.
+///
+/// `invbool` is unsupported: it was only ever used in a few modules.
+/// Consider using a `bool` inverting the logic instead.
 #[proc_macro]
 pub fn module(ts: TokenStream) -> TokenStream {
     let mut it = ts.into_iter();

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -218,7 +218,7 @@ fn permissions_are_readonly(perms: &str) -> bool {
 /// }
 /// ```
 ///
-/// ## Suported Parameter Types
+/// # Supported Parameter Types
 ///
 /// - `bool`    - Corresponds to C `bool` param type.
 /// - `u8`      - Corresponds to C `char` param type.

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -176,7 +176,7 @@ fn permissions_are_readonly(perms: &str) -> bool {
 /// The `type` argument should be a type which implements the [`KernelModule`] trait.
 /// Also accepts various forms of kernel metadata.
 ///
-/// ## Example
+/// # Examples
 /// ```rust,no_run
 /// use kernel::prelude::*;
 ///

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -155,12 +155,28 @@ fn build_modinfo_string_param(module: &str, field: &str, param: &str, content: &
         + &__build_modinfo_string_base(module, field, &content, &variable, false)
 }
 
+fn permissions_are_readonly(perms: &str) -> bool {
+    let (radix, digits) = if let Some(n) = perms.strip_prefix("0x") {
+        (16, n)
+    } else if let Some(n) = perms.strip_prefix("0o") {
+        (8, n)
+    } else if let Some(n) = perms.strip_prefix("0b") {
+        (2, n)
+    } else {
+        (10, perms)
+    };
+    match u32::from_str_radix(digits, radix) {
+        Ok(perms) => perms & 0o222 == 0,
+        Err(_) => false
+    }
+}
+
 /// Declares a kernel module.
 ///
 /// The `type` argument should be a type which implements the [`KernelModule`] trait.
 /// Also accepts various forms of kernel metadata.
 ///
-/// Example:
+/// ## Example
 /// ```rust,no_run
 /// use kernel::prelude::*;
 ///
@@ -170,17 +186,49 @@ fn build_modinfo_string_param(module: &str, field: &str, param: &str, content: &
 ///     author: b"Rust for Linux Contributors",
 ///     description: b"My very own kernel module!",
 ///     license: b"GPL v2",
-///     params: {},
+///     params: {
+///        my_i32: i32 {
+///            default: 42,
+///            permissions: 0o000,
+///            description: b"Example of i32",
+///        },
+///        writeable_i32: i32 {
+///            default: 42,
+///            permissions: 0o644,
+///            description: b"Example of i32",
+///        },
+///    },
 /// }
 ///
 /// struct MyKernelModule;
 ///
 /// impl KernelModule for MyKernelModule {
 ///     fn init() -> KernelResult<Self> {
+///         // If the parameter is writeable, then the kparam lock must be
+///         // taken to read the parameter:
+///         {
+///             let lock = THIS_MODULE.kernel_param_lock();
+///             println!("i32 param is:  {}", writeable_i32.read(&lock));
+///         }
+///         // If the parameter is read only, it can be read without locking
+///         // the kernel parameters:
+///         println!("i32 param is:  {}", my_i32.read());
 ///         Ok(MyKernelModule)
 ///     }
 /// }
 /// ```
+///
+/// ## Suported Parameter Types
+///
+/// - `bool`    - Corresponds to C `bool` param type.
+/// - `u8`      - Corresponds to C `char` param type.
+/// - `i16`     - Corresponds to C `short` param type.
+/// - `u16`     - Corresponds to C `ushort` param type.
+/// - `i32`     - Corresponds to C `int` param type.
+/// - `u32`     - Corresponds to C `uint` param type.
+/// - `u64`     - Corresponds to C `ullong` param type.
+/// - `str`     - Corresponds to C `charp` param type.
+///               Reading the param returns a `&[u8]`.
 #[proc_macro]
 pub fn module(ts: TokenStream) -> TokenStream {
     let mut it = ts.into_iter();
@@ -215,10 +263,10 @@ pub fn module(ts: TokenStream) -> TokenStream {
         assert_eq!(group.delimiter(), Delimiter::Brace);
 
         let mut param_it = group.stream().into_iter();
-        let param_default = if param_type == "bool" {
-            get_ident(&mut param_it, "default")
-        } else {
-            get_literal(&mut param_it, "default")
+        let param_default = match param_type.as_ref() {
+            "bool" => get_ident(&mut param_it, "default"),
+            "str" => get_byte_string(&mut param_it, "default"),
+            _ => get_literal(&mut param_it, "default"),
         };
         let param_permissions = get_literal(&mut param_it, "permissions");
         let param_description = get_byte_string(&mut param_it, "description");
@@ -228,7 +276,13 @@ pub fn module(ts: TokenStream) -> TokenStream {
         // TODO: other kinds: arrays, unsafes, etc.
         let param_kernel_type = match param_type.as_ref() {
             "bool" => "bool",
+            "u8" => "char",
+            "i16" => "short",
+            "u16" => "ushort",
             "i32" => "int",
+            "u32" => "uint",
+            "u64" => "ullong",
+            "str" => "charp",
             t => panic!("Unrecognized type {}", t),
         };
 
@@ -244,18 +298,83 @@ pub fn module(ts: TokenStream) -> TokenStream {
             &param_name,
             &param_description,
         ));
+        let param_type_internal = match param_type.as_ref() {
+            "str" => "*mut kernel::c_types::c_char",
+            _ => &param_type,
+        };
+        let param_default = match param_type.as_ref() {
+            "str" => format!("b\"{}\0\" as *const _ as *mut kernel::c_types::c_char", param_default),
+            _ => param_default,
+        };
+        let read_func = match (param_type.as_ref(), permissions_are_readonly(&param_permissions)) {
+            ("str", false) => format!(
+                "
+                    fn read<'lck>(&self, lock: &'lck kernel::KParamGuard) -> &'lck [u8] {{
+                        // SAFETY: The pointer is provided either in `param_default` when building the module,
+                        // or by the kernel through `param_set_charp`. Both will be valid C strings.
+                        // Parameters are locked by `KParamGuard`.
+                        unsafe {{
+                            kernel::c_types::c_string_bytes(__{name}_{param_name}_value)
+                        }}
+                    }}
+                ",
+                name = name,
+                param_name = param_name,
+            ),
+            ("str", true) => format!(
+                "
+                    fn read(&self) -> &[u8] {{
+                        // SAFETY: The pointer is provided either in `param_default` when building the module,
+                        // or by the kernel through `param_set_charp`. Both will be valid C strings.
+                        // Parameters do not need to be locked because they are read only or sysfs is not enabled.
+                        unsafe {{
+                            kernel::c_types::c_string_bytes(__{name}_{param_name}_value)
+                        }}
+                    }}
+                ",
+                name = name,
+                param_name = param_name,
+            ),
+            (_, false) => format!(
+                "
+                    // SAFETY: Parameters are locked by `KParamGuard`.
+                    fn read<'lck>(&self, lock: &'lck kernel::KParamGuard) -> &'lck {param_type_internal} {{
+                        unsafe {{ &__{name}_{param_name}_value }}
+                    }}
+                ",
+                name = name,
+                param_name = param_name,
+                param_type_internal = param_type_internal,
+            ),
+            (_, true) => format!(
+                "
+                    // SAFETY: Parameters do not need to be locked because they are read only or sysfs is not enabled.
+                    fn read(&self) -> &{param_type_internal} {{
+                        unsafe {{ &__{name}_{param_name}_value }}
+                    }}
+                ",
+                name = name,
+                param_name = param_name,
+                param_type_internal = param_type_internal,
+            ),
+        };
+        let kparam = format!(
+            "
+                kernel::bindings::kernel_param__bindgen_ty_1 {{
+                    arg: unsafe {{ &__{name}_{param_name}_value }} as *const _ as *mut kernel::c_types::c_void,
+                }},
+            ",
+            name = name,
+            param_name = param_name,
+        );
         params_modinfo.push_str(
             &format!(
                 "
-                static mut __{name}_{param_name}_value: {param_type} = {param_default};
+                static mut __{name}_{param_name}_value: {param_type_internal} = {param_default};
 
                 struct __{name}_{param_name};
 
-                impl __{name}_{param_name} {{
-                    fn read(&self) -> {param_type} {{
-                        unsafe {{ __{name}_{param_name}_value }}
-                    }}
-                }}
+                impl __{name}_{param_name} {{ {read_func} }}
 
                 const {param_name}: __{name}_{param_name} = __{name}_{param_name};
 
@@ -291,17 +410,17 @@ pub fn module(ts: TokenStream) -> TokenStream {
                     perm: {permissions},
                     level: -1,
                     flags: 0,
-                    __bindgen_anon_1: kernel::bindings::kernel_param__bindgen_ty_1 {{
-                        arg: unsafe {{ &__{name}_{param_name}_value }} as *const _ as *mut kernel::c_types::c_void,
-                    }},
+                    __bindgen_anon_1: {kparam}
                 }});
                 ",
                 name = name,
-                param_type = param_type,
+                param_type_internal = param_type_internal,
+                read_func = read_func,
                 param_kernel_type = param_kernel_type,
                 param_default = param_default,
                 param_name = param_name,
                 permissions = param_permissions,
+                kparam = kparam,
             )
         );
     }


### PR DESCRIPTION
Adding support for `&str` params (as `charp`) and a handful of primitive types.
Addresses some of https://github.com/Rust-for-Linux/linux/issues/11.