### PR TITLE
Add functions to read/write plain old data (POD) types.

### DIFF
--- a/rust/kernel/sysctl.rs
+++ b/rust/kernel/sysctl.rs
@@ -76,7 +76,7 @@ impl SysctlStorage for atomic::AtomicBool {
         } else {
             b"0\n"
         };
-        (value.len(), data.write(value))
+        (value.len(), data.write_slice(value))
     }
 }
 


### PR DESCRIPTION
Other minor changes:
* Made UserSlicePtr::new public. This is to allow drivers to access user
buffers that don't come directly from file operations.
* Ability to clone UserSlicePtr. This is for cases when we need to read
then write; so we clone before creating a reader/writer.