### PR TITLE
print.rs: Allow printing in the kernel crate

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -69,6 +69,9 @@ pub use crate::types::{CStr, Mode};
 /// [`PAGE_SHIFT`]: ../../../include/asm-generic/page.h
 pub const PAGE_SIZE: usize = 1 << bindings::PAGE_SHIFT;
 
+/// Prefix to appear before log messages printed from within the kernel crate.
+const __LOG_PREFIX: &[u8] = b"rust_kernel\0";
+
 /// The top level entrypoint to implementing a kernel module.
 ///
 /// For any teardown or cleanup operations, your type may implement [`Drop`].

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -209,12 +209,13 @@ macro_rules! print_macro (
     ($format_string:path, false, $fmt:expr) => (
         // SAFETY: This hidden macro should only be called by the documented
         // printing macros which ensure the format string is one of the fixed
-        // ones. All `__MODULE_NAME`s are null-terminated as they are generated
-        // by the `module!` proc macro.
+        // ones. All `__LOG_PREFIX`s are null-terminated as they are generated
+        // by the `module!` proc macro or fixed values defined in a kernel
+        // crate.
         unsafe {
-            kernel::print::call_printk(
+            $crate::print::call_printk(
                 &$format_string,
-                crate::__MODULE_NAME,
+                crate::__LOG_PREFIX,
                 $fmt.as_bytes(),
             );
         }
@@ -222,7 +223,7 @@ macro_rules! print_macro (
 
     // Without extra arguments: no need to format anything (`CONT` case).
     ($format_string:path, true, $fmt:expr) => (
-        kernel::print::call_printk_cont(
+        $crate::print::call_printk_cont(
             $fmt.as_bytes(),
         );
     );
@@ -245,12 +246,13 @@ macro_rules! print_macro (
         //
         // SAFETY: This hidden macro should only be called by the documented
         // printing macros which ensure the format string is one of the fixed
-        // ones. All `__MODULE_NAME`s are null-terminated as they are generated
-        // by the `module!` proc macro.
+        // ones. All `__LOG_PREFIX`s are null-terminated as they are generated
+        // by the `module!` proc macro or fixed values defined in a kernel
+        // crate.
         unsafe {
-            kernel::print::format_and_call::<$cont>(
+            $crate::print::format_and_call::<$cont>(
                 &$format_string,
-                crate::__MODULE_NAME,
+                crate::__LOG_PREFIX,
                 format_args!($fmt, $($arg)*),
             );
         }

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -587,7 +587,7 @@ pub fn module(ts: TokenStream) -> TokenStream {
             /// The module name.
             ///
             /// Used by the printing macros, e.g. [`info!`].
-            const __MODULE_NAME: &[u8] = b\"{name}\\0\";
+            const __LOG_PREFIX: &[u8] = b\"{name}\\0\";
 
             static mut __MOD: Option<{type_}> = None;
 


### PR DESCRIPTION
The `pr_*` print macros previously didn't compile when used from the
`kernel` crate because they refer to the path `kernel` instead of
using the `$crate` variable and require a `const __MODULE_NAME` to be
defined in any crate in which they are used.

This fixes both issues and changes the `__MODULE_NAME` to `__LOG_PREFIX`
to reflect the fact that the print macro may be called from a module or
a kernel library.

Signed-off-by: Adam Bratschi-Kaye <ark.email@gmail.com>