### PR TITLE
MAINTAINERS: update

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15549,13 +15549,16 @@ S:	Maintained
 F:	drivers/infiniband/ulp/rtrs/
 
 RUST
-W:	https://github.com/Rust-for-Linux/linux
-S:	Maintained
-K:	\b(?i:rust)\b
+M:	Miguel Ojeda <ojeda@kernel.org>
+M:	Alex Gaynor <alex.gaynor@gmail.com>
 L:	rust-for-linux@vger.kernel.org
+S:	Maintained
+W:	https://github.com/Rust-for-Linux/linux
+B:	https://github.com/Rust-for-Linux/linux/issues
+T:	git https://github.com/Rust-for-Linux/linux.git rust-next
 F:	rust/
 F:	Documentation/rust/
-F:	drivers/char/rust_example/
+K:	\b(?i:rust)\b
 
 RXRPC SOCKETS (AF_RXRPC)
 M:	David Howells <dhowells@redhat.com>


### PR DESCRIPTION
  - Add Alex and Miguel as maintainers.
  - Sort the keys properly.
  - Remove the unexisting `F:` key.
  - Add `B:` and `T:` keys.

Fixes #123.

Reported-by: Josh Abraham <sinisterpatrician@gmail.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>