### PR TITLE
Enable `rustfmt` formatting of code in doc comments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 edition = "2018"
+format_code_in_doc_comments = true

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -154,7 +154,7 @@ fn panic(_info: &PanicInfo) -> ! {
 ///     // This prints `8`.
 ///     println!("{}", offset_of!(Test, b));
 /// }
-///```
+/// ```
 #[macro_export]
 macro_rules! offset_of {
     ($type:ty, $($f:tt)*) => {{
@@ -189,14 +189,13 @@ macro_rules! offset_of {
 /// }
 ///
 /// fn test() {
-///     let test = Test{a: 10, b: 20};
+///     let test = Test { a: 10, b: 20 };
 ///     let b_ptr = &test.b;
 ///     let test_alias = unsafe { container_of!(b_ptr, Test, b) };
 ///     // This prints `true`.
 ///     println!("{}", core::ptr::eq(&test, test_alias));
 /// }
-///```
-///
+/// ```
 #[macro_export]
 macro_rules! container_of {
     ($ptr:expr, $type:ty, $($f:tt)*) => {{

--- a/rust/kernel/module_param.rs
+++ b/rust/kernel/module_param.rs
@@ -211,7 +211,7 @@ macro_rules! impl_module_param {
 /// make_param_ops!(
 ///     /// Documentation for new param ops.
 ///     PARAM_OPS_MYTYPE, // Name for the static.
-///     MyType            // A type which implements [`ModuleParam`].
+///     MyType // A type which implements [`ModuleParam`].
 /// );
 /// ```
 macro_rules! make_param_ops {

--- a/rust/kernel/static_assert.rs
+++ b/rust/kernel/static_assert.rs
@@ -22,7 +22,7 @@
 /// static_assert!(X[1] == 'a' as u8);
 ///
 /// const fn f(x: i32) -> i32 {
-///    x + 2
+///     x + 2
 /// }
 /// static_assert!(f(40) == 42);
 /// ```

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -10,7 +10,7 @@
 //!```
 //! fn test() {
 //!     // SAFETY: `init` is called below.
-//!     let data = alloc::sync::Arc::pin(unsafe{ Mutex::new(0) });
+//!     let data = alloc::sync::Arc::pin(unsafe { Mutex::new(0) });
 //!     mutex_init!(data.as_ref(), "test::data");
 //!     *data.lock() = 10;
 //!     kernel::println!("{}", *data.lock());


### PR DESCRIPTION
It is not enabled by default, but it is quite an important feature!

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>