### PR TITLE
Remove non-prefixed printing macros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,45 +216,27 @@ jobs:
           grep '] rust_minimal: Rust minimal sample (exit)$' qemu-stdout.log
 
       - run: |
-          grep '] rust_print: Rust printing macros sample (init)$'                 qemu-stdout.log
+          grep '] rust_print: Rust printing macros sample (init)$'       qemu-stdout.log
 
-          grep '] rust_print: Emergency message (level 0) with newline w/o args$'  qemu-stdout.log
-          grep '] rust_print: Alert message (level 1) with newline w/o args$'      qemu-stdout.log
-          grep '] rust_print: Critical message (level 2) with newline w/o args$'   qemu-stdout.log
-          grep '] rust_print: Error message (level 3) with newline w/o args$'      qemu-stdout.log
-          grep '] rust_print: Warning message (level 4) with newline w/o args$'    qemu-stdout.log
-          grep '] rust_print: Notice message (level 5) with newline w/o args$'     qemu-stdout.log
-          grep '] rust_print: Info message (level 6) with newline w/o args$'       qemu-stdout.log
-          grep '] rust_print: A line that is continued with newline w/o args$'     qemu-stdout.log
+          grep '] rust_print: Emergency message (level 0) without args$' qemu-stdout.log
+          grep '] rust_print: Alert message (level 1) without args$'     qemu-stdout.log
+          grep '] rust_print: Critical message (level 2) without args$'  qemu-stdout.log
+          grep '] rust_print: Error message (level 3) without args$'     qemu-stdout.log
+          grep '] rust_print: Warning message (level 4) without args$'   qemu-stdout.log
+          grep '] rust_print: Notice message (level 5) without args$'    qemu-stdout.log
+          grep '] rust_print: Info message (level 6) without args$'      qemu-stdout.log
+          grep '] rust_print: A line that is continued without args$'    qemu-stdout.log
 
-          grep '] rust_print: Emergency message (level 0) w/o newline w/o args$'   qemu-stdout.log
-          grep '] rust_print: Alert message (level 1) w/o newline w/o args$'       qemu-stdout.log
-          grep '] rust_print: Critical message (level 2) w/o newline w/o args$'    qemu-stdout.log
-          grep '] rust_print: Error message (level 3) w/o newline w/o args$'       qemu-stdout.log
-          grep '] rust_print: Warning message (level 4) w/o newline w/o args$'     qemu-stdout.log
-          grep '] rust_print: Notice message (level 5) w/o newline w/o args$'      qemu-stdout.log
-          grep '] rust_print: Info message (level 6) w/o newline w/o args$'        qemu-stdout.log
-          grep '] rust_print: A line that is continued w/o newline w/o args$'      qemu-stdout.log
+          grep '] rust_print: Emergency message (level 0) with args$'    qemu-stdout.log
+          grep '] rust_print: Alert message (level 1) with args$'        qemu-stdout.log
+          grep '] rust_print: Critical message (level 2) with args$'     qemu-stdout.log
+          grep '] rust_print: Error message (level 3) with args$'        qemu-stdout.log
+          grep '] rust_print: Warning message (level 4) with args$'      qemu-stdout.log
+          grep '] rust_print: Notice message (level 5) with args$'       qemu-stdout.log
+          grep '] rust_print: Info message (level 6) with args$'         qemu-stdout.log
+          grep '] rust_print: A line that is continued with args$'       qemu-stdout.log
 
-          grep '] rust_print: Emergency message (level 0) with newline with args$' qemu-stdout.log
-          grep '] rust_print: Alert message (level 1) with newline with args$'     qemu-stdout.log
-          grep '] rust_print: Critical message (level 2) with newline with args$'  qemu-stdout.log
-          grep '] rust_print: Error message (level 3) with newline with args$'     qemu-stdout.log
-          grep '] rust_print: Warning message (level 4) with newline with args$'   qemu-stdout.log
-          grep '] rust_print: Notice message (level 5) with newline with args$'    qemu-stdout.log
-          grep '] rust_print: Info message (level 6) with newline with args$'      qemu-stdout.log
-          grep '] rust_print: A line that is continued with newline with args$'    qemu-stdout.log
-
-          grep '] rust_print: Emergency message (level 0) w/o newline with args$'  qemu-stdout.log
-          grep '] rust_print: Alert message (level 1) w/o newline with args$'      qemu-stdout.log
-          grep '] rust_print: Critical message (level 2) w/o newline with args$'   qemu-stdout.log
-          grep '] rust_print: Error message (level 3) w/o newline with args$'      qemu-stdout.log
-          grep '] rust_print: Warning message (level 4) w/o newline with args$'    qemu-stdout.log
-          grep '] rust_print: Notice message (level 5) w/o newline with args$'     qemu-stdout.log
-          grep '] rust_print: Info message (level 6) w/o newline with args$'       qemu-stdout.log
-          grep '] rust_print: A line that is continued w/o newline with args$'     qemu-stdout.log
-
-          grep '] rust_print: Rust printing macros sample (exit)$'                 qemu-stdout.log
+          grep '] rust_print: Rust printing macros sample (exit)$'       qemu-stdout.log
 
       - run: |
           grep '] rust_module_parameters: Rust module parameters sample (init)$'           qemu-stdout.log

--- a/drivers/android/allocation.rs
+++ b/drivers/android/allocation.rs
@@ -151,7 +151,7 @@ impl Drop for Allocation<'_> {
             let view = AllocationView::new(self, info.offsets.start);
             for i in info.offsets.clone().step_by(size_of::<usize>()) {
                 if self.cleanup_object(i, &view).is_err() {
-                    warn!("Error cleaning up object at offset {}", i)
+                    pr_warn!("Error cleaning up object at offset {}\n", i)
                 }
             }
         }

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -557,7 +557,7 @@ impl Process {
                 .reservation_abort(ptr - mapping.address)
                 .is_err()
             {
-                warn!("Offset {} failed to free", ptr - mapping.address);
+                pr_warn!("Offset {} failed to free\n", ptr - mapping.address);
             }
         }
     }
@@ -566,7 +566,7 @@ impl Process {
         let mut inner = self.inner.lock();
         if let Some(ref mut mapping) = &mut inner.mapping {
             if mapping.alloc.reservation_commit(offset, data).is_err() {
-                warn!("Offset {} failed to be marked freeable", offset);
+                pr_warn!("Offset {} failed to be marked freeable\n", offset);
             }
         }
     }

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -398,7 +398,7 @@ impl Thread {
                     self.process.get_node_from_handle(handle, strong)
                 })?;
             }
-            _ => warn!("Unsupported binder object type: {:x}", header.type_),
+            _ => pr_warn!("Unsupported binder object type: {:x}\n", header.type_),
         }
         Ok(())
     }

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -140,7 +140,7 @@ impl<'a> Drop for KParamGuard<'a> {
 ///
 /// fn test() {
 ///     // This prints `8`.
-///     info!("{}", offset_of!(Test, b));
+///     pr_info!("{}\n", offset_of!(Test, b));
 /// }
 /// ```
 #[macro_export]
@@ -181,7 +181,7 @@ macro_rules! offset_of {
 ///     let b_ptr = &test.b;
 ///     let test_alias = unsafe { container_of!(b_ptr, Test, b) };
 ///     // This prints `true`.
-///     info!("{}", core::ptr::eq(&test, test_alias));
+///     pr_info!("{}\n", core::ptr::eq(&test, test_alias));
 /// }
 /// ```
 #[macro_export]

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -15,7 +15,6 @@ pub use alloc::{borrow::ToOwned, string::String};
 
 pub use module::module;
 
-pub use super::{alert, cont, crit, emerg, err, info, notice, warn};
 pub use super::{pr_alert, pr_cont, pr_crit, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
 
 pub use super::static_assert;

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -206,7 +206,7 @@ pub unsafe fn format_and_call<const CONT: bool>(
 #[macro_export]
 macro_rules! print_macro (
     // Without extra arguments: no need to format anything.
-    ($format_string:path, false, $suffix:literal, $fmt:expr) => (
+    ($format_string:path, false, $fmt:expr) => (
         // SAFETY: This hidden macro should only be called by the documented
         // printing macros which ensure the format string is one of the fixed
         // ones. All `__MODULE_NAME`s are null-terminated as they are generated
@@ -215,20 +215,20 @@ macro_rules! print_macro (
             kernel::print::call_printk(
                 &$format_string,
                 crate::__MODULE_NAME,
-                concat!($fmt, $suffix).as_bytes(),
+                $fmt.as_bytes(),
             );
         }
     );
 
     // Without extra arguments: no need to format anything (`CONT` case).
-    ($format_string:path, true, $suffix:literal, $fmt:expr) => (
+    ($format_string:path, true, $fmt:expr) => (
         kernel::print::call_printk_cont(
-            concat!($fmt, $suffix).as_bytes(),
+            $fmt.as_bytes(),
         );
     );
 
     // With extra arguments: we need to perform formatting.
-    ($format_string:path, $cont:literal, $suffix:literal, $fmt:expr, $($arg:tt)*) => (
+    ($format_string:path, $cont:literal, $fmt:expr, $($arg:tt)*) => (
         // Forwarding the call to a function to perform the formatting
         // is needed here to avoid stack overflows in non-optimized builds when
         // invoking the printing macros a lot of times in the same function.
@@ -251,7 +251,7 @@ macro_rules! print_macro (
             kernel::print::format_and_call::<$cont>(
                 &$format_string,
                 crate::__MODULE_NAME,
-                format_args!(concat!($fmt, $suffix), $($arg)*),
+                format_args!($fmt, $($arg)*),
             );
         }
     );
@@ -268,9 +268,6 @@ macro_rules! print_macro (
 
 /// Prints an emergency-level message (level 0).
 ///
-/// Use [`emerg!`] unless you need to continue the message with [`cont!`]
-/// or [`pr_cont!`].
-///
 /// Use this level if the system is unusable.
 ///
 /// Equivalent to the kernel's [`pr_emerg`] macro.
@@ -284,20 +281,16 @@ macro_rules! print_macro (
 /// # Examples
 ///
 /// ```
-/// pr_emerg!("hello {} ", "there");
-/// cont!("with arguments");
+/// pr_emerg!("hello {}\n", "there");
 /// ```
 #[macro_export]
 macro_rules! pr_emerg (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::EMERG, false, "", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::EMERG, false, $($arg)*)
     )
 );
 
 /// Prints an alert-level message (level 1).
-///
-/// Use [`alert!`] unless you need to continue the message with [`cont!`]
-/// or [`pr_cont!`].
 ///
 /// Use this level if action must be taken immediately.
 ///
@@ -312,20 +305,16 @@ macro_rules! pr_emerg (
 /// # Examples
 ///
 /// ```
-/// pr_alert!("hello {} ", "there");
-/// cont!("with arguments");
+/// pr_alert!("hello {}\n", "there");
 /// ```
 #[macro_export]
 macro_rules! pr_alert (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::ALERT, false, "", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::ALERT, false, $($arg)*)
     )
 );
 
 /// Prints a critical-level message (level 2).
-///
-/// Use [`crit!`] unless you need to continue the message with [`cont!`]
-/// or [`pr_cont!`].
 ///
 /// Use this level for critical conditions.
 ///
@@ -340,20 +329,16 @@ macro_rules! pr_alert (
 /// # Examples
 ///
 /// ```
-/// pr_crit!("hello {} ", "there");
-/// cont!("with arguments");
+/// pr_crit!("hello {}\n", "there");
 /// ```
 #[macro_export]
 macro_rules! pr_crit (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::CRIT, false, "", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::CRIT, false, $($arg)*)
     )
 );
 
 /// Prints an error-level message (level 3).
-///
-/// Use [`err!`] unless you need to continue the message with [`cont!`]
-/// or [`pr_cont!`].
 ///
 /// Use this level for error conditions.
 ///
@@ -368,20 +353,16 @@ macro_rules! pr_crit (
 /// # Examples
 ///
 /// ```
-/// pr_err!("hello {} ", "there");
-/// cont!("with arguments");
+/// pr_err!("hello {}\n", "there");
 /// ```
 #[macro_export]
 macro_rules! pr_err (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::ERR, false, "", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::ERR, false, $($arg)*)
     )
 );
 
 /// Prints a warning-level message (level 4).
-///
-/// Use [`warn!`] unless you need to continue the message with [`cont!`]
-/// or [`pr_cont!`].
 ///
 /// Use this level for warning conditions.
 ///
@@ -396,20 +377,16 @@ macro_rules! pr_err (
 /// # Examples
 ///
 /// ```
-/// pr_warn!("hello {} ", "there");
-/// cont!("with arguments");
+/// pr_warn!("hello {}\n", "there");
 /// ```
 #[macro_export]
 macro_rules! pr_warn (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::WARNING, false, "", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::WARNING, false, $($arg)*)
     )
 );
 
 /// Prints a notice-level message (level 5).
-///
-/// Use [`notice!`] unless you need to continue the message with [`cont!`]
-/// or [`pr_cont!`].
 ///
 /// Use this level for normal but significant conditions.
 ///
@@ -424,20 +401,16 @@ macro_rules! pr_warn (
 /// # Examples
 ///
 /// ```
-/// pr_notice!("hello {} ", "there");
-/// cont!("with arguments");
+/// pr_notice!("hello {}\n", "there");
 /// ```
 #[macro_export]
 macro_rules! pr_notice (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::NOTICE, false, "", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::NOTICE, false, $($arg)*)
     )
 );
 
 /// Prints an info-level message (level 6).
-///
-/// Use [`info!`] unless you need to continue the message with [`cont!`]
-/// or [`pr_cont!`].
 ///
 /// Use this level for informational messages.
 ///
@@ -452,21 +425,17 @@ macro_rules! pr_notice (
 /// # Examples
 ///
 /// ```
-/// pr_info!("hello {} ", "there");
-/// cont!("with arguments");
+/// pr_info!("hello {}\n", "there");
 /// ```
 #[macro_export]
 #[doc(alias = "print")]
 macro_rules! pr_info (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::INFO, false, "", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::INFO, false, $($arg)*)
     )
 );
 
 /// Continues a previous log message in the same line.
-///
-/// Use [`cont!`] unless you need to continue the message (again) with [`cont!`]
-/// or [`pr_cont!`].
 ///
 /// Use only when continuing a previous `pr_*!` macro (e.g. [`pr_info!`]).
 ///
@@ -481,229 +450,12 @@ macro_rules! pr_info (
 /// # Examples
 ///
 /// ```
-/// pr_info!("hello ");
-/// pr_cont!("th");
-/// cont!("ere!");
-///
-/// pr_info!("format ");
-/// pr_cont!("{} ", "some");
-/// cont!("{}", "arguments");
+/// pr_info!("hello");
+/// pr_cont!(" {}\n", "there");
 /// ```
 #[macro_export]
 macro_rules! pr_cont (
     ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::CONT, true, "", $($arg)*)
-    )
-);
-
-/// Prints an emergency-level message, with a newline (level 0).
-///
-/// Use this level if the system is unusable.
-///
-/// Similar to the kernel's [`pr_emerg`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_emerg`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_emerg
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// emerg!("hello there!");
-/// emerg!("format {} arguments", "some");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_emerg")]
-macro_rules! emerg (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::EMERG, false, "\n", $($arg)*)
-    )
-);
-
-/// Prints an alert-level message, with a newline (level 1).
-///
-/// Use this level if action must be taken immediately.
-///
-/// Similar to the kernel's [`pr_alert`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_alert`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_alert
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// alert!("hello there!");
-/// alert!("format {} arguments", "some");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_alert")]
-macro_rules! alert (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::ALERT, false, "\n", $($arg)*)
-    )
-);
-
-/// Prints a critical-level message, with a newline (level 2).
-///
-/// Use this level for critical conditions.
-///
-/// Similar to the kernel's [`pr_crit`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_crit`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_crit
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// pr_crit!("hello there!");
-/// pr_crit!("format {} arguments", "some");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_crit")]
-macro_rules! crit (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::CRIT, false, "\n", $($arg)*)
-    )
-);
-
-/// Prints an error-level message, with a newline (level 3).
-///
-/// Use this level for error conditions.
-///
-/// Similar to the kernel's [`pr_err`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_err`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_err
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// err!("hello there!");
-/// err!("format {} arguments", "some");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_err")]
-macro_rules! err (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::ERR, false, "\n", $($arg)*)
-    )
-);
-
-/// Prints a warning-level message, with a newline (level 4).
-///
-/// Use this level for warning conditions.
-///
-/// Similar to the kernel's [`pr_warn`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_warn`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_warn
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// warn!("hello there!");
-/// warn!("format {} arguments", "some");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_warn")]
-macro_rules! warn (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::WARNING, false, "\n", $($arg)*)
-    )
-);
-
-/// Prints a notice-level message, with a newline (level 5).
-///
-/// Use this level for normal but significant conditions.
-///
-/// Similar to the kernel's [`pr_notice`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_notice`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_notice
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// notice!("hello there!");
-/// notice!("format {} arguments", "some");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_notice")]
-macro_rules! notice (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::NOTICE, false, "\n", $($arg)*)
-    )
-);
-
-/// Prints an info-level message, with a newline (level 6).
-///
-/// Use this level for informational messages.
-///
-/// Similar to the kernel's [`pr_info`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_info`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_info
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// info!("hello there!");
-/// info!("format {} arguments", "some");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_info")]
-#[doc(alias = "println")]
-macro_rules! info (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::INFO, false, "\n", $($arg)*)
-    )
-);
-
-/// Continues a previous log message in the same line, with a newline.
-///
-/// Use only when continuing a previous `pr_*!` macro (e.g. [`pr_info!`]).
-///
-/// Similar to the kernel's [`pr_cont`] macro.
-///
-/// Mimics the interface of [`std::println!`]. See [`core::fmt`] and
-/// [`alloc::format!`] for information about the formatting syntax.
-///
-/// [`pr_cont`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_cont
-/// [`std::println!`]: https://doc.rust-lang.org/std/macro.println.html
-///
-/// # Examples
-///
-/// ```
-/// pr_info!("hello ");
-/// cont!("there!");
-///
-/// pr_info!("format {}", "some");
-/// cont!(" {}", "arguments");
-/// ```
-#[macro_export]
-#[doc(alias = "pr_cont")]
-macro_rules! cont (
-    ($($arg:tt)*) => (
-        $crate::print_macro!($crate::print::format_strings::CONT, true, "\n", $($arg)*)
+        $crate::print_macro!($crate::print::format_strings::CONT, true, $($arg)*)
     )
 );

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -13,7 +13,7 @@
 //!     let data = alloc::sync::Arc::pin(unsafe { Mutex::new(0) });
 //!     mutex_init!(data.as_ref(), "test::data");
 //!     *data.lock() = 10;
-//!     info!("{}", *data.lock());
+//!     pr_info!("{}\n", *data.lock());
 //! }
 //! ```
 

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -355,11 +355,11 @@ fn generated_array_ops_name(vals: &str, max_length: usize) -> String {
 ///         // taken to read the parameter:
 ///         {
 ///             let lock = THIS_MODULE.kernel_param_lock();
-///             info!("i32 param is:  {}", writeable_i32.read(&lock));
+///             pr_info!("i32 param is:  {}\n", writeable_i32.read(&lock));
 ///         }
 ///         // If the parameter is read only, it can be read without locking
 ///         // the kernel parameters:
-///         info!("i32 param is:  {}", my_i32.read());
+///         pr_info!("i32 param is:  {}\n", my_i32.read());
 ///         Ok(MyKernelModule)
 ///     }
 /// }

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -27,7 +27,7 @@ struct RustFile;
 
 impl FileOpener<()> for RustFile {
     fn open(_ctx: &()) -> KernelResult<Self::Wrapper> {
-        info!("rust file was opened!");
+        pr_info!("rust file was opened!\n");
         Ok(Box::try_new(Self)?)
     }
 }
@@ -44,7 +44,7 @@ struct RustChrdev {
 
 impl KernelModule for RustChrdev {
     fn init() -> KernelResult<Self> {
-        info!("Rust character device sample (init)");
+        pr_info!("Rust character device sample (init)\n");
 
         let mut chrdev_reg =
             chrdev::Registration::new_pinned(cstr!("rust_chrdev"), 0, &THIS_MODULE)?;
@@ -61,6 +61,6 @@ impl KernelModule for RustChrdev {
 
 impl Drop for RustChrdev {
     fn drop(&mut self) {
-        info!("Rust character device sample (exit)");
+        pr_info!("Rust character device sample (exit)\n");
     }
 }

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -23,8 +23,8 @@ struct RustMinimal {
 
 impl KernelModule for RustMinimal {
     fn init() -> KernelResult<Self> {
-        info!("Rust minimal sample (init)");
-        info!("Am I built-in? {}", !cfg!(MODULE));
+        pr_info!("Rust minimal sample (init)\n");
+        pr_info!("Am I built-in? {}\n", !cfg!(MODULE));
 
         Ok(RustMinimal {
             message: "on the heap!".to_owned(),
@@ -34,7 +34,7 @@ impl KernelModule for RustMinimal {
 
 impl Drop for RustMinimal {
     fn drop(&mut self) {
-        info!("My message is {}", self.message);
-        info!("Rust minimal sample (exit)");
+        pr_info!("My message is {}\n", self.message);
+        pr_info!("Rust minimal sample (exit)\n");
     }
 }

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -128,7 +128,7 @@ struct RustMiscdev {
 
 impl KernelModule for RustMiscdev {
     fn init() -> KernelResult<Self> {
-        info!("Rust miscellaneous device sample (init)");
+        pr_info!("Rust miscellaneous device sample (init)\n");
 
         let state = SharedState::try_new()?;
 
@@ -140,6 +140,6 @@ impl KernelModule for RustMiscdev {
 
 impl Drop for RustMiscdev {
     fn drop(&mut self) {
-        info!("Rust miscellaneous device sample (exit)");
+        pr_info!("Rust miscellaneous device sample (exit)\n");
     }
 }

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -46,19 +46,19 @@ struct RustModuleParameters;
 
 impl KernelModule for RustModuleParameters {
     fn init() -> KernelResult<Self> {
-        info!("Rust module parameters sample (init)");
+        pr_info!("Rust module parameters sample (init)\n");
 
         {
             let lock = THIS_MODULE.kernel_param_lock();
-            info!("Parameters:");
-            info!("  my_bool:    {}", my_bool.read());
-            info!("  my_i32:     {}", my_i32.read(&lock));
-            info!(
-                "  my_str:     {}",
+            pr_info!("Parameters:\n");
+            pr_info!("  my_bool:    {}\n", my_bool.read());
+            pr_info!("  my_i32:     {}\n", my_i32.read(&lock));
+            pr_info!(
+                "  my_str:     {}\n",
                 core::str::from_utf8(my_str.read(&lock))?
             );
-            info!("  my_usize:   {}", my_usize.read(&lock));
-            info!("  my_array:   {:?}", my_array.read());
+            pr_info!("  my_usize:   {}\n", my_usize.read(&lock));
+            pr_info!("  my_array:   {:?}\n", my_array.read());
         }
 
         Ok(RustModuleParameters)
@@ -67,6 +67,6 @@ impl KernelModule for RustModuleParameters {
 
 impl Drop for RustModuleParameters {
     fn drop(&mut self) {
-        info!("Rust module parameters sample (exit)");
+        pr_info!("Rust module parameters sample (exit)\n");
     }
 }

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -21,75 +21,31 @@ struct RustPrint;
 
 impl KernelModule for RustPrint {
     fn init() -> KernelResult<Self> {
-        info!("Rust printing macros sample (init)");
+        pr_info!("Rust printing macros sample (init)\n");
 
-        emerg!("Emergency message (level 0) with newline w/o args");
-        alert!("Alert message (level 1) with newline w/o args");
-        crit!("Critical message (level 2) with newline w/o args");
-        err!("Error message (level 3) with newline w/o args");
-        warn!("Warning message (level 4) with newline w/o args");
-        notice!("Notice message (level 5) with newline w/o args");
-        info!("Info message (level 6) with newline w/o args");
-
-        pr_info!("A line that");
-        pr_cont!(" is continued");
-        cont!(" with newline w/o args");
-
-        pr_emerg!("Emergency message (level 0) w/o newline w/o args\n");
-        pr_alert!("Alert message (level 1) w/o newline w/o args\n");
-        pr_crit!("Critical message (level 2) w/o newline w/o args\n");
-        pr_err!("Error message (level 3) w/o newline w/o args\n");
-        pr_warn!("Warning message (level 4) w/o newline w/o args\n");
-        pr_notice!("Notice message (level 5) w/o newline w/o args\n");
-        pr_info!("Info message (level 6) w/o newline w/o args\n");
+        pr_emerg!("Emergency message (level 0) without args\n");
+        pr_alert!("Alert message (level 1) without args\n");
+        pr_crit!("Critical message (level 2) without args\n");
+        pr_err!("Error message (level 3) without args\n");
+        pr_warn!("Warning message (level 4) without args\n");
+        pr_notice!("Notice message (level 5) without args\n");
+        pr_info!("Info message (level 6) without args\n");
 
         pr_info!("A line that");
         pr_cont!(" is continued");
-        pr_cont!(" w/o newline w/o args\n");
+        pr_cont!(" without args\n");
 
-        emerg!(
-            "{} message (level {}) with newline with args",
-            "Emergency",
-            0
-        );
-        alert!("{} message (level {}) with newline with args", "Alert", 1);
-        crit!(
-            "{} message (level {}) with newline with args",
-            "Critical",
-            2
-        );
-        err!("{} message (level {}) with newline with args", "Error", 3);
-        warn!("{} message (level {}) with newline with args", "Warning", 4);
-        notice!("{} message (level {}) with newline with args", "Notice", 5);
-        info!("{} message (level {}) with newline with args", "Info", 6);
+        pr_emerg!("{} message (level {}) with args\n", "Emergency", 0);
+        pr_alert!("{} message (level {}) with args\n", "Alert", 1);
+        pr_crit!("{} message (level {}) with args\n", "Critical", 2);
+        pr_err!("{} message (level {}) with args\n", "Error", 3);
+        pr_warn!("{} message (level {}) with args\n", "Warning", 4);
+        pr_notice!("{} message (level {}) with args\n", "Notice", 5);
+        pr_info!("{} message (level {}) with args\n", "Info", 6);
 
         pr_info!("A {} that", "line");
         pr_cont!(" is {}", "continued");
-        cont!(" with {} with args", "newline");
-
-        pr_emerg!(
-            "{} message (level {}) w/o newline with args\n",
-            "Emergency",
-            0
-        );
-        pr_alert!("{} message (level {}) w/o newline with args\n", "Alert", 1);
-        pr_crit!(
-            "{} message (level {}) w/o newline with args\n",
-            "Critical",
-            2
-        );
-        pr_err!("{} message (level {}) w/o newline with args\n", "Error", 3);
-        pr_warn!(
-            "{} message (level {}) w/o newline with args\n",
-            "Warning",
-            4
-        );
-        pr_notice!("{} message (level {}) w/o newline with args\n", "Notice", 5);
-        pr_info!("{} message (level {}) w/o newline with args\n", "Info", 6);
-
-        pr_info!("A {} that", "line");
-        pr_cont!(" is {}", "continued");
-        pr_cont!(" w/o {} with args\n", "newline");
+        pr_cont!(" with {}\n", "args");
 
         Ok(RustPrint)
     }
@@ -97,6 +53,6 @@ impl KernelModule for RustPrint {
 
 impl Drop for RustPrint {
     fn drop(&mut self) {
-        info!("Rust printing macros sample (exit)");
+        pr_info!("Rust printing macros sample (exit)\n");
     }
 }

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -119,7 +119,7 @@ struct RustSemaphore {
 
 impl KernelModule for RustSemaphore {
     fn init() -> KernelResult<Self> {
-        info!("Rust semaphore sample (init)");
+        pr_info!("Rust semaphore sample (init)\n");
 
         let sema = Arc::try_new(Semaphore {
             // SAFETY: `condvar_init!` is called below.
@@ -148,7 +148,7 @@ impl KernelModule for RustSemaphore {
 
 impl Drop for RustSemaphore {
     fn drop(&mut self) {
-        info!("Rust semaphore sample (exit)");
+        pr_info!("Rust semaphore sample (exit)\n");
     }
 }
 

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -22,14 +22,14 @@ struct RustStackProbing;
 
 impl KernelModule for RustStackProbing {
     fn init() -> KernelResult<Self> {
-        info!("Rust stack probing sample (init)");
+        pr_info!("Rust stack probing sample (init)\n");
 
         // Including this large variable on the stack will trigger
         // stack probing on the supported archs.
         // This will verify that stack probing does not lead to
         // any errors if we need to link `__rust_probestack`.
         let x: [u64; 514] = core::hint::black_box([5; 514]);
-        info!("Large array has length: {}", x.len());
+        pr_info!("Large array has length: {}\n", x.len());
 
         Ok(RustStackProbing)
     }
@@ -37,6 +37,6 @@ impl KernelModule for RustStackProbing {
 
 impl Drop for RustStackProbing {
     fn drop(&mut self) {
-        info!("Rust stack probing sample (exit)");
+        pr_info!("Rust stack probing sample (exit)\n");
     }
 }

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -27,7 +27,7 @@ struct RustSync;
 
 impl KernelModule for RustSync {
     fn init() -> KernelResult<Self> {
-        info!("Rust synchronisation primitives sample (init)");
+        pr_info!("Rust synchronisation primitives sample (init)\n");
 
         // Test mutexes.
         {
@@ -35,7 +35,7 @@ impl KernelModule for RustSync {
             let data = Pin::from(Box::try_new(unsafe { Mutex::new(0) })?);
             mutex_init!(data.as_ref(), "RustSync::init::data1");
             *data.lock() = 10;
-            info!("Value: {}", *data.lock());
+            pr_info!("Value: {}\n", *data.lock());
 
             // SAFETY: `init` is called below.
             let cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
@@ -57,7 +57,7 @@ impl KernelModule for RustSync {
             let data = Pin::from(Box::try_new(unsafe { SpinLock::new(0) })?);
             spinlock_init!(data.as_ref(), "RustSync::init::data2");
             *data.lock() = 10;
-            info!("Value: {}", *data.lock());
+            pr_info!("Value: {}\n", *data.lock());
 
             // SAFETY: `init` is called below.
             let cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
@@ -79,6 +79,6 @@ impl KernelModule for RustSync {
 
 impl Drop for RustSync {
     fn drop(&mut self) {
-        info!("Rust synchronisation primitives sample (exit)");
+        pr_info!("Rust synchronisation primitives sample (exit)\n");
     }
 }


### PR DESCRIPTION
As suggested by Greg, it is simpler if we match the C side since
people will jump back and forth between C and Rust.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>