### PR TITLE
Move `File` to its own module.

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -8,7 +8,8 @@ use core::{
 };
 use kernel::{
     bindings, c_types,
-    file_operations::{File, FileOpener, FileOperations, IoctlCommand, IoctlHandler, PollTable},
+    file::File,
+    file_operations::{FileOpener, FileOperations, IoctlCommand, IoctlHandler, PollTable},
     io_buffer::{IoBufferReader, IoBufferWriter},
     linked_list::List,
     pages::Pages,

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -4,7 +4,8 @@ use alloc::sync::Arc;
 use core::{alloc::AllocError, mem::size_of, pin::Pin};
 use kernel::{
     bindings,
-    file_operations::{File, PollTable},
+    file::File,
+    file_operations::PollTable,
     io_buffer::{IoBufferReader, IoBufferWriter},
     linked_list::{GetLinks, Links, List},
     prelude::*,

--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Files and file descriptors.
+//!
+//! C headers: [`include/linux/fs.h`](../../../../include/linux/fs.h) and
+//! [`include/linux/file.h`](../../../../include/linux/file.h)
+
+use crate::bindings;
+
+/// Wraps the kernel's `struct file`.
+///
+/// # Invariants
+///
+/// The pointer [`File::ptr`] is non-null and valid.
+pub struct File {
+    pub(crate) ptr: *const bindings::file,
+}
+
+impl File {
+    /// Constructs a new [`struct file`] wrapper.
+    ///
+    /// # Safety
+    ///
+    /// The pointer `ptr` must be non-null and valid for the lifetime of the object.
+    pub(crate) unsafe fn from_ptr(ptr: *const bindings::file) -> File {
+        // INVARIANTS: the safety contract ensures the type invariant will hold.
+        File { ptr }
+    }
+
+    /// Returns the current seek/cursor/pointer position (`struct file::f_pos`).
+    pub fn pos(&self) -> u64 {
+        // SAFETY: `File::ptr` is guaranteed to be valid by the type invariants.
+        unsafe { (*self.ptr).f_pos as u64 }
+    }
+
+    /// Returns whether the file is in blocking mode.
+    pub fn is_blocking(&self) -> bool {
+        // SAFETY: `File::ptr` is guaranteed to be valid by the type invariants.
+        unsafe { (*self.ptr).f_flags & bindings::O_NONBLOCK == 0 }
+    }
+}

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -13,44 +13,12 @@ use alloc::sync::Arc;
 use crate::{
     bindings, c_types,
     error::{Error, KernelResult},
+    file::File,
     io_buffer::{IoBufferReader, IoBufferWriter},
     iov_iter::IovIter,
     sync::{CondVar, Ref, RefCounted},
     user_ptr::{UserSlicePtr, UserSlicePtrReader, UserSlicePtrWriter},
 };
-
-/// Wraps the kernel's `struct file`.
-///
-/// # Invariants
-///
-/// The pointer [`File::ptr`] is non-null and valid.
-pub struct File {
-    ptr: *const bindings::file,
-}
-
-impl File {
-    /// Constructs a new [`struct file`] wrapper.
-    ///
-    /// # Safety
-    ///
-    /// The pointer `ptr` must be non-null and valid for the lifetime of the object.
-    unsafe fn from_ptr(ptr: *const bindings::file) -> File {
-        // INVARIANTS: the safety contract ensures the type invariant will hold.
-        File { ptr }
-    }
-
-    /// Returns the current seek/cursor/pointer position (`struct file::f_pos`).
-    pub fn pos(&self) -> u64 {
-        // SAFETY: `File::ptr` is guaranteed to be valid by the type invariants.
-        unsafe { (*self.ptr).f_pos as u64 }
-    }
-
-    /// Returns whether the file is in blocking mode.
-    pub fn is_blocking(&self) -> bool {
-        // SAFETY: `File::ptr` is guaranteed to be valid by the type invariants.
-        unsafe { (*self.ptr).f_flags & bindings::O_NONBLOCK == 0 }
-    }
-}
 
 /// Wraps the kernel's `struct poll_table_struct`.
 ///

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -40,6 +40,7 @@ pub mod buffer;
 pub mod c_types;
 pub mod chrdev;
 mod error;
+pub mod file;
 pub mod file_operations;
 pub mod miscdev;
 pub mod pages;

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -10,7 +10,8 @@ use core::pin::Pin;
 use kernel::prelude::*;
 use kernel::{
     cstr,
-    file_operations::{File, FileOpener, FileOperations},
+    file::File,
+    file_operations::{FileOpener, FileOperations},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
     sync::{CondVar, Mutex},

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -9,7 +9,8 @@
 #![feature(allocator_api, global_asm)]
 
 use kernel::{
-    file_operations::{File, FileOperations},
+    file::File,
+    file_operations::FileOperations,
     io_buffer::{IoBufferReader, IoBufferWriter},
     prelude::*,
 };

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -23,7 +23,8 @@ use core::{
 };
 use kernel::{
     condvar_init, cstr, declare_file_operations,
-    file_operations::{File, FileOpener, FileOperations, IoctlCommand, IoctlHandler},
+    file::File,
+    file_operations::{FileOpener, FileOperations, IoctlCommand, IoctlHandler},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev::Registration,
     mutex_init,


### PR DESCRIPTION
This is a pure refactor in preparation for adding more features to
`File` so that file descriptors can be transferred between processes by
Binder.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>