### PR TITLE
Generalise `read` and `write`.

### DIFF
--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -14,7 +14,6 @@ use kernel::{
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
     sync::{CondVar, Mutex},
-    user_ptr::{UserSlicePtrReader, UserSlicePtrWriter},
     Error,
 };
 
@@ -74,7 +73,7 @@ impl FileOperations for Token {
 
     kernel::declare_file_operations!(read, write);
 
-    fn read(&self, _: &File, data: &mut UserSlicePtrWriter, offset: u64) -> KernelResult<usize> {
+    fn read<T: IoBufferWriter>(&self, _: &File, data: &mut T, offset: u64) -> KernelResult<usize> {
         // Succeed if the caller doesn't provide a buffer or if not at the start.
         if data.is_empty() || offset != 0 {
             return Ok(0);
@@ -102,7 +101,12 @@ impl FileOperations for Token {
         Ok(1)
     }
 
-    fn write(&self, data: &mut UserSlicePtrReader, _offset: u64) -> KernelResult<usize> {
+    fn write<T: IoBufferReader>(
+        &self,
+        _: &File,
+        data: &mut T,
+        _offset: u64,
+    ) -> KernelResult<usize> {
         {
             let mut inner = self.shared.inner.lock();
 

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -12,7 +12,6 @@ use kernel::{
     file_operations::{File, FileOperations},
     io_buffer::{IoBufferReader, IoBufferWriter},
     prelude::*,
-    user_ptr::{UserSlicePtrReader, UserSlicePtrWriter},
 };
 
 #[derive(Default)]
@@ -21,7 +20,12 @@ struct RandomFile;
 impl FileOperations for RandomFile {
     kernel::declare_file_operations!(read, write);
 
-    fn read(&self, file: &File, buf: &mut UserSlicePtrWriter, _offset: u64) -> KernelResult<usize> {
+    fn read<T: IoBufferWriter>(
+        &self,
+        file: &File,
+        buf: &mut T,
+        _offset: u64,
+    ) -> KernelResult<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
 
@@ -39,7 +43,12 @@ impl FileOperations for RandomFile {
         Ok(total_len)
     }
 
-    fn write(&self, buf: &mut UserSlicePtrReader, _offset: u64) -> KernelResult<usize> {
+    fn write<T: IoBufferReader>(
+        &self,
+        _file: &File,
+        buf: &mut T,
+        _offset: u64,
+    ) -> KernelResult<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
         while !buf.is_empty() {

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -84,7 +84,7 @@ impl FileOperations for FileState {
 
     declare_file_operations!(read, write, ioctl);
 
-    fn read(&self, _: &File, data: &mut UserSlicePtrWriter, offset: u64) -> KernelResult<usize> {
+    fn read<T: IoBufferWriter>(&self, _: &File, data: &mut T, offset: u64) -> KernelResult<usize> {
         if data.is_empty() || offset > 0 {
             return Ok(0);
         }
@@ -94,7 +94,12 @@ impl FileOperations for FileState {
         Ok(1)
     }
 
-    fn write(&self, data: &mut UserSlicePtrReader, _offset: u64) -> KernelResult<usize> {
+    fn write<T: IoBufferReader>(
+        &self,
+        _: &File,
+        data: &mut T,
+        _offset: u64,
+    ) -> KernelResult<usize> {
         {
             let mut inner = self.shared.inner.lock();
             inner.count = inner.count.saturating_add(data.len());


### PR DESCRIPTION
This is also in preparation for adding support for `read_iter` and
`write_iter`.

An extra argument is being added to `write` for consistency with the
other functions.

Otherwise, this is a pure refactor.

Based on #229.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>