### PR TITLE
rust/kernel: Move PointerWrapper trait to types.rs

### DIFF
--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -4,9 +4,13 @@
 //!
 //! C header: [`include/linux/types.h`](../../../../include/linux/types.h)
 
-use core::ops::Deref;
+use core::{ops::Deref, pin::Pin};
+
+use alloc::{boxed::Box, sync::Arc};
 
 use crate::bindings;
+use crate::c_types;
+use crate::sync::{Ref, RefCounted};
 
 /// Permissions.
 ///
@@ -70,4 +74,65 @@ macro_rules! cstr {
         let s = concat!($str, "\x00");
         unsafe { $crate::CStr::new_unchecked(s) }
     }};
+}
+
+/// Used to convert an object into a raw pointer that represents it.
+///
+/// It can eventually be converted back into the object. This is used to store objects as pointers
+/// in kernel data structures, for example, an implementation of [`FileOperations`] in `struct
+/// file::private_data`.
+pub trait PointerWrapper {
+    /// Returns the raw pointer.
+    fn into_pointer(self) -> *const c_types::c_void;
+
+    /// Returns the instance back from the raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The passed pointer must come from a previous call to [`PointerWrapper::into_pointer()`].
+    unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self;
+}
+
+impl<T> PointerWrapper for Box<T> {
+    fn into_pointer(self) -> *const c_types::c_void {
+        Box::into_raw(self) as _
+    }
+
+    unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        Box::from_raw(ptr as _)
+    }
+}
+
+impl<T: RefCounted> PointerWrapper for Ref<T> {
+    fn into_pointer(self) -> *const c_types::c_void {
+        Ref::into_raw(self) as _
+    }
+
+    unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        Ref::from_raw(ptr as _)
+    }
+}
+
+impl<T> PointerWrapper for Arc<T> {
+    fn into_pointer(self) -> *const c_types::c_void {
+        Arc::into_raw(self) as _
+    }
+
+    unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        Arc::from_raw(ptr as _)
+    }
+}
+
+impl<T: PointerWrapper + Deref> PointerWrapper for Pin<T> {
+    fn into_pointer(self) -> *const c_types::c_void {
+        // SAFETY: We continue to treat the pointer as pinned by returning just a pointer to it to
+        // the caller.
+        let inner = unsafe { Pin::into_inner_unchecked(self) };
+        inner.into_pointer()
+    }
+
+    unsafe fn from_pointer(p: *const c_types::c_void) -> Self {
+        // SAFETY: The object was originally pinned.
+        Pin::new_unchecked(T::from_pointer(p))
+    }
 }


### PR DESCRIPTION
Since usage of PointerWrapper is not limited only to file
operations, move it out from file_operations.rs to a more
suitable place, types.rs.

Fixes #144

Signed-off-by: Sumera Priyadarsini <sylphrenadin@gmail.com>