### PR TITLE
Add `module_misc_device` macro.

### DIFF
--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -13,7 +13,7 @@
 
 pub use alloc::{borrow::ToOwned, string::String};
 
-pub use module::module;
+pub use module::{module, module_misc_device};
 
 pub use super::{pr_alert, pr_cont, pr_crit, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
 


### PR DESCRIPTION
It mimics the C version that allows a module to be defined that exposes
a misc device.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>