### PR TITLE
Add rust-analyzer notes to quick-start.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ x509.genkey
 
 # Documentation toolchain
 sphinx_*/
+
+# Rust analyzer configuration
+/rust-project.json

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -145,6 +145,23 @@ the component manually::
 The standalone installers also come with ``rustdoc``.
 
 
+rust-analyzer
+*************
+
+The `rust-analyzer <https://rust-analyzer.github.io/>`_ language server can
+be used with many editors to enable syntax highlighting, completion, go to
+definition, and other features.
+
+``rust-analyzer`` will need to be
+`configured <https://rust-analyzer.github.io/manual.html#non-cargo-based-projects>`_
+to work with the kernel by adding a ``rust-project.json`` file in the root folder.
+The example ``Documentation/rust/rust-project.json`` can
+be used after updating ``sysroot_src`` and including the relevant modules.
+The path to ``sysroot_src`` is given by::
+
+    $(rustc --print sysroot)/lib/rustlib/src/rust/library
+
+
 Configuration
 -------------
 

--- a/Documentation/rust/rust-project.json
+++ b/Documentation/rust/rust-project.json
@@ -1,0 +1,35 @@
+{
+    "sysroot_src": <path-to-sysroot-source>,
+    "crates": [
+        {
+            "root_module": "rust/module.rs",
+            "edition": "2018",
+            "deps": []
+        },
+        {
+            "root_module": "rust/kernel/lib.rs",
+            "edition": "2018",
+            "deps": [
+                {
+                    "crate": 0,
+                    "name": "module"
+                }
+            ]
+        },
+        {
+            "root_module": <path-to-module>,
+            "edition": "2018",
+            "deps": [
+                {
+                    "crate": 0,
+                    "name": "module"
+                },
+                {
+                    "crate": 1,
+                    "name": "kernel"
+                }
+            ]
+        },
+        <...entries for other modules...>
+    ]
+}


### PR DESCRIPTION
Added a section in the quick start docs on how to configure rust-analyzer (from @wedsonaf's example https://github.com/Rust-for-Linux/linux/issues/202).