### PR TITLE
Add SPI Abstraction

### DIFF
--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -17,6 +17,7 @@
 #include <linux/slab.h>
 #include <linux/wait.h>
 #include <linux/workqueue.h>
+#include <linux/spi/spi.h>
 
 /* `bindgen` gets confused at certain things. */
 const size_t RUST_CONST_HELPER_ARCH_SLAB_MINALIGN = ARCH_SLAB_MINALIGN;

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -31,6 +31,7 @@
 #include <linux/spinlock.h>
 #include <linux/wait.h>
 #include <linux/workqueue.h>
+#include <linux/spi/spi.h>
 
 __noreturn void rust_helper_BUG(void)
 {
@@ -156,6 +157,13 @@ void rust_helper_init_work_with_key(struct work_struct *work, work_func_t func,
 	work->func = func;
 }
 EXPORT_SYMBOL_GPL(rust_helper_init_work_with_key);
+
+void rust_helper_spi_message_init(struct spi_message *m)
+{
+	memset(m, 0, sizeof *m);
+	spi_message_init_no_memset(m);
+}
+EXPORT_SYMBOL_GPL(rust_helper_spi_message_init);
 
 /*
  * `bindgen` binds the C `size_t` type as the Rust `usize` type, so we can

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -59,6 +59,9 @@ pub use uapi;
 #[doc(hidden)]
 pub use build_error::build_error;
 
+#[cfg(CONFIG_SPI)]
+pub mod spi;
+
 /// Prefix to appear before log messages printed from within the `kernel` crate.
 const __LOG_PREFIX: &[u8] = b"rust_kernel\0";
 

--- a/rust/kernel/spi.rs
+++ b/rust/kernel/spi.rs
@@ -295,6 +295,7 @@ impl SpiMessage {
     }
     /// Equivalent of `spi_message_init`
     pub fn spi_message_init(&mut self) {
+        unsafe { bindings::spi_message_init(&mut self.0) }
     }
 }
 

--- a/rust/kernel/spi.rs
+++ b/rust/kernel/spi.rs
@@ -255,6 +255,49 @@ impl SpiDeviceId {
     }
 }
 
+/// Wrapper struct around the kernel's `struct spi_transfer`.
+pub struct SpiTransfer(bindings::spi_transfer);
+
+impl SpiTransfer {
+    pub fn new() -> Self {
+        SpiTransfer(bindings::spi_transfer::default())
+    }
+
+    pub fn with_tx_buf(mut self, buf: &[u8]) -> Self {
+        // Make sure no tx_buf nor rx_buf has been provided before
+        // TODO: replace with a `Result`
+        assert!(self.0.len == 0);
+
+        self.0.tx_buf = buf.as_ptr() as *const core::ffi::c_void;
+        self.0.len = buf.len() as core::ffi::c_uint;
+
+        self
+    }
+
+    pub fn with_rx_buf(mut self, buf: &mut[u8]) -> Self {
+        // Make sure no tx_buf nor rx_buf has been provided before
+        // TODO: replace with a `Result`
+        assert!(self.0.len == 0);
+
+        self.0.rx_buf = buf.as_mut_ptr() as *mut core::ffi::c_void;
+        self.0.len = buf.len() as core::ffi::c_uint;
+
+        self
+    }
+}
+
+#[derive(Default)]
+pub struct SpiMessage(bindings::spi_message);
+
+impl SpiMessage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Equivalent of `spi_message_init`
+    pub fn spi_message_init(&mut self) {
+    }
+}
+
 /// High level abstraction over the kernel's SPI functions such as `spi_write_then_read`.
 // TODO this should be a mod, right?
 pub struct Spi;

--- a/rust/kernel/spi.rs
+++ b/rust/kernel/spi.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! This module provides safer and higher level abstraction over the kernel's SPI types
+//! and functions.
+//!
+//! C header: [`include/linux/spi/spi.h`](../../../../include/linux/spi/spi.h)
+
+use crate::bindings;
+use crate::error::{code::*, from_result, Error, Result};
+use crate::str::CStr;
+use alloc::boxed::Box;
+use core::marker::PhantomData;
+use core::pin::Pin;
+use macros::vtable;
+
+/// Wrapper struct around the kernel's `spi_device`.
+#[derive(Clone, Copy)]
+pub struct SpiDevice(*mut bindings::spi_device);
+
+impl SpiDevice {
+    /// Create an [`SpiDevice`] from a mutable spi_device raw pointer. This function is unsafe
+    /// as the pointer might be invalid.
+    ///
+    /// The pointer must be valid. This can be achieved by calling `to_ptr` on a previously
+    /// constructed, safe `SpiDevice` instance, or by making sure that the pointer points
+    /// to valid memory.
+    ///
+    /// You probably do not want to use this abstraction directly. It is mainly used
+    /// by this abstraction to wrap valid pointers given by the Kernel to the different
+    /// SPI methods: `probe`, `remove` and `shutdown`.
+    pub unsafe fn from_ptr(dev: *mut bindings::spi_device) -> Self {
+        SpiDevice(dev)
+    }
+
+    /// Access the raw pointer from an [`SpiDevice`] instance.
+    pub fn to_ptr(&mut self) -> *mut bindings::spi_device {
+        self.0
+    }
+}
+
+/// Corresponds to the kernel's spi_driver's methods. Implement this trait on a type to
+/// express the need of a custom probe, remove or shutdown function for your SPI driver.
+#[vtable]
+pub trait SpiMethods {
+    /// Corresponds to the kernel's `spi_driver`'s `probe` method field.
+    fn probe(_spi_dev: &mut SpiDevice) -> Result<i32> {
+        unreachable!("There should be a NULL in the probe filed of spi_driver's");
+    }
+
+    /// Corresponds to the kernel's `spi_driver`'s `remove` method field.
+    fn remove(_spi_dev: &mut SpiDevice) {
+        unreachable!("There should be a NULL in the remove filed of spi_driver's");
+    }
+
+    /// Corresponds to the kernel's `spi_driver`'s `shutdown` method field.
+    fn shutdown(_spi_dev: &mut SpiDevice) {
+        unreachable!("There should be a NULL in the shutdown filed of spi_driver's");
+    }
+}
+
+/// Registration of an SPI driver.
+pub struct DriverRegistration<T: SpiMethods> {
+    this_module: &'static crate::ThisModule,
+    registered: bool,
+    name: &'static CStr,
+    spi_driver: bindings::spi_driver,
+    _p: PhantomData<T>,
+}
+
+impl<T: SpiMethods> DriverRegistration<T> {
+    fn new(this_module: &'static crate::ThisModule, name: &'static CStr) -> Self {
+        DriverRegistration {
+            this_module,
+            name,
+            registered: false,
+            spi_driver: bindings::spi_driver::default(),
+            _p: PhantomData,
+        }
+    }
+
+    /// Create a new `DriverRegistration` and register it. This is equivalent to creating
+    /// a static `spi_driver` and then calling `spi_driver_register` on it in C.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let spi_driver =
+    ///     spi::DriverRegistration::new_pinned::<MySpiMethods>(&THIS_MODULE, cstr!("my_driver_name"))?;
+    /// ```
+    pub fn new_pinned(
+        this_module: &'static crate::ThisModule,
+        name: &'static CStr,
+    ) -> Result<Pin<Box<Self>>> {
+        let mut registration = Pin::from(Box::try_new(Self::new(this_module, name))?);
+
+        registration.as_mut().register()?;
+
+        Ok(registration)
+    }
+
+    /// Register a [`DriverRegistration`]. This is equivalent to calling `spi_driver_register`
+    /// on your `spi_driver` in C, without creating it first.
+    fn register(self: Pin<&mut Self>) -> Result {
+        // SAFETY: We do not move out of the reference we get, and are only registering
+        // `this` once over the course of the module, since we check that the `registered`
+        // field was not already set to true.
+        let this = unsafe { self.get_unchecked_mut() };
+        if this.registered {
+            return Err(EINVAL);
+        }
+
+        let mut spi_driver = this.spi_driver;
+
+        if T::HAS_PROBE {
+            spi_driver.probe = Some(probe_callback::<T>);
+        }
+        if T::HAS_REMOVE {
+            spi_driver.remove = Some(remove_callback::<T>);
+        }
+        if T::HAS_SHUTDOWN {
+            spi_driver.remove = Some(shutdown_callback::<T>);
+        }
+
+        spi_driver.driver.name = this.name.as_ptr() as *const core::ffi::c_char;
+
+        // SAFETY: Since we are using a pinned `self`, we can register the driver safely as
+        // if we were using a static instance. The kernel will access this driver over the
+        // entire lifespan of a module and therefore needs a pointer valid for the entirety
+        // of this lifetime.
+        let res =
+            unsafe { bindings::__spi_register_driver(this.this_module.0, &mut this.spi_driver) };
+
+        if res != 0 {
+            return Err(Error::from_errno(res));
+        }
+
+        this.registered = true;
+
+        Ok(())
+    }
+}
+
+impl<T: SpiMethods> Drop for DriverRegistration<T> {
+    fn drop(&mut self) {
+        // SAFETY: We are simply unregistering an `spi_driver` that we know to be valid.
+        // [`DriverRegistration`] instances can only be created by being registered at the
+        // same time, so we are sure that we'll never unregister an unregistered `spi_driver`.
+        unsafe { bindings::driver_unregister(&mut self.spi_driver.driver) }
+    }
+}
+
+unsafe extern "C" fn probe_callback<T: SpiMethods>(
+    spi: *mut bindings::spi_device,
+) -> core::ffi::c_int {
+    from_result(|| Ok(T::probe(&mut SpiDevice(spi))?))
+}
+
+unsafe extern "C" fn remove_callback<T: SpiMethods>(spi: *mut bindings::spi_device) {
+    T::remove(&mut SpiDevice(spi));
+}
+
+unsafe extern "C" fn shutdown_callback<T: SpiMethods>(spi: *mut bindings::spi_device) {
+    T::shutdown(&mut SpiDevice(spi));
+}
+
+// SAFETY: The only method is `register()`, which requires a (pinned) mutable `Registration`, so it
+// is safe to pass `&Registration` to multiple threads because it offers no interior mutability.
+unsafe impl<T: SpiMethods> Sync for DriverRegistration<T> {}
+
+// SAFETY: All functions work from any thread.
+unsafe impl<T: SpiMethods> Send for DriverRegistration<T> {}
+
+/// High level abstraction over the kernel's SPI functions such as `spi_write_then_read`.
+// TODO this should be a mod, right?
+pub struct Spi;
+
+impl Spi {
+    /// Corresponds to the kernel's `spi_write_then_read`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let to_write = "rust-for-linux".as_bytes();
+    /// let mut to_receive = [0u8; 10]; // let's receive 10 bytes back
+    ///
+    /// // `spi_device` was previously provided by the kernel in that case
+    /// let transfer_result = Spi::write_then_read(spi_device, &to_write, &mut to_receive);
+    /// ```
+    pub fn write_then_read(dev: &mut SpiDevice, tx_buf: &[u8], rx_buf: &mut [u8]) -> Result {
+        // SAFETY: The `dev` argument must uphold the safety guarantees made when creating
+        // the [`SpiDevice`] instance. It should therefore point to a valid `spi_device`
+        // and valid memory. We also know that a rust slice will always contain a proper
+        // size and that it is safe to use as is. Converting from a Rust pointer to a
+        // generic C `void*` pointer is normal, and does not pose size issues on the
+        // kernel's side, which will use the given Transfer Receive sizes as bytes.
+        let res = unsafe {
+            bindings::spi_write_then_read(
+                dev.to_ptr(),
+                tx_buf.as_ptr() as *const core::ffi::c_void,
+                tx_buf.len() as core::ffi::c_uint,
+                rx_buf.as_mut_ptr() as *mut core::ffi::c_void,
+                rx_buf.len() as core::ffi::c_uint,
+            )
+        };
+
+        match res {
+            0 => Ok(()),                        // 0 indicates a valid transfer,
+            err => Err(Error::from_errno(err)), // A negative number indicates an error
+        }
+    }
+
+    /// Corresponds to the kernel's `spi_write`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let to_write = "rust-for-linux".as_bytes();
+    ///
+    /// // `spi_device` was previously provided by the kernel in that case
+    /// let write_result = Spi::write(spi_device, &to_write);
+    /// ```
+    pub fn write(dev: &mut SpiDevice, tx_buf: &[u8]) -> Result {
+        Spi::write_then_read(dev, tx_buf, &mut [0u8; 0])
+    }
+
+    /// Corresponds to the kernel's `spi_read`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut to_receive = [0u8; 10]; // let's receive 10 bytes
+    ///
+    /// // `spi_device` was previously provided by the kernel in that case
+    /// let transfer_result = Spi::read(spi_device, &mut to_receive);
+    /// ```
+    pub fn read(dev: &mut SpiDevice, rx_buf: &mut [u8]) -> Result {
+        Spi::write_then_read(dev, &[0u8; 0], rx_buf)
+    }
+}

--- a/samples/rust/Kconfig
+++ b/samples/rust/Kconfig
@@ -37,4 +37,14 @@ config SAMPLE_RUST_HOSTPROGS
 
 	  If unsure, say N.
 
+config SAMPLE_RUST_SPI_DUMMY
+	tristate "SPI dummy"
+	help
+	  This option builds the Rust SPI dummy sample.
+
+	  To compile this as a module, choose M here:
+	  the module will be called rust_spi_dummy.
+
+	  If unsure, say N.
+
 endif # SAMPLES_RUST

--- a/samples/rust/Makefile
+++ b/samples/rust/Makefile
@@ -2,5 +2,6 @@
 
 obj-$(CONFIG_SAMPLE_RUST_MINIMAL)		+= rust_minimal.o
 obj-$(CONFIG_SAMPLE_RUST_PRINT)			+= rust_print.o
+obj-$(CONFIG_SAMPLE_RUST_SPI_DUMMY)		+= spi_dummy.o
 
 subdir-$(CONFIG_SAMPLE_RUST_HOSTPROGS)		+= hostprogs

--- a/samples/rust/spi_dummy.rs
+++ b/samples/rust/spi_dummy.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use alloc::boxed::Box;
+use core::pin::Pin;
+use kernel::c_str;
+use kernel::prelude::*;
+use kernel::spi::*;
+
+module! {
+    type: SPIDummy,
+    name: "rust_spi_dummy",
+    author: "ks0n",
+    description: "SPI Dummy Driver",
+    license: "GPL",
+}
+
+struct SPIDummyMethods;
+
+#[vtable]
+impl SpiMethods for SPIDummyMethods {
+    fn probe(spi_device: &mut SpiDevice) -> Result<i32, Error> {
+        pr_info!("[SPI-RS] SPI Registered\n");
+        pr_info!(
+            "[SPI-RS] SPI Registered, spi_device = {:#?}\n",
+            spi_device.to_ptr()
+        );
+
+        Ok(0)
+    }
+}
+
+struct SPIDummy {
+    _spi: Pin<Box<DriverRegistration<SPIDummyMethods>>>,
+}
+
+const TEST: u8 = 0;
+const fn test() -> usize {
+    42
+}
+
+static ID_TABLE: &[SpiDeviceId] = &[
+    SpiDeviceId::new(c_str!("test1")).with_driver_data_pointer(&TEST),
+    SpiDeviceId::new(c_str!("test2")).with_driver_data_pointer(&test),
+    SpiDeviceId::new(c_str!("test3")).with_driver_data_number(42),
+    SpiDeviceId::sentinel(),
+];
+
+impl kernel::Module for SPIDummy {
+    fn init(module: &'static ThisModule) -> Result<Self> {
+        pr_info!("[SPI-RS] Init\n");
+
+        let spi = DriverRegistration::new_pinned(module, c_str!("SPIDummy"), Some(&ID_TABLE))?;
+
+        Ok(SPIDummy { _spi: spi })
+    }
+}
+
+impl Drop for SPIDummy {
+    fn drop(&mut self) {
+        pr_info!("[SPI-RS] Exit\n");
+    }
+}


### PR DESCRIPTION
Hi,

@CohenArthur @n1tram1 and myself are working on a Rust chrdev module for the MFRC522 RFID reader for a class. In order to do so, we needed a new SPI abstraction so we created it.

It is not finished yet but we would like to have some feedback on our work and we are hoping we can merge it in the future.

Currently our driver is compiling correctly using our abstraction ~~but we have are having some Kernel OOPS when our SPI probe function returns~~ (fixed by e55c21a)
```dmesg
[   36.266704] mfrc522: [MFRC522-RS] Init
[   36.267087] mfrc522: [MFRC522-RS] SPI Registered
[   36.272868] Unable to handle kernel paging request at virtual address ffff80001087b7d0
[   36.282778] Mem abort info:
[   36.286541]   ESR = 0x96000007
[   36.290281]   EC = 0x25: DABT (current EL), IL = 32 bits
[   36.296322]   SET = 0, FnV = 0
[   36.300027]   EA = 0, S1PTW = 0
[   36.303836] Data abort info:
[   36.307375]   ISV = 0, ISS = 0x00000007
[   36.311887]   CM = 0, WnR = 0
[   36.315514] swapper pgtable: 4k pages, 48-bit VAs, pgdp=00000000013f1000
[   36.322967] [ffff80001087b7d0] pgd=0000000001810003, p4d=0000000001810003, pud=0000000001811003, pmd=00000000039b9003, pte=0000000000000000
[   36.337034] Internal error: Oops: 96000007 [#1] PREEMPT SMP
[   36.343378] Modules linked in: mfrc522 hci_uart btqca btbcm bluetooth ecdh_generic ecc 8021q mrp garp stp llc spidev brcmfmac vc4 cec brcmutil drm_kms_helper cfg80211 drm raspberrypi_cpufreq rfkill clk_raspberrypi raspberrypi_hwmon crct10dif_ce i2c_bcm2835 bcm2835_thermal bcm2835_rng rng_core spi_bcm2835 aes_neon_bs aes_neon_blk ip_tables x_tables ipv6
[   36.378161] CPU: 3 PID: 539 Comm: systemd-udevd Tainted: G        W         5.12.0-rc4+ #25
[   36.388189] Hardware name: Raspberry Pi 3 Model B Plus Rev 1.3 (DT)
[   36.395343] pstate: 80000005 (Nzcv daif -PAN -UAO -TCO BTYPE=--)
[   36.402250] pc : dev_uevent+0x138/0x1e8
[   36.406966] lr : uevent_show+0x90/0x118
[   36.411677] sp : ffff80001079bba0
[   36.415849] x29: ffff80001079bbc0 x28: ffff670b41b9d400
[   36.422066] x27: 0000000000000000 x26: 0000000000000001
[   36.428281] x25: 0000000000000000 x24: ffff670b49b42700
[   36.434496] x23: ffffdc99f37a4168 x22: ffff670b4191a880
[   36.440711] x21: ffff670b42475800 x20: ffff670b47f59000
[   36.446900] x19: ffff670b42475800 x18: 0000000000000000
[   36.453060] x17: 0000000000000000 x16: 0000000000000000
[   36.459216] x15: ffff670b4342f0d0 x14: 0000000000000000
[   36.465374] x13: 0000000000000001 x12: 0000000000000000
[   36.471522] x11: 0000000000000001 x10: ffff670b47f58000
[   36.477660] x9 : 0de4e88efe7dd600 x8 : ffff80001087b7d0
[   36.483806] x7 : 0000000000000000 x6 : 000000000000003f
[   36.489957] x5 : 0000000000000040 x4 : ffff80001079bb80
[   36.496107] x3 : 0000000000000001 x2 : ffff670b47f59000
[   36.502254] x1 : ffff670b42475800 x0 : ffff670b4191a880
[   36.508389] Call trace:
[   36.511582]  dev_uevent+0x138/0x1e8
[   36.515824]  uevent_show+0x90/0x118
[   36.520048]  dev_attr_show+0x20/0x58
[   36.524339]  sysfs_kf_seq_show+0xa0/0x110
[   36.529046]  kernfs_seq_show+0x2c/0x9c
[   36.533465]  seq_read_iter+0x11c/0x3b4
[   36.537858]  kernfs_fop_read_iter+0x68/0x188
[   36.542758]  vfs_read+0x290/0x2bc
[   36.546666]  ksys_read+0x74/0xe0
[   36.550464]  __arm64_sys_read+0x1c/0x28
[   36.554867]  el0_svc_common+0x90/0x110
[   36.559170]  do_el0_svc+0x24/0x80
[   36.563029]  el0_svc+0x28/0x88
[   36.566622]  el0_sync_handler+0x84/0xe4
[   36.571006]  el0_sync+0x154/0x180
[   36.574856] Code: aa1403e0 97f8c37e f9403668 b40000c8 (f9400102)
[   36.581549] ---[ end trace 556d98a75f645ca9 ]---
[   36.588678] Unable to handle kernel paging request at virtual address ffff80001087b7d0
[   36.597285] Mem abort info:
[   36.600580]   ESR = 0x96000007
[   36.604092]   EC = 0x25: DABT (current EL), IL = 32 bits
[   36.609969]   SET = 0, FnV = 0
[   36.613503]   EA = 0, S1PTW = 0
[   36.617115] Data abort info:
[   36.620451]   ISV = 0, ISS = 0x00000007
[   36.624759]   CM = 0, WnR = 0
[   36.628167] swapper pgtable: 4k pages, 48-bit VAs, pgdp=00000000013f1000
[   36.635407] [ffff80001087b7d0] pgd=0000000001810003, p4d=0000000001810003, pud=0000000001811003, pmd=00000000039b9003, pte=0000000000000000
[   36.649039] Internal error: Oops: 96000007 [#2] PREEMPT SMP
[   36.655146] Modules linked in: mfrc522 hci_uart btqca btbcm bluetooth ecdh_generic ecc 8021q mrp garp stp llc spidev brcmfmac vc4 cec brcmutil drm_kms_helper cfg80211 drm raspberrypi_cpufreq rfkill clk_raspberrypi raspberrypi_hwmon crct10dif_ce i2c_bcm2835 bcm2835_thermal bcm2835_rng rng_core spi_bcm2835 aes_neon_bs aes_neon_blk ip_tables x_tables ipv6
[   36.688923] CPU: 0 PID: 181 Comm: systemd-udevd Tainted: G      D W         5.12.0-rc4+ #25
[   36.698488] Hardware name: Raspberry Pi 3 Model B Plus Rev 1.3 (DT)
[   36.705416] pstate: 80000005 (Nzcv daif -PAN -UAO -TCO BTYPE=--)
[   36.712093] pc : dev_uevent+0x138/0x1e8
[   36.716577] lr : uevent_show+0x90/0x118
[   36.721052] sp : ffff8000104e3ba0
[   36.724989] x29: ffff8000104e3bc0 x28: ffff670b43875400
[   36.730970] x27: 0000000000000000 x26: 0000000000000001
[   36.736956] x25: 0000000000000000 x24: ffff670b47de2e00
[   36.742944] x23: ffffdc99f37a4168 x22: ffff670b4191a880
[   36.748923] x21: ffff670b42475800 x20: ffff670b434c0000
[   36.754895] x19: ffff670b42475800 x18: 0000000000000000
[   36.760851] x17: 0000000000000000 x16: 0000000000000000
[   36.766787] x15: ffff670b4342f0d0 x14: 0000000000000000
[   36.772723] x13: 0000000000000000 x12: 0000000000000000
[   36.778653] x11: 0000000000000002 x10: 0000000080080000
[   36.784572] x9 : 0de4e88efe7dd600 x8 : ffff80001087b7d0
[   36.790498] x7 : 0000000000000000 x6 : 000000000000003f
[   36.796428] x5 : 0000000000000040 x4 : ffff8000104e3b80
[   36.802356] x3 : 0000000000000001 x2 : ffff670b434c0000
[   36.808284] x1 : ffff670b42475800 x0 : ffff670b4191a880
[   36.814202] Call trace:
[   36.817189]  dev_uevent+0x138/0x1e8
[   36.821226]  uevent_show+0x90/0x118
[   36.825254]  dev_attr_show+0x20/0x58
[   36.829352]  sysfs_kf_seq_show+0xa0/0x110
[   36.833874]  kernfs_seq_show+0x2c/0x9c
[   36.838115]  seq_read_iter+0x11c/0x3b4
[   36.842337]  kernfs_fop_read_iter+0x68/0x188
[   36.847072]  vfs_read+0x290/0x2bc
[   36.850820]  ksys_read+0x74/0xe0
[   36.854464]  __arm64_sys_read+0x1c/0x28
[   36.858717]  el0_svc_common+0x90/0x110
[   36.862874]  do_el0_svc+0x24/0x80
[   36.866589]  el0_svc+0x28/0x88
[   36.870038]  el0_sync_handler+0x84/0xe4
[   36.874278]  el0_sync+0x154/0x180
[   36.877984] Code: aa1403e0 97f8c37e f9403668 b40000c8 (f9400102)
[   36.884527] ---[ end trace 556d98a75f645caa ]---
```

Here is the code to our driver if you want to see how we are using it: https://github.com/ks0n/mfrc522-linux