### PR TITLE
Remove blank line at EOF

### DIFF
--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -201,4 +201,3 @@ a few ways out:
   - If you don't need loadable module support, you may compile without
     the ``-Zsymbol-mangling-version=v0`` flag. However, we don't maintain
     support for that, so avoid it unless you are in a hurry.
-


### PR DESCRIPTION
This removes a warning from `git am` when applying the RFC patches.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>