### PR TITLE
Simplify how clients define file operations.

### DIFF
--- a/drivers/char/rust_example.rs
+++ b/drivers/char/rust_example.rs
@@ -51,6 +51,8 @@ struct RustFile;
 impl FileOperations for RustFile {
     type Wrapper = Box<Self>;
 
+    kernel::declare_file_operations!();
+
     fn open() -> KernelResult<Self::Wrapper> {
         println!("rust file was opened!");
         Ok(Box::try_new(Self)?)


### PR DESCRIPTION
This was discussed on the following thread:
https://lore.kernel.org/rust-for-linux/CANiq72kHf8m2BGcj+znWnoLzfy_1kP3BQuRAmGTZXnW3tdtnhA@mail.gmail.com/T/