### PR TITLE
Reduce the need for boilerplate code in simple drivers.

### DIFF
--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -520,6 +520,12 @@ pub trait FileOpener<T: ?Sized>: FileOperations {
     fn open(context: &T) -> KernelResult<Self::Wrapper>;
 }
 
+impl<T: FileOperations<Wrapper = Box<T>> + Default> FileOpener<()> for T {
+    fn open(_: &()) -> KernelResult<Self::Wrapper> {
+        Ok(Box::try_new(T::default())?)
+    }
+}
+
 /// Corresponds to the kernel's `struct file_operations`.
 ///
 /// You implement this trait whenever you would create a `struct file_operations`.
@@ -532,7 +538,7 @@ pub trait FileOperations: Send + Sync + Sized {
     const TO_USE: ToUse;
 
     /// The pointer type that will be used to hold ourselves.
-    type Wrapper: PointerWrapper<Self>;
+    type Wrapper: PointerWrapper<Self> = Box<Self>;
 
     /// Cleans up after the last reference to the file goes away.
     ///

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -15,6 +15,7 @@
 #![feature(
     allocator_api,
     alloc_error_handler,
+    associated_type_defaults,
     const_fn,
     const_mut_refs,
     const_panic,

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -8,10 +8,7 @@
 use alloc::boxed::Box;
 use core::pin::Pin;
 use kernel::prelude::*;
-use kernel::{
-    chrdev, cstr,
-    file_operations::{FileOpener, FileOperations},
-};
+use kernel::{chrdev, cstr, file_operations::FileOperations};
 
 module! {
     type: RustChrdev,
@@ -23,18 +20,10 @@ module! {
     },
 }
 
+#[derive(Default)]
 struct RustFile;
 
-impl FileOpener<()> for RustFile {
-    fn open(_ctx: &()) -> KernelResult<Self::Wrapper> {
-        pr_info!("rust file was opened!\n");
-        Ok(Box::try_new(Self)?)
-    }
-}
-
 impl FileOperations for RustFile {
-    type Wrapper = Box<Self>;
-
     kernel::declare_file_operations!();
 }
 


### PR DESCRIPTION
Provide a default `FileOpener` implementation for types that implement
`Default`, whose wrappers are `Box`, and that have no per-device shared
state.

Make `Box` the default wrapper, so that drivers only need to define
`Wrapper` if they need something different.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>