### PR TITLE
Add support for `read_iter` and `write_iter`.

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -6,6 +6,7 @@
 #include <linux/sched/signal.h>
 #include <linux/gfp.h>
 #include <linux/highmem.h>
+#include <linux/uio.h>
 
 void rust_helper_BUG(void)
 {
@@ -91,6 +92,18 @@ int rust_helper_cond_resched(void)
 	return cond_resched();
 }
 EXPORT_SYMBOL_GPL(rust_helper_cond_resched);
+
+size_t rust_helper_copy_from_iter(void *addr, size_t bytes, struct iov_iter *i)
+{
+	return copy_from_iter(addr, bytes, i);
+}
+EXPORT_SYMBOL_GPL(rust_helper_copy_from_iter);
+
+size_t rust_helper_copy_to_iter(const void *addr, size_t bytes, struct iov_iter *i)
+{
+	return copy_to_iter(addr, bytes, i);
+}
+EXPORT_SYMBOL_GPL(rust_helper_copy_to_iter);
 
 #if !defined(CONFIG_ARM)
 // See https://github.com/rust-lang/rust-bindgen/issues/1671

--- a/rust/kernel/bindings_helper.h
+++ b/rust/kernel/bindings_helper.h
@@ -7,6 +7,7 @@
 #include <linux/slab.h>
 #include <linux/sysctl.h>
 #include <linux/uaccess.h>
+#include <linux/uio.h>
 #include <linux/version.h>
 #include <linux/miscdevice.h>
 #include <linux/poll.h>

--- a/rust/kernel/iov_iter.rs
+++ b/rust/kernel/iov_iter.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! IO vector iterators.
+//!
+//! C header: [`include/linux/uio.h`](../../../../include/linux/uio.h)
+
+use crate::{
+    bindings, c_types,
+    error::Error,
+    io_buffer::{IoBufferReader, IoBufferWriter},
+    KernelResult,
+};
+
+extern "C" {
+    fn rust_helper_copy_to_iter(
+        addr: *const c_types::c_void,
+        bytes: usize,
+        i: *mut bindings::iov_iter,
+    ) -> usize;
+
+    fn rust_helper_copy_from_iter(
+        addr: *mut c_types::c_void,
+        bytes: usize,
+        i: *mut bindings::iov_iter,
+    ) -> usize;
+}
+
+/// Wraps the kernel's `struct iov_iter`.
+///
+/// # Invariants
+///
+/// The pointer [`IovIter::ptr`] is non-null and valid.
+pub struct IovIter {
+    ptr: *mut bindings::iov_iter,
+}
+
+impl IovIter {
+    fn common_len(&self) -> usize {
+        // SAFETY: `IovIter::ptr` is guaranteed to be valid by the type invariants.
+        unsafe { (*self.ptr).count }
+    }
+
+    /// Constructs a new [`struct iov_iter`] wrapper.
+    ///
+    /// # Safety
+    ///
+    /// The pointer `ptr` must be non-null and valid for the lifetime of the object.
+    pub(crate) unsafe fn from_ptr(ptr: *mut bindings::iov_iter) -> Self {
+        // INVARIANTS: the safety contract ensures the type invariant will hold.
+        Self { ptr }
+    }
+}
+
+impl IoBufferWriter for IovIter {
+    fn len(&self) -> usize {
+        self.common_len()
+    }
+
+    fn clear(&mut self, mut len: usize) -> KernelResult {
+        while len > 0 {
+            // SAFETY: `IovIter::ptr` is guaranteed to be valid by the type invariants.
+            let written = unsafe { bindings::iov_iter_zero(len, self.ptr) };
+            if written == 0 {
+                return Err(Error::EFAULT);
+            }
+
+            len -= written;
+        }
+        Ok(())
+    }
+
+    unsafe fn write_raw(&mut self, data: *const u8, len: usize) -> KernelResult {
+        let res = rust_helper_copy_to_iter(data as _, len, self.ptr);
+        if res != len {
+            Err(Error::EFAULT)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl IoBufferReader for IovIter {
+    fn len(&self) -> usize {
+        self.common_len()
+    }
+
+    unsafe fn read_raw(&mut self, out: *mut u8, len: usize) -> KernelResult {
+        let res = rust_helper_copy_from_iter(out as _, len, self.ptr);
+        if res != len {
+            Err(Error::EFAULT)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -60,6 +60,7 @@ pub mod sync;
 pub mod sysctl;
 
 pub mod io_buffer;
+pub mod iov_iter;
 mod types;
 pub mod user_ptr;
 

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -18,7 +18,7 @@ use kernel::{
 struct RandomFile;
 
 impl FileOperations for RandomFile {
-    kernel::declare_file_operations!(read, write);
+    kernel::declare_file_operations!(read, write, read_iter, write_iter);
 
     fn read<T: IoBufferWriter>(
         &self,


### PR DESCRIPTION
Implementations only need to declare their desire to have the
appropriate fields in `struct file_operations` set, there is no need to
implement a variant of `read` or `write`.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>