### PR TITLE
Allow `miscdev::Registration` to carry some context with it.

### DIFF
--- a/drivers/char/rust_example.rs
+++ b/drivers/char/rust_example.rs
@@ -148,7 +148,7 @@ impl KernelModule for RustExample {
 
         Ok(RustExample {
             message: "on the heap!".to_owned(),
-            _dev: miscdev::Registration::new_pinned::<RustFile>(cstr!("rust_miscdev"), None)?,
+            _dev: miscdev::Registration::new_pinned::<RustFile>(cstr!("rust_miscdev"), None, ())?,
             _chrdev: chrdev_reg,
         })
     }

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -80,8 +80,13 @@ impl<T: Sync> Registration<T> {
 
 // SAFETY: The only method is `register()`, which requires a (pinned) mutable `Registration`, so it
 // is safe to pass `&Registration` to multiple threads because it offers no interior mutability,
-// except maybe through [`Registration::context`], but it is itself [`Sync`].
+// except maybe through `Registration::context`, but it is itself `Sync`.
 unsafe impl<T: Sync> Sync for Registration<T> {}
+
+// SAFETY: All functions work from any thread. So as long as the `Registration::context` is
+// `Send`, so is `Registration<T>`. `T` needs to be `Sync` because it's a requirement of
+// `Registration<T>`.
+unsafe impl<T: Send + Sync> Send for Registration<T> {}
 
 impl<T: Sync> Drop for Registration<T> {
     /// Removes the registration from the kernel if it has completed successfully before.

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -42,9 +42,9 @@ impl<T: Sync> Registration<T> {
     pub fn new_pinned<F: FileOperations>(
         name: CStr<'static>,
         minor: Option<i32>,
-        state: T,
+        context: T,
     ) -> KernelResult<Pin<Box<Self>>> {
-        let mut r = Pin::from(Box::try_new(Self::new(state))?);
+        let mut r = Pin::from(Box::try_new(Self::new(context))?);
         r.as_mut().register::<F>(name, minor)?;
         Ok(r)
     }


### PR DESCRIPTION
This is based on #160 