### PR TITLE
Move creation of `struct file_operations` to a const function.

### DIFF
--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -112,7 +112,7 @@ impl<const N: usize> Registration<{ N }> {
         // SAFETY: Calling unsafe functions and manipulating `MaybeUninit`
         // pointer.
         unsafe {
-            bindings::cdev_init(cdev, &file_operations::FileOperationsVtable::<T>::VTABLE);
+            bindings::cdev_init(cdev, file_operations::FileOperationsVtable::<T>::build());
             (*cdev).owner = this.this_module.0;
             let rc = bindings::cdev_add(cdev, inner.dev + inner.used as bindings::dev_t, 1);
             if rc != 0 {

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -201,7 +201,7 @@ unsafe extern "C" fn fsync_callback<T: FileOperations>(
 pub(crate) struct FileOperationsVtable<T>(marker::PhantomData<T>);
 
 impl<T: FileOperations> FileOperationsVtable<T> {
-    pub(crate) const VTABLE: bindings::file_operations = bindings::file_operations {
+    const VTABLE: bindings::file_operations = bindings::file_operations {
         open: Some(open_callback::<T>),
         release: Some(release_callback::<T>),
         read: if T::TO_USE.read {
@@ -260,6 +260,11 @@ impl<T: FileOperations> FileOperationsVtable<T> {
         },
         write_iter: None,
     };
+
+    /// Builds an instance of [`struct file_operations`].
+    pub(crate) const fn build() -> &'static bindings::file_operations {
+        &Self::VTABLE
+    }
 }
 
 /// Represents which fields of [`struct file_operations`] should be populated with pointers.

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -61,7 +61,7 @@ impl Registration {
 
         this.mdev = Some(bindings::miscdevice::default());
         let dev = this.mdev.as_mut().unwrap();
-        dev.fops = &FileOperationsVtable::<T>::VTABLE;
+        dev.fops = FileOperationsVtable::<T>::build();
         dev.name = name.as_ptr() as *const c_types::c_char;
         dev.minor = minor.unwrap_or(bindings::MISC_DYNAMIC_MINOR as i32);
         let ret = unsafe { bindings::misc_register(dev) };


### PR DESCRIPTION
We'll make it unsafe in another commit.