### PR TITLE
Export everything as GPL

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -88,17 +88,14 @@ quiet_cmd_exports = EXPORTS $@
 	$(NM) -p --defined-only $< \
 		| grep -E ' (T|R|D) ' | cut -d ' ' -f 3 | grep -E '^(__rust_|_R)' \
 		| xargs -n1 -Isymbol \
-		echo 'EXPORT_SYMBOL$(exports_target_type)(symbol);' > $@
+		echo 'EXPORT_SYMBOL_RUST_GPL(symbol);' > $@
 
-$(objtree)/rust/exports_core_generated.h: private exports_target_type := _RUST
 $(objtree)/rust/exports_core_generated.h: $(objtree)/rust/core.o FORCE
 	$(call if_changed,exports)
 
-$(objtree)/rust/exports_alloc_generated.h: private exports_target_type := _RUST
 $(objtree)/rust/exports_alloc_generated.h: $(objtree)/rust/alloc.o FORCE
 	$(call if_changed,exports)
 
-$(objtree)/rust/exports_kernel_generated.h: private exports_target_type := _RUST_GPL
 $(objtree)/rust/exports_kernel_generated.h: $(objtree)/rust/kernel.o FORCE
 	$(call if_changed,exports)
 

--- a/rust/exports.c
+++ b/rust/exports.c
@@ -9,7 +9,6 @@
 
 #include <linux/module.h>
 
-#define EXPORT_SYMBOL_RUST(sym)     extern int sym; EXPORT_SYMBOL(sym);
 #define EXPORT_SYMBOL_RUST_GPL(sym) extern int sym; EXPORT_SYMBOL_GPL(sym);
 
 #include "exports_core_generated.h"

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -31,55 +31,55 @@ void rust_helper_spin_lock_init(spinlock_t *lock, const char *name,
 	spin_lock_init(lock);
 #endif
 }
-EXPORT_SYMBOL(rust_helper_spin_lock_init);
+EXPORT_SYMBOL_GPL(rust_helper_spin_lock_init);
 
 void rust_helper_spin_lock(spinlock_t *lock)
 {
 	spin_lock(lock);
 }
-EXPORT_SYMBOL(rust_helper_spin_lock);
+EXPORT_SYMBOL_GPL(rust_helper_spin_lock);
 
 void rust_helper_spin_unlock(spinlock_t *lock)
 {
 	spin_unlock(lock);
 }
-EXPORT_SYMBOL(rust_helper_spin_unlock);
+EXPORT_SYMBOL_GPL(rust_helper_spin_unlock);
 
 void rust_helper_init_wait(struct wait_queue_entry *wq_entry)
 {
 	init_wait(wq_entry);
 }
-EXPORT_SYMBOL(rust_helper_init_wait);
+EXPORT_SYMBOL_GPL(rust_helper_init_wait);
 
 int rust_helper_current_pid(void)
 {
 	return current->pid;
 }
-EXPORT_SYMBOL(rust_helper_current_pid);
+EXPORT_SYMBOL_GPL(rust_helper_current_pid);
 
 int rust_helper_signal_pending(void)
 {
 	return signal_pending(current);
 }
-EXPORT_SYMBOL(rust_helper_signal_pending);
+EXPORT_SYMBOL_GPL(rust_helper_signal_pending);
 
 struct page *rust_helper_alloc_pages(gfp_t gfp_mask, unsigned int order)
 {
 	return alloc_pages(gfp_mask, order);
 }
-EXPORT_SYMBOL(rust_helper_alloc_pages);
+EXPORT_SYMBOL_GPL(rust_helper_alloc_pages);
 
 void *rust_helper_kmap(struct page *page)
 {
 	return kmap(page);
 }
-EXPORT_SYMBOL(rust_helper_kmap);
+EXPORT_SYMBOL_GPL(rust_helper_kmap);
 
 void rust_helper_kunmap(struct page *page)
 {
 	return kunmap(page);
 }
-EXPORT_SYMBOL(rust_helper_kunmap);
+EXPORT_SYMBOL_GPL(rust_helper_kunmap);
 
 // See https://github.com/rust-lang/rust-bindgen/issues/1671
 static_assert(__builtin_types_compatible_p(size_t, uintptr_t),


### PR DESCRIPTION
This means we are now also exporting the helpers, `core` and `alloc`
as GPL too.

It is simpler and also allows us to not worry later on if, for
instance, we want to have our own `alloc`.

In the future, if someone wants some of this as non-GPL, they can
nevertheless come to us to discuss why etc.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>