### PR TITLE
Rust: document rustfmt macro preservation

### DIFF
--- a/Documentation/rust/coding.rst
+++ b/Documentation/rust/coding.rst
@@ -22,6 +22,9 @@ good news!
 .. note:: Conventions on comments and documentation are not checked by
   ``rustfmt``. Thus we still need to take care of those: please see
   :ref:`Documentation/rust/docs.rst <rust_docs>`.
+  
+.. note:: `rustfmt` also preserves formatting inside most macros. So you might
+  need to manually adjust newlines and indents inside macro invocations.
 
 We use the tool's default settings. This means we are following the idiomatic
 Rust style. For instance, we use 4 spaces for indentation rather than tabs.


### PR DESCRIPTION
Some common std macros get reformatted. But by default `rustfmt` Is conservative and preserves macro formatting.