### PR TITLE
README.md: Link to mailing list archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The goal of this project is to add support for the Rust language to the Linux kernel. This repository contains the work that will be eventually submitted for review to the LKML.
 
-Feel free to contribute! To start, take a look at [`Documentation/rust`](https://github.com/Rust-for-Linux/linux/tree/rust/Documentation/rust). We use GitHub issues and PRs for the moment, but discussions, questions, etc. take place on the rust-for-linux@vger.kernel.org mailing list.
+Feel free to contribute! To start, take a look at [`Documentation/rust`](https://github.com/Rust-for-Linux/linux/tree/rust/Documentation/rust). We use GitHub issues and PRs for the moment, but discussions, questions, etc. take place on the [`rust-for-linux@vger.kernel.org`](https://lore.kernel.org/rust-for-linux/) mailing list.
 
 All contributors to this effort are understood to have agreed to the Linux kernel development process as explained in the different files under [`Documentation/process`](https://www.kernel.org/doc/html/latest/process/index.html).
 


### PR DESCRIPTION
For new people taking about the project, it's helpful to have a way to quickly find the mailing list archives. Add a link to lore.