### PR TITLE
Rust: fix quick-start list markdown format

### DIFF
--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -188,16 +188,16 @@ If you use GDB/Binutils and Rust symbols aren't getting demangled, the reason
 is your toolchain doesn't support Rust's new v0 mangling scheme yet. There are
 a few ways out:
 
-  - If you don't mind building your own tools, we provide the following fork
-    with the support cherry-picked from GCC on top of very recent releases:
+- If you don't mind building your own tools, we provide the following fork
+  with the support cherry-picked from GCC on top of very recent releases:
 
-        https://github.com/Rust-for-Linux/binutils-gdb/releases/tag/gdb-10.1-release-rust
+      https://github.com/Rust-for-Linux/binutils-gdb/releases/tag/gdb-10.1-release-rust
         https://github.com/Rust-for-Linux/binutils-gdb/releases/tag/binutils-2_35_1-rust
 
-  - If you only need GDB and can enable ``CONFIG_DEBUG_INFO``, do so:
-    some versions of GDB (e.g. vanilla GDB 10.1) are able to use
-    the pre-demangled names embedded in the debug info.
+- If you only need GDB and can enable ``CONFIG_DEBUG_INFO``, do so:
+  some versions of GDB (e.g. vanilla GDB 10.1) are able to use
+  the pre-demangled names embedded in the debug info.
 
-  - If you don't need loadable module support, you may compile without
-    the ``-Zsymbol-mangling-version=v0`` flag. However, we don't maintain
-    support for that, so avoid it unless you are in a hurry.
+- If you don't need loadable module support, you may compile without
+  the ``-Zsymbol-mangling-version=v0`` flag. However, we don't maintain
+  support for that, so avoid it unless you are in a hurry.


### PR DESCRIPTION
On GitHub, indented lists like:

```
  - example 1
  - example 2
```

Get rendered as quoted list items, rather than just list items.

Note: GitHub appears to render tickets and docs differently, so the list items are rendered correctly in some contexts, but badly in others. 