### PR TITLE
Remove wrong sentence about mangling in `v0` scheme

### DIFF
--- a/rust/exports.c
+++ b/rust/exports.c
@@ -4,9 +4,8 @@
 // the entire `include/linux/export.h` logic in Rust.
 //
 // This requires the Rust's new/future `v0` mangling scheme because the default
-// one ("legacy") 1) uses a hash suffix which cannot be predicted across
-// compiler versions and 2) uses invalid characters for C identifiers
-// (thus we cannot use the `EXPORT_SYMBOL_*` macros).
+// one ("legacy") uses invalid characters for C identifiers (thus we cannot use
+// the `EXPORT_SYMBOL_*` macros).
 
 #include <linux/module.h>
 


### PR DESCRIPTION
@bjorn3 helpfully noted that symbols do not stay the same across
`rustc` compiler versions.

The overall sentence is anyway a bit misleading, because the "hard"
requirement is the second one: mixing `rustc` compiler versions
is not something we will support. IIRC I was thinking about possible
patch level fixes to `rustc` stable versions when I wrote that.

Link: https://github.com/Rust-for-Linux/linux/pull/52#discussion_r598094152
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>