### PR TITLE
rust: doc: Replace a ref tag in doc-guide/kernel-doc.rst

### DIFF
--- a/Documentation/doc-guide/kernel-doc.rst
+++ b/Documentation/doc-guide/kernel-doc.rst
@@ -12,7 +12,7 @@ when it is embedded in source files.
    comments. Please stick to the style described here.
 
 .. note:: kernel-doc does not cover Rust code: please see
-   :ref:`Documentation/rust/docs.rst <rust_docs>` instead.
+   Documentation/rust/docs.rst instead.
 
 The kernel-doc structure is extracted from the comments, and proper
 `Sphinx C Domain`_ function and type descriptions with anchors are


### PR DESCRIPTION
replace a ref tag to normal path tag in doc-guide/kernel-doc.rst

Link: https://lore.kernel.org/linux-doc/87lf9lrgp3.fsf@meer.lwn.net/
Signed-off-by: Wu XiangCheng <bobwxc@email.cn>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>