### PR TITLE
Migrate to the new stack probes option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         arch: [x86_64, arm64]
         toolchain: [gcc, clang, llvm]
         config: [debug, release]
-        rustc: [2021-01-21]
+        rustc: [2021-01-24]
         output: [src] # [src, build]
         install: [rustup] # [rustup, standalone]
         sysroot: [common] # [common, custom]
@@ -27,7 +27,7 @@ jobs:
           - arch: x86_64
             toolchain: gcc
             config: debug
-            rustc: 2021-01-21
+            rustc: 2021-01-24
             output: build
             install: rustup
             sysroot: custom
@@ -35,7 +35,7 @@ jobs:
           - arch: arm64
             toolchain: clang
             config: release
-            rustc: 2021-01-21
+            rustc: 2021-01-24
             output: build
             install: standalone
             sysroot: common
@@ -43,7 +43,7 @@ jobs:
           - arch: x86_64
             toolchain: llvm
             config: debug
-            rustc: 2021-01-21
+            rustc: 2021-01-24
             output: build
             install: standalone
             sysroot: custom

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -21,7 +21,7 @@ rustc
 *****
 
 A recent *nightly* Rust toolchain (with, at least, ``rustc``) is required,
-e.g. ``nightly-2021-01-21``. Our goal is to use a stable toolchain as soon
+e.g. ``nightly-2021-01-24``. Our goal is to use a stable toolchain as soon
 as possible, but for the moment we depend on a handful of nightly features.
 
 If you are using ``rustup``, run::

--- a/arch/arm64/rust/target.json
+++ b/arch/arm64/rust/target.json
@@ -25,7 +25,14 @@
   },
   "relocation-model": "static",
   "relro-level": "full",
-  "stack-probes": true,
+  "stack-probes": {
+    "kind": "inline-or-call",
+    "min-llvm-version-for-inline": [
+      11,
+      0,
+      1
+    ]
+  },
   "target-c-int-width": "32",
   "target-endian": "little",
   "target-pointer-width": "64",

--- a/arch/x86/rust/target.json
+++ b/arch/x86/rust/target.json
@@ -27,7 +27,14 @@
   },
   "relocation-model": "static",
   "relro-level": "full",
-  "stack-probes": true,
+  "stack-probes": {
+    "kind": "inline-or-call",
+    "min-llvm-version-for-inline": [
+      11,
+      0,
+      1
+    ]
+  },
   "target-c-int-width": "32",
   "target-endian": "little",
   "target-pointer-width": "64",


### PR DESCRIPTION
The stack probes options changed from taking a boolean to a set
of options. For the moment, use `inline-or-call` for both x86_64
and arm64, since that is what the x86 builtin targets moved to
and since we had it enabled for arm64 too (although note that
arm64 does not have it in the builtin target).

This also raises the minimum version of `rustc` to 2021-01-24,
which is just a few days from the previous one (2021-01-21), which
is easier than trying to support both formats.

Triggered by #84.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>