### PR TITLE
Rename `KernelResult` to just `Result`.

### DIFF
--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -24,7 +24,7 @@ unsafe impl Send for Context {}
 unsafe impl Sync for Context {}
 
 impl Context {
-    pub(crate) fn new() -> KernelResult<Pin<Arc<Self>>> {
+    pub(crate) fn new() -> Result<Pin<Arc<Self>>> {
         let mut ctx_ref = Arc::try_new(Self {
             // SAFETY: Init is called below.
             manager: unsafe {
@@ -44,7 +44,7 @@ impl Context {
         Ok(unsafe { Pin::new_unchecked(ctx_ref) })
     }
 
-    pub(crate) fn set_manager_node(&self, node_ref: NodeRef) -> KernelResult {
+    pub(crate) fn set_manager_node(&self, node_ref: NodeRef) -> Result {
         let mut manager = self.manager.lock();
         if manager.node.is_some() {
             return Err(Error::EBUSY);

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -170,11 +170,7 @@ impl GetLinks for NodeDeath {
 }
 
 impl DeliverToRead for NodeDeath {
-    fn do_work(
-        self: Arc<Self>,
-        _thread: &Thread,
-        writer: &mut UserSlicePtrWriter,
-    ) -> KernelResult<bool> {
+    fn do_work(self: Arc<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         let done = {
             let inner = self.inner.lock();
             if inner.aborted {
@@ -335,7 +331,7 @@ impl Node {
         inner.weak.has_count = true;
     }
 
-    fn write(&self, writer: &mut UserSlicePtrWriter, code: u32) -> KernelResult {
+    fn write(&self, writer: &mut UserSlicePtrWriter, code: u32) -> Result {
         writer.write(&code)?;
         writer.write(&self.ptr)?;
         writer.write(&self.cookie)?;
@@ -344,11 +340,7 @@ impl Node {
 }
 
 impl DeliverToRead for Node {
-    fn do_work(
-        self: Arc<Self>,
-        _thread: &Thread,
-        writer: &mut UserSlicePtrWriter,
-    ) -> KernelResult<bool> {
+    fn do_work(self: Arc<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         let mut owner_inner = self.owner.inner.lock();
         let inner = self.inner.access_mut(&mut owner_inner);
         let strong = inner.strong.count > 0;

--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -46,11 +46,7 @@ trait DeliverToRead {
     /// Performs work. Returns true if remaining work items in the queue should be processed
     /// immediately, or false if it should return to caller before processing additional work
     /// items.
-    fn do_work(
-        self: Arc<Self>,
-        thread: &Thread,
-        writer: &mut UserSlicePtrWriter,
-    ) -> KernelResult<bool>;
+    fn do_work(self: Arc<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool>;
 
     /// Cancels the given work item. This is called instead of [`DeliverToRead::do_work`] when work
     /// won't be delivered.
@@ -89,11 +85,7 @@ impl DeliverCode {
 }
 
 impl DeliverToRead for DeliverCode {
-    fn do_work(
-        self: Arc<Self>,
-        _thread: &Thread,
-        writer: &mut UserSlicePtrWriter,
-    ) -> KernelResult<bool> {
+    fn do_work(self: Arc<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         writer.write(&self.code)?;
         Ok(true)
     }
@@ -115,7 +107,7 @@ struct BinderModule {
 }
 
 impl KernelModule for BinderModule {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         let pinned_ctx = Context::new()?;
         let ctx = unsafe { Pin::into_inner_unchecked(pinned_ctx) };
         let reg = Registration::<Arc<Context>>::new_pinned::<process::Process>(

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -137,11 +137,7 @@ impl Transaction {
 }
 
 impl DeliverToRead for Transaction {
-    fn do_work(
-        self: Arc<Self>,
-        thread: &Thread,
-        writer: &mut UserSlicePtrWriter,
-    ) -> KernelResult<bool> {
+    fn do_work(self: Arc<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         /* TODO: Initialise the following fields from tr:
             pub sender_pid: pid_t,
             pub sender_euid: uid_t,

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -16,7 +16,7 @@ use core::pin::Pin;
 
 use crate::bindings;
 use crate::c_types;
-use crate::error::{Error, KernelResult};
+use crate::error::{Error, Result};
 use crate::file_operations;
 use crate::types::CStr;
 
@@ -67,7 +67,7 @@ impl<const N: usize> Registration<{ N }> {
         name: CStr<'static>,
         minors_start: u16,
         this_module: &'static crate::ThisModule,
-    ) -> KernelResult<Pin<Box<Self>>> {
+    ) -> Result<Pin<Box<Self>>> {
         Ok(Pin::from(Box::try_new(Self::new(
             name,
             minors_start,
@@ -78,7 +78,7 @@ impl<const N: usize> Registration<{ N }> {
     /// Registers a character device.
     ///
     /// You may call this once per device type, up to `N` times.
-    pub fn register<T: file_operations::FileOpener<()>>(self: Pin<&mut Self>) -> KernelResult {
+    pub fn register<T: file_operations::FileOpener<()>>(self: Pin<&mut Self>) -> Result {
         // SAFETY: We must ensure that we never move out of `this`.
         let this = unsafe { self.get_unchecked_mut() };
         if this.inner.is_none() {

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -91,13 +91,13 @@ impl From<TryReserveError> for Error {
 ///
 /// In Rust, it is idiomatic to model functions that may fail as returning
 /// a [`Result`]. Since in the kernel many functions return an error code,
-/// [`KernelResult`] is a type alias for a [`Result`] that uses [`Error`] as
-/// its error type.
+/// [`Result`] is a type alias for a [`core::result::Result`] that uses
+/// [`Error`] as its error type.
 ///
 /// Note that even if a function does not return anything when it succeeds,
-/// it should still be modeled as returning a `KernelResult` rather than
+/// it should still be modeled as returning a `Result` rather than
 /// just an [`Error`].
-pub type KernelResult<T = ()> = Result<T, Error>;
+pub type Result<T = ()> = core::result::Result<T, Error>;
 
 impl From<AllocError> for Error {
     fn from(_: AllocError) -> Error {

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -12,7 +12,7 @@ use alloc::sync::Arc;
 
 use crate::{
     bindings, c_types,
-    error::{Error, KernelResult},
+    error::{Error, Result},
     file::File,
     io_buffer::{IoBufferReader, IoBufferWriter},
     iov_iter::IovIter,
@@ -78,7 +78,7 @@ pub enum SeekFrom {
     Current(i64),
 }
 
-fn from_kernel_result<T>(r: KernelResult<T>) -> T
+fn from_kernel_result<T>(r: Result<T>) -> T
 where
     T: TryFrom<c_types::c_int>,
     T::Error: core::fmt::Debug,
@@ -423,30 +423,25 @@ macro_rules! declare_file_operations {
 /// For each macro, there is a handler function that takes the appropriate types as arguments.
 pub trait IoctlHandler: Sync {
     /// Handles ioctls defined with the `_IO` macro, that is, with no buffer as argument.
-    fn pure(&self, _file: &File, _cmd: u32, _arg: usize) -> KernelResult<i32> {
+    fn pure(&self, _file: &File, _cmd: u32, _arg: usize) -> Result<i32> {
         Err(Error::EINVAL)
     }
 
     /// Handles ioctls defined with the `_IOR` macro, that is, with an output buffer provided as
     /// argument.
-    fn read(&self, _file: &File, _cmd: u32, _writer: &mut UserSlicePtrWriter) -> KernelResult<i32> {
+    fn read(&self, _file: &File, _cmd: u32, _writer: &mut UserSlicePtrWriter) -> Result<i32> {
         Err(Error::EINVAL)
     }
 
     /// Handles ioctls defined with the `_IOW` macro, that is, with an input buffer provided as
     /// argument.
-    fn write(
-        &self,
-        _file: &File,
-        _cmd: u32,
-        _reader: &mut UserSlicePtrReader,
-    ) -> KernelResult<i32> {
+    fn write(&self, _file: &File, _cmd: u32, _reader: &mut UserSlicePtrReader) -> Result<i32> {
         Err(Error::EINVAL)
     }
 
     /// Handles ioctls defined with the `_IOWR` macro, that is, with a buffer for both input and
     /// output provided as argument.
-    fn read_write(&self, _file: &File, _cmd: u32, _data: UserSlicePtr) -> KernelResult<i32> {
+    fn read_write(&self, _file: &File, _cmd: u32, _data: UserSlicePtr) -> Result<i32> {
         Err(Error::EINVAL)
     }
 }
@@ -482,7 +477,7 @@ impl IoctlCommand {
     ///
     /// It is meant to be used in implementations of [`FileOperations::ioctl`] and
     /// [`FileOperations::compat_ioctl`].
-    pub fn dispatch<T: IoctlHandler>(&mut self, handler: &T, file: &File) -> KernelResult<i32> {
+    pub fn dispatch<T: IoctlHandler>(&mut self, handler: &T, file: &File) -> Result<i32> {
         let dir = (self.cmd >> bindings::_IOC_DIRSHIFT) & bindings::_IOC_DIRMASK;
         if dir == bindings::_IOC_NONE {
             return handler.pure(file, self.cmd, self.arg);
@@ -534,11 +529,11 @@ pub trait FileOpener<T: ?Sized>: FileOperations {
     /// Creates a new instance of this file.
     ///
     /// Corresponds to the `open` function pointer in `struct file_operations`.
-    fn open(context: &T) -> KernelResult<Self::Wrapper>;
+    fn open(context: &T) -> Result<Self::Wrapper>;
 }
 
 impl<T: FileOperations<Wrapper = Box<T>> + Default> FileOpener<()> for T {
-    fn open(_: &()) -> KernelResult<Self::Wrapper> {
+    fn open(_: &()) -> Result<Self::Wrapper> {
         Ok(Box::try_new(T::default())?)
     }
 }
@@ -568,52 +563,42 @@ pub trait FileOperations: Send + Sync + Sized {
     /// Reads data from this file to the caller's buffer.
     ///
     /// Corresponds to the `read` and `read_iter` function pointers in `struct file_operations`.
-    fn read<T: IoBufferWriter>(
-        &self,
-        _file: &File,
-        _data: &mut T,
-        _offset: u64,
-    ) -> KernelResult<usize> {
+    fn read<T: IoBufferWriter>(&self, _file: &File, _data: &mut T, _offset: u64) -> Result<usize> {
         Err(Error::EINVAL)
     }
 
     /// Writes data from the caller's buffer to this file.
     ///
     /// Corresponds to the `write` and `write_iter` function pointers in `struct file_operations`.
-    fn write<T: IoBufferReader>(
-        &self,
-        _file: &File,
-        _data: &mut T,
-        _offset: u64,
-    ) -> KernelResult<usize> {
+    fn write<T: IoBufferReader>(&self, _file: &File, _data: &mut T, _offset: u64) -> Result<usize> {
         Err(Error::EINVAL)
     }
 
     /// Changes the position of the file.
     ///
     /// Corresponds to the `llseek` function pointer in `struct file_operations`.
-    fn seek(&self, _file: &File, _offset: SeekFrom) -> KernelResult<u64> {
+    fn seek(&self, _file: &File, _offset: SeekFrom) -> Result<u64> {
         Err(Error::EINVAL)
     }
 
     /// Performs IO control operations that are specific to the file.
     ///
     /// Corresponds to the `unlocked_ioctl` function pointer in `struct file_operations`.
-    fn ioctl(&self, _file: &File, _cmd: &mut IoctlCommand) -> KernelResult<i32> {
+    fn ioctl(&self, _file: &File, _cmd: &mut IoctlCommand) -> Result<i32> {
         Err(Error::EINVAL)
     }
 
     /// Performs 32-bit IO control operations on that are specific to the file on 64-bit kernels.
     ///
     /// Corresponds to the `compat_ioctl` function pointer in `struct file_operations`.
-    fn compat_ioctl(&self, _file: &File, _cmd: &mut IoctlCommand) -> KernelResult<i32> {
+    fn compat_ioctl(&self, _file: &File, _cmd: &mut IoctlCommand) -> Result<i32> {
         Err(Error::EINVAL)
     }
 
     /// Syncs pending changes to this file.
     ///
     /// Corresponds to the `fsync` function pointer in `struct file_operations`.
-    fn fsync(&self, _file: &File, _start: u64, _end: u64, _datasync: bool) -> KernelResult<u32> {
+    fn fsync(&self, _file: &File, _start: u64, _end: u64, _datasync: bool) -> Result<u32> {
         Err(Error::EINVAL)
     }
 
@@ -621,7 +606,7 @@ pub trait FileOperations: Send + Sync + Sized {
     ///
     /// Corresponds to the `mmap` function pointer in `struct file_operations`.
     /// TODO: wrap `vm_area_struct` so that we don't have to expose it.
-    fn mmap(&self, _file: &File, _vma: &mut bindings::vm_area_struct) -> KernelResult {
+    fn mmap(&self, _file: &File, _vma: &mut bindings::vm_area_struct) -> Result {
         Err(Error::EINVAL)
     }
 
@@ -629,7 +614,7 @@ pub trait FileOperations: Send + Sync + Sized {
     /// changes.
     ///
     /// Corresponds to the `poll` function pointer in `struct file_operations`.
-    fn poll(&self, _file: &File, _table: &PollTable) -> KernelResult<u32> {
+    fn poll(&self, _file: &File, _table: &PollTable) -> Result<u32> {
         Ok(bindings::POLLIN | bindings::POLLOUT | bindings::POLLRDNORM | bindings::POLLWRNORM)
     }
 }

--- a/rust/kernel/iov_iter.rs
+++ b/rust/kernel/iov_iter.rs
@@ -8,7 +8,7 @@ use crate::{
     bindings, c_types,
     error::Error,
     io_buffer::{IoBufferReader, IoBufferWriter},
-    KernelResult,
+    Result,
 };
 
 extern "C" {
@@ -56,7 +56,7 @@ impl IoBufferWriter for IovIter {
         self.common_len()
     }
 
-    fn clear(&mut self, mut len: usize) -> KernelResult {
+    fn clear(&mut self, mut len: usize) -> Result {
         while len > 0 {
             // SAFETY: `IovIter::ptr` is guaranteed to be valid by the type invariants.
             let written = unsafe { bindings::iov_iter_zero(len, self.ptr) };
@@ -69,7 +69,7 @@ impl IoBufferWriter for IovIter {
         Ok(())
     }
 
-    unsafe fn write_raw(&mut self, data: *const u8, len: usize) -> KernelResult {
+    unsafe fn write_raw(&mut self, data: *const u8, len: usize) -> Result {
         let res = rust_helper_copy_to_iter(data as _, len, self.ptr);
         if res != len {
             Err(Error::EFAULT)
@@ -84,7 +84,7 @@ impl IoBufferReader for IovIter {
         self.common_len()
     }
 
-    unsafe fn read_raw(&mut self, out: *mut u8, len: usize) -> KernelResult {
+    unsafe fn read_raw(&mut self, out: *mut u8, len: usize) -> Result {
         let res = rust_helper_copy_from_iter(out as _, len, self.ptr);
         if res != len {
             Err(Error::EFAULT)

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -65,7 +65,7 @@ pub mod iov_iter;
 mod types;
 pub mod user_ptr;
 
-pub use crate::error::{Error, KernelResult};
+pub use crate::error::{Error, Result};
 pub use crate::types::{CStr, Mode};
 
 /// Page size defined in terms of the `PAGE_SHIFT` macro from C.
@@ -86,7 +86,7 @@ pub trait KernelModule: Sized + Sync {
     /// should do.
     ///
     /// Equivalent to the `module_init` macro in the C API.
-    fn init() -> KernelResult<Self>;
+    fn init() -> Result<Self>;
 }
 
 /// Equivalent to `THIS_MODULE` in the C API.

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -6,7 +6,7 @@
 //!
 //! Reference: <https://www.kernel.org/doc/html/latest/driver-api/misc_devices.html>
 
-use crate::error::{Error, KernelResult};
+use crate::error::{Error, Result};
 use crate::file_operations::{FileOpenAdapter, FileOpener, FileOperationsVtable};
 use crate::{bindings, c_types, CStr};
 use alloc::boxed::Box;
@@ -44,7 +44,7 @@ impl<T: Sync> Registration<T> {
         name: CStr<'static>,
         minor: Option<i32>,
         context: T,
-    ) -> KernelResult<Pin<Box<Self>>> {
+    ) -> Result<Pin<Box<Self>>> {
         let mut r = Pin::from(Box::try_new(Self::new(context))?);
         r.as_mut().register::<F>(name, minor)?;
         Ok(r)
@@ -58,7 +58,7 @@ impl<T: Sync> Registration<T> {
         self: Pin<&mut Self>,
         name: CStr<'static>,
         minor: Option<i32>,
-    ) -> KernelResult {
+    ) -> Result {
         // SAFETY: We must ensure that we never move out of `this`.
         let this = unsafe { self.get_unchecked_mut() };
         if this.registered {

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -19,4 +19,4 @@ pub use super::{pr_alert, pr_cont, pr_crit, pr_emerg, pr_err, pr_info, pr_notice
 
 pub use super::static_assert;
 
-pub use super::{KernelModule, KernelResult};
+pub use super::{KernelModule, Result};

--- a/rust/kernel/random.rs
+++ b/rust/kernel/random.rs
@@ -12,7 +12,7 @@ use crate::{bindings, c_types, error};
 ///
 /// Ensures that the CSPRNG has been seeded before generating any random bytes,
 /// and will block until it is ready.
-pub fn getrandom(dest: &mut [u8]) -> error::KernelResult {
+pub fn getrandom(dest: &mut [u8]) -> error::Result {
     let res = unsafe { bindings::wait_for_random_bytes() };
     if res != 0 {
         return Err(error::Error::from_kernel_errno(res));
@@ -30,7 +30,7 @@ pub fn getrandom(dest: &mut [u8]) -> error::KernelResult {
 /// Fills a byte slice with random bytes generated from the kernel's CSPRNG.
 ///
 /// If the CSPRNG is not yet seeded, returns an `Err(EAGAIN)` immediately.
-pub fn getrandom_nonblock(dest: &mut [u8]) -> error::KernelResult {
+pub fn getrandom_nonblock(dest: &mut [u8]) -> error::Result {
     if !unsafe { bindings::rng_is_initialized() } {
         return Err(error::Error::EAGAIN);
     }

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -13,7 +13,7 @@
 //!
 //! [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 
-use crate::KernelResult;
+use crate::Result;
 use alloc::boxed::Box;
 use core::{
     mem::ManuallyDrop,
@@ -48,7 +48,7 @@ unsafe impl<T: RefCounted + ?Sized + Sync + Send> Sync for Ref<T> {}
 
 impl<T: RefCounted> Ref<T> {
     /// Constructs a new reference counted instance of `T`.
-    pub fn try_new(contents: T) -> KernelResult<Self> {
+    pub fn try_new(contents: T) -> Result<Self> {
         let boxed = Box::try_new(contents)?;
         boxed.get_count().count.store(1, Ordering::Relaxed);
         let ptr = NonNull::from(Box::leak(boxed));

--- a/rust/kernel/user_ptr.rs
+++ b/rust/kernel/user_ptr.rs
@@ -8,7 +8,7 @@ use crate::{
     c_types,
     error::Error,
     io_buffer::{IoBufferReader, IoBufferWriter},
-    KernelResult,
+    Result,
 };
 use alloc::vec::Vec;
 
@@ -75,7 +75,7 @@ impl UserSlicePtr {
     ///
     /// Returns `EFAULT` if the address does not currently point to
     /// mapped, readable memory.
-    pub fn read_all(self) -> KernelResult<Vec<u8>> {
+    pub fn read_all(self) -> Result<Vec<u8>> {
         self.reader().read_all()
     }
 
@@ -90,7 +90,7 @@ impl UserSlicePtr {
     /// mapped, writable memory (in which case some data from before the
     /// fault may be written), or `data` is larger than the user slice
     /// (in which case no data is written).
-    pub fn write_all(self, data: &[u8]) -> KernelResult {
+    pub fn write_all(self, data: &[u8]) -> Result {
         self.writer().write_slice(data)
     }
 
@@ -126,7 +126,7 @@ impl IoBufferReader for UserSlicePtrReader {
     /// # Safety
     ///
     /// The output buffer must be valid.
-    unsafe fn read_raw(&mut self, out: *mut u8, len: usize) -> KernelResult {
+    unsafe fn read_raw(&mut self, out: *mut u8, len: usize) -> Result {
         if len > self.1 || len > u32::MAX as usize {
             return Err(Error::EFAULT);
         }
@@ -153,7 +153,7 @@ impl IoBufferWriter for UserSlicePtrWriter {
         self.1
     }
 
-    fn clear(&mut self, mut len: usize) -> KernelResult {
+    fn clear(&mut self, mut len: usize) -> Result {
         let mut ret = Ok(());
         if len > self.1 {
             ret = Err(Error::EFAULT);
@@ -173,7 +173,7 @@ impl IoBufferWriter for UserSlicePtrWriter {
         ret
     }
 
-    unsafe fn write_raw(&mut self, data: *const u8, len: usize) -> KernelResult {
+    unsafe fn write_raw(&mut self, data: *const u8, len: usize) -> Result {
         if len > self.1 || len > u32::MAX as usize {
             return Err(Error::EFAULT);
         }

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -434,7 +434,7 @@ impl ModuleInfo {
 /// struct MyKernelModule;
 ///
 /// impl KernelModule for MyKernelModule {
-///     fn init() -> KernelResult<Self> {
+///     fn init() -> Result<Self> {
 ///         // If the parameter is writeable, then the kparam lock must be
 ///         // taken to read the parameter:
 ///         {
@@ -818,7 +818,7 @@ pub fn module_misc_device(ts: TokenStream) -> TokenStream {
             }}
 
             impl kernel::KernelModule for {module} {{
-                fn init() -> kernel::KernelResult<Self> {{
+                fn init() -> kernel::Result<Self> {{
                     Ok(Self {{
                         _dev: kernel::miscdev::Registration::new_pinned::<{type_}>(
                             kernel::cstr!(\"{name}\"),

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -30,7 +30,7 @@ struct RustChrdev {
 }
 
 impl KernelModule for RustChrdev {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         pr_info!("Rust character device sample (init)\n");
 
         let mut chrdev_reg =

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -20,7 +20,7 @@ struct RustMinimal {
 }
 
 impl KernelModule for RustMinimal {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         pr_info!("Rust minimal sample (init)\n");
         pr_info!("Am I built-in? {}\n", !cfg!(MODULE));
 

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -45,7 +45,7 @@ module! {
 struct RustModuleParameters;
 
 impl KernelModule for RustModuleParameters {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         pr_info!("Rust module parameters sample (init)\n");
 
         {

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -18,7 +18,7 @@ module! {
 struct RustPrint;
 
 impl KernelModule for RustPrint {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         pr_info!("Rust printing macros sample (init)\n");
 
         pr_emerg!("Emergency message (level 0) without args\n");

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -21,12 +21,7 @@ struct RandomFile;
 impl FileOperations for RandomFile {
     kernel::declare_file_operations!(read, write, read_iter, write_iter);
 
-    fn read<T: IoBufferWriter>(
-        &self,
-        file: &File,
-        buf: &mut T,
-        _offset: u64,
-    ) -> KernelResult<usize> {
+    fn read<T: IoBufferWriter>(&self, file: &File, buf: &mut T, _offset: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
 
@@ -44,12 +39,7 @@ impl FileOperations for RandomFile {
         Ok(total_len)
     }
 
-    fn write<T: IoBufferReader>(
-        &self,
-        _file: &File,
-        buf: &mut T,
-        _offset: u64,
-    ) -> KernelResult<usize> {
+    fn write<T: IoBufferReader>(&self, _file: &File, buf: &mut T, _offset: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
         while !buf.is_empty() {

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -58,7 +58,7 @@ struct FileState {
 }
 
 impl FileState {
-    fn consume(&self) -> KernelResult {
+    fn consume(&self) -> Result {
         let mut inner = self.shared.inner.lock();
         while inner.count == 0 {
             if self.shared.changed.wait(&mut inner) {
@@ -71,7 +71,7 @@ impl FileState {
 }
 
 impl FileOpener<Arc<Semaphore>> for FileState {
-    fn open(shared: &Arc<Semaphore>) -> KernelResult<Box<Self>> {
+    fn open(shared: &Arc<Semaphore>) -> Result<Box<Self>> {
         Ok(Box::try_new(Self {
             read_count: AtomicU64::new(0),
             shared: shared.clone(),
@@ -84,7 +84,7 @@ impl FileOperations for FileState {
 
     declare_file_operations!(read, write, ioctl);
 
-    fn read<T: IoBufferWriter>(&self, _: &File, data: &mut T, offset: u64) -> KernelResult<usize> {
+    fn read<T: IoBufferWriter>(&self, _: &File, data: &mut T, offset: u64) -> Result<usize> {
         if data.is_empty() || offset > 0 {
             return Ok(0);
         }
@@ -94,12 +94,7 @@ impl FileOperations for FileState {
         Ok(1)
     }
 
-    fn write<T: IoBufferReader>(
-        &self,
-        _: &File,
-        data: &mut T,
-        _offset: u64,
-    ) -> KernelResult<usize> {
+    fn write<T: IoBufferReader>(&self, _: &File, data: &mut T, _offset: u64) -> Result<usize> {
         {
             let mut inner = self.shared.inner.lock();
             inner.count = inner.count.saturating_add(data.len());
@@ -112,7 +107,7 @@ impl FileOperations for FileState {
         Ok(data.len())
     }
 
-    fn ioctl(&self, file: &File, cmd: &mut IoctlCommand) -> KernelResult<i32> {
+    fn ioctl(&self, file: &File, cmd: &mut IoctlCommand) -> Result<i32> {
         cmd.dispatch(self, file)
     }
 }
@@ -122,7 +117,7 @@ struct RustSemaphore {
 }
 
 impl KernelModule for RustSemaphore {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         pr_info!("Rust semaphore sample (init)\n");
 
         let sema = Arc::try_new(Semaphore {
@@ -160,7 +155,7 @@ const IOCTL_GET_READ_COUNT: u32 = 0x80086301;
 const IOCTL_SET_READ_COUNT: u32 = 0x40086301;
 
 impl IoctlHandler for FileState {
-    fn read(&self, _: &File, cmd: u32, writer: &mut UserSlicePtrWriter) -> KernelResult<i32> {
+    fn read(&self, _: &File, cmd: u32, writer: &mut UserSlicePtrWriter) -> Result<i32> {
         match cmd {
             IOCTL_GET_READ_COUNT => {
                 writer.write(&self.read_count.load(Ordering::Relaxed))?;
@@ -170,7 +165,7 @@ impl IoctlHandler for FileState {
         }
     }
 
-    fn write(&self, _: &File, cmd: u32, reader: &mut UserSlicePtrReader) -> KernelResult<i32> {
+    fn write(&self, _: &File, cmd: u32, reader: &mut UserSlicePtrReader) -> Result<i32> {
         match cmd {
             IOCTL_SET_READ_COUNT => {
                 self.read_count.store(reader.read()?, Ordering::Relaxed);

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -19,7 +19,7 @@ module! {
 struct RustStackProbing;
 
 impl KernelModule for RustStackProbing {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         pr_info!("Rust stack probing sample (init)\n");
 
         // Including this large variable on the stack will trigger

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -24,7 +24,7 @@ module! {
 struct RustSync;
 
 impl KernelModule for RustSync {
-    fn init() -> KernelResult<Self> {
+    fn init() -> Result<Self> {
         pr_info!("Rust synchronisation primitives sample (init)\n");
 
         // Test mutexes.


### PR DESCRIPTION
This is just a rename followed by `rustfmt`, no functional change is
intended.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>