### PR TITLE
Generate docs for `core` and `alloc` locally

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -6,6 +6,10 @@ extra-$(CONFIG_RUST) += bindings_generated.rs libmodule.so
 extra-$(CONFIG_RUST) += exports_core_generated.h exports_alloc_generated.h
 extra-$(CONFIG_RUST) += exports_kernel_generated.h
 
+# `$(rustc_flags)` is passed in case the user added `--sysroot`.
+rustc_sysroot = $(shell $(RUSTC) $(rustc_flags) --print sysroot)
+rustc_src = $(rustc_sysroot)/lib/rustlib/src/rust
+
 RUSTDOC = rustdoc
 
 quiet_cmd_rustdoc = RUSTDOC $<
@@ -14,9 +18,13 @@ quiet_cmd_rustdoc = RUSTDOC $<
 	$(RUSTDOC) $(filter-out --emit=%, $(rustc_flags)) \
 		$(rustdoc_target_flags) -L $(objtree)/rust/ \
 		--output $(objtree)/rust/doc --crate-name $(subst rustdoc-,,$@) \
-		-Fmissing-docs @$(objtree)/include/generated/rustc_cfg $<
+		@$(objtree)/include/generated/rustc_cfg $<
 
-rustdoc: rustdoc-module rustdoc-compiler_builtins rustdoc-kernel
+rustdoc: rustdoc-core rustdoc-module rustdoc-compiler_builtins rustdoc-alloc rustdoc-kernel
+
+rustdoc-core: private skip_clippy = 1
+rustdoc-core: $(rustc_src)/library/core/src/lib.rs FORCE
+	$(call if_changed,rustdoc)
 
 rustdoc-module: private rustdoc_target_flags = --crate-type proc-macro \
     --extern proc_macro
@@ -24,6 +32,11 @@ rustdoc-module: $(srctree)/rust/module.rs FORCE
 	$(call if_changed,rustdoc)
 
 rustdoc-compiler_builtins: $(srctree)/rust/compiler_builtins.rs FORCE
+	$(call if_changed,rustdoc)
+
+rustdoc-alloc: private skip_clippy = 1
+rustdoc-alloc: $(rustc_src)/library/alloc/src/lib.rs \
+    $(objtree)/rust/compiler_builtins.o FORCE
 	$(call if_changed,rustdoc)
 
 rustdoc-kernel: private rustdoc_target_flags = --extern alloc \
@@ -114,10 +127,6 @@ quiet_cmd_rustc_library = $(if $(skip_clippy),RUSTC,$(RUSTC_OR_CLIPPY_QUIET)) L 
 	mv $(objtree)/rust/$(patsubst %.o,%,$(notdir $@)).d $(depfile); \
 	sed -i '/^\#/d' $(depfile) \
 	$(if $(rustc_objcopy),;$(OBJCOPY) $(rustc_objcopy) $@)
-
-# `$(rustc_flags)` is passed in case the user added `--sysroot`.
-rustc_sysroot = $(shell $(RUSTC) $(rustc_flags) --print sysroot)
-rustc_src = $(rustc_sysroot)/lib/rustlib/src/rust
 
 .SECONDEXPANSION:
 $(objtree)/rust/core.o: private skip_clippy = 1

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -22,25 +22,24 @@ quiet_cmd_rustdoc = RUSTDOC $<
 
 rustdoc: rustdoc-core rustdoc-module rustdoc-compiler_builtins rustdoc-alloc rustdoc-kernel
 
-rustdoc-core: private skip_clippy = 1
 rustdoc-core: $(rustc_src)/library/core/src/lib.rs FORCE
 	$(call if_changed,rustdoc)
 
 rustdoc-module: private rustdoc_target_flags = --crate-type proc-macro \
-    --extern proc_macro
+    --extern proc_macro -Fmissing-docs
 rustdoc-module: $(srctree)/rust/module.rs FORCE
 	$(call if_changed,rustdoc)
 
+rustdoc-compiler_builtins: private rustdoc_target_flags = -Fmissing-docs
 rustdoc-compiler_builtins: $(srctree)/rust/compiler_builtins.rs FORCE
 	$(call if_changed,rustdoc)
 
-rustdoc-alloc: private skip_clippy = 1
 rustdoc-alloc: $(rustc_src)/library/alloc/src/lib.rs \
     $(objtree)/rust/compiler_builtins.o FORCE
 	$(call if_changed,rustdoc)
 
 rustdoc-kernel: private rustdoc_target_flags = --extern alloc \
-    --extern module=$(objtree)/rust/libmodule.so
+    --extern module=$(objtree)/rust/libmodule.so -Fmissing-docs
 rustdoc-kernel: $(srctree)/rust/kernel/lib.rs rustdoc-module \
     $(objtree)/rust/libmodule.so $(objtree)/rust/bindings_generated.rs FORCE
 	$(call if_changed,rustdoc)

--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -29,7 +29,7 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
-#![deny(missing_docs)]
+#![forbid(missing_docs)]
 
 macro_rules! define_panicking_intrinsics(
     ($reason: tt, { $($ident: ident, )* }) => {

--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -29,7 +29,6 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
-#![forbid(missing_docs)]
 
 macro_rules! define_panicking_intrinsics(
     ($reason: tt, { $($ident: ident, )* }) => {

--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -29,6 +29,7 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
+#![deny(missing_docs)]
 
 macro_rules! define_panicking_intrinsics(
     ($reason: tt, { $($ident: ident, )* }) => {

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -17,6 +17,7 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
+#![deny(missing_docs)]
 
 // Ensure conditional compilation based on the kernel configuration works;
 // otherwise we may silently break things like initcall handling.

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -17,7 +17,6 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
-#![deny(missing_docs)]
 
 // Ensure conditional compilation based on the kernel configuration works;
 // otherwise we may silently break things like initcall handling.

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -8,7 +8,7 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
-#![deny(missing_docs)]
+#![forbid(missing_docs)]
 
 use proc_macro::{token_stream, Delimiter, Group, TokenStream, TokenTree};
 

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -8,6 +8,7 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
+#![deny(missing_docs)]
 
 use proc_macro::{token_stream, Delimiter, Group, TokenStream, TokenTree};
 

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -8,7 +8,6 @@
 #![deny(clippy::correctness)]
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
-#![forbid(missing_docs)]
 
 use proc_macro::{token_stream, Delimiter, Group, TokenStream, TokenTree};
 


### PR DESCRIPTION
Resolve #97 
There are several places in `core` and `alloc` using `allow(missing_doc)` lint.
And this is not compatible with `-Fmissing-docs`.
So I moved the lint to individual crates.