### PR TITLE
Make `wait` require a mutable reference to guard.

### DIFF
--- a/drivers/char/rust_example.rs
+++ b/drivers/char/rust_example.rs
@@ -99,10 +99,9 @@ impl KernelModule for RustExample {
             let cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
             condvar_init!(cv.as_ref(), "RustExample::init::cv1");
             {
-                let guard = data.lock();
-                #[allow(clippy::while_immutable_condition)]
+                let mut guard = data.lock();
                 while *guard != 10 {
-                    let _ = cv.wait(&guard);
+                    let _ = cv.wait(&mut guard);
                 }
             }
             cv.notify_one();
@@ -122,10 +121,9 @@ impl KernelModule for RustExample {
             let cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
             condvar_init!(cv.as_ref(), "RustExample::init::cv2");
             {
-                let guard = data.lock();
-                #[allow(clippy::while_immutable_condition)]
+                let mut guard = data.lock();
                 while *guard != 10 {
-                    let _ = cv.wait(&guard);
+                    let _ = cv.wait(&mut guard);
                 }
             }
             cv.notify_one();

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -65,7 +65,7 @@ impl CondVar {
     ///
     /// Returns whether there is a signal pending.
     #[must_use = "wait returns if a signal is pending, so the caller must check the return value"]
-    pub fn wait<L: Lock>(&self, guard: &Guard<L>) -> bool {
+    pub fn wait<L: Lock>(&self, guard: &mut Guard<L>) -> bool {
         let lock = guard.lock;
         let mut wait = MaybeUninit::<bindings::wait_queue_entry>::uninit();
 


### PR DESCRIPTION
This fixes a clippy warning where it couldn't figure out how a variable
could change.