### PR TITLE
libkernel: remove leftover `extern crate`

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -10,8 +10,6 @@
 #[cfg(not(CONFIG_RUST))]
 compile_error!("Missing kernel configuration for conditional compilation");
 
-extern crate alloc;
-
 use core::panic::PanicInfo;
 
 mod allocator;


### PR DESCRIPTION
It was the last one.