### PR TITLE
rust: sync: Make Lock::locked_data() return raw pointer

### DIFF
--- a/rust/kernel/sync/guard.rs
+++ b/rust/kernel/sync/guard.rs
@@ -30,14 +30,14 @@ impl<L: Lock + ?Sized> core::ops::Deref for Guard<'_, L> {
 
     fn deref(&self) -> &Self::Target {
         // SAFETY: The caller owns the lock, so it is safe to deref the protected data.
-        unsafe { &*self.lock.locked_data().get() }
+        unsafe { &*self.lock.locked_data() }
     }
 }
 
 impl<L: Lock + ?Sized> core::ops::DerefMut for Guard<'_, L> {
     fn deref_mut(&mut self) -> &mut L::Inner {
         // SAFETY: The caller owns the lock, so it is safe to deref the protected data.
-        unsafe { &mut *self.lock.locked_data().get() }
+        unsafe { &mut *self.lock.locked_data() }
     }
 }
 
@@ -78,5 +78,5 @@ pub trait Lock {
     unsafe fn unlock(&self);
 
     /// Returns the data protected by the lock.
-    fn locked_data(&self) -> &core::cell::UnsafeCell<Self::Inner>;
+    fn locked_data(&self) -> *mut Self::Inner;
 }

--- a/rust/kernel/sync/locked_by.rs
+++ b/rust/kernel/sync/locked_by.rs
@@ -69,7 +69,7 @@ impl<T, L: Lock + ?Sized> LockedBy<T, L> {
     /// because in any case at most one thread (or CPU) can access the protected data at a time.
     pub fn new(owner: &L, data: T) -> Self {
         Self {
-            owner: owner.locked_data().get(),
+            owner: owner.locked_data(),
             data: UnsafeCell::new(data),
         }
     }

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -95,7 +95,7 @@ impl<T: ?Sized> Lock for Mutex<T> {
         bindings::mutex_unlock(self.mutex.get());
     }
 
-    fn locked_data(&self) -> &UnsafeCell<T> {
-        &self.data
+    fn locked_data(&self) -> *mut T {
+        self.data.get()
     }
 }

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -102,7 +102,7 @@ impl<T: ?Sized> Lock for SpinLock<T> {
         rust_helper_spin_unlock(self.spin_lock.get());
     }
 
-    fn locked_data(&self) -> &UnsafeCell<T> {
-        &self.data
+    fn locked_data(&self) -> *mut T {
+        self.data.get()
     }
 }


### PR DESCRIPTION
@wedsonaf This PR is more for discussion purpose.

Currently `Lock::locked_data` returns `&UnsafeCell<T>`, I think we can change it to `*mut T`, reasons as follow:

- The solely purpose of `&UnsafeCell<T>` is to get a `*mut T`, why not directly return `*mut T`?
- Returning a `&UnsafeCell<T>` means we store underlying data in a `UnsafeCell`, and I think this is more an implementation detail, which we don't want to expose to API level.
- Besides, say we want to access data outside Rust world (e.g. a static C variable), we cannot put it in a Rust `UnsafeCell`, right? Because of that, we cannot implement a proper `Lock` struct for it.

An example for the third point: `__cpu_online_mask` is protected by `cpus_write_lock()` and `cpus_write_unlock()`, if we are about to implement a `CPUOnlineLock`, we could code as follow:
```rust
pub struct CPUOnlineLock {}

impl Lock for CPUOnlineLock {
    type Inner = bindings::cpumask;
    fn lock_noguard(&self) {
        unsafe {
            bindings::cpus_write_lock();
        }
    }
    unsafe fn unlock(&self) {
         bindings::cpus_write_unlock();
    }

    fn locked_data(&self) -> &UnsafeCell<Self::Inner> {
        // what we are going to return here?
        // if the API return `* mut T`, we can return
        // unsafe { &__cpu_online_mask }
        // here.
    }
}
```

Thoughts?

 