### PR TITLE
GitHub: `README.md` improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 The goal of this project is to add support for the Rust language to the Linux kernel. This repository contains the work that will be eventually submitted for review to the LKML.
 
-Feel free to contribute! To start, take a look at [`Documentation/rust`](https://github.com/Rust-for-Linux/linux/tree/rust/Documentation/rust). We use GitHub issues and PRs for the moment, but discussions, questions, etc. take place on the [`rust-for-linux@vger.kernel.org`](https://lore.kernel.org/rust-for-linux/) mailing list. Please see [this page](http://vger.kernel.org/vger-lists.html#rust-for-linux) to subscribe. Instructions on how to format the subscription e-mail can be found [here.](http://vger.kernel.org/majordomo-info.html#subscription)
+Feel free to [contribute](https://github.com/Rust-for-Linux/linux/contribute)! To start, take a look at [`Documentation/rust`](https://github.com/Rust-for-Linux/linux/tree/rust/Documentation/rust).
+
+General discussions, announcements, questions, etc. take place on the mailing list at rust-for-linux@vger.kernel.org ([subscribe](mailto:majordomo@vger.kernel.org?body=subscribe%20rust-for-linux), [instructions](http://vger.kernel.org/majordomo-info.html), [archive](https://lore.kernel.org/rust-for-linux/)).
 
 All contributors to this effort are understood to have agreed to the Linux kernel development process as explained in the different files under [`Documentation/process`](https://www.kernel.org/doc/html/latest/process/index.html).
 


### PR DESCRIPTION
  - Add "contribute" link (a GitHub feature which shows information
    relevant to newcomers, such as the "good first issues").

  - Re-organized links for the mailing list.

  - Removed mention of "GitHub issues and PR", in an attempt to
    reduce confusion (we have the "contribute" link now, plus
    a lot of issues and PRs going on, so it is more obvious they
    are used). Split the paragraph to further increase clarity.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>