### PR TITLE
Handle possible allocation failure in `user_ptr`.

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -4,13 +4,9 @@
 //!
 //! C header: [`include/uapi/asm-generic/errno-base.h`](../../../include/uapi/asm-generic/errno-base.h)
 
-use core::num::TryFromIntError;
-use core::str::Utf8Error;
-
-use alloc::alloc::AllocError;
-
-use crate::bindings;
-use crate::c_types;
+use crate::{bindings, c_types};
+use alloc::{alloc::AllocError, collections::TryReserveError};
+use core::{num::TryFromIntError, str::Utf8Error};
 
 /// Generic integer kernel error.
 ///
@@ -69,6 +65,12 @@ impl From<TryFromIntError> for Error {
 impl From<Utf8Error> for Error {
     fn from(_: Utf8Error) -> Error {
         Error::EINVAL
+    }
+}
+
+impl From<TryReserveError> for Error {
+    fn from(_: TryReserveError) -> Error {
+        Error::ENOMEM
     }
 }
 

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -12,7 +12,13 @@
 //! do so first instead of bypassing this crate.
 
 #![no_std]
-#![feature(allocator_api, alloc_error_handler, const_fn, const_mut_refs)]
+#![feature(
+    allocator_api,
+    alloc_error_handler,
+    const_fn,
+    const_mut_refs,
+    try_reserve
+)]
 #![deny(clippy::complexity)]
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]

--- a/rust/kernel/user_ptr.rs
+++ b/rust/kernel/user_ptr.rs
@@ -4,12 +4,8 @@
 //!
 //! C header: [`include/linux/uaccess.h`](../../../../include/linux/uaccess.h)
 
-use alloc::vec;
+use crate::{c_types, error};
 use alloc::vec::Vec;
-use core::u32;
-
-use crate::c_types;
-use crate::error;
 
 extern "C" {
     fn rust_helper_access_ok(addr: *const c_types::c_void, len: c_types::c_ulong)
@@ -134,7 +130,9 @@ impl UserSlicePtrReader {
     /// Returns `EFAULT` if the address does not currently point to
     /// mapped, readable memory.
     pub fn read_all(&mut self) -> error::KernelResult<Vec<u8>> {
-        let mut data = vec![0; self.1];
+        let mut data = Vec::<u8>::new();
+        data.try_reserve_exact(self.1)?;
+        data.resize(self.1, 0);
         self.read(&mut data)?;
         Ok(data)
     }


### PR DESCRIPTION
One aspect that isn't great about this is that we have a new dependency on `try_reserve`.

I'm also using it in binder for the same purpose: allocate memory fallibly in a vector (`try_reserve_exact`).