### PR TITLE
RFC: rust: chrdev: fix use-after-free on module unload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,6 +252,10 @@ jobs:
             | sed s:$'\r'$:: \
             | tee qemu-stdout.log
 
+      # The kernel should not be generating any warnings
+      - run: |
+          ! grep '] WARNING:' qemu-stdout.log
+
       # Check
       - run: |
           grep '] rust_minimal: Rust minimal sample (init)$' qemu-stdout.log


### PR DESCRIPTION
Note that this issue is potentially present on any driver module which
stores its `cdev` in `kmalloc`-ed memory. This is not seen as a problem,
as module unloading is currently "best effort" only.

The kernel's `struct cdev` is a reference-counted `kobject`. This
means that the object isn't guaranteed to be cleaned up after a
call to `cdev_del` - the cleanup may occur later.

Rust's `chrdev` places the `struct cdev` in `kmalloc`-ed memory.
On module unload, it calls `cdev_del` and `kfree`s all module memory,
including the `struct cdev`. But that structure might only be cleaned
up later - resulting in a potential use-after-free.

This issue is reliably triggered using CONFIG_DEBUG_KOBJECT_RELEASE,
which has been developed specifically to catch this subtle class of
bugs.

Fix by allocating the `cdev` using `cdev_alloc`, which stores the
object on the kernel's `kalloc` heap. Now it can outlive the
module, and be cleaned up+released when the kernel decides it's time.