### PR TITLE
rust/kernel: move from_kernel_result! macro to error.rs

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -106,6 +106,7 @@ impl From<AllocError> for Error {
     }
 }
 
+#[doc(hidden)]
 pub fn from_kernel_result_helper<T>(r: Result<T>) -> T
 where
     T: TryFrom<c_types::c_int>,
@@ -117,6 +118,27 @@ where
     }
 }
 
+/// Transforms a [`crate::error::Result<T>`] to a kernel C integer result.
+///
+/// This is useful when calling Rust functions that return [`crate::error::Result<T>`]
+/// from inside `extern "C"` functions that need to return an integer
+/// error result.
+///
+/// `T` should be convertible to an integer via `TryFrom<c_types::c_int>`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// unsafe extern "C" fn probe_callback(
+///     pdev: *mut bindings::platform_device,
+/// ) -> c_types::c_int {
+///     from_kernel_result! {
+///         let ptr = devm_alloc(pdev)?;
+///         rust_helper_platform_set_drvdata(pdev, ptr);
+///         Ok(0)
+///     }
+/// }
+/// ```
 #[macro_export]
 macro_rules! from_kernel_result {
     ($($tt:tt)*) => {{

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -13,6 +13,7 @@ use crate::{
     bindings, c_types,
     error::{Error, Result},
     file::File,
+    from_kernel_result,
     io_buffer::{IoBufferReader, IoBufferWriter},
     iov_iter::IovIter,
     sync::CondVar,
@@ -76,25 +77,6 @@ pub enum SeekFrom {
 
     /// Equivalent to C's `SEEK_CUR`.
     Current(i64),
-}
-
-fn from_kernel_result<T>(r: Result<T>) -> T
-where
-    T: TryFrom<c_types::c_int>,
-    T::Error: core::fmt::Debug,
-{
-    match r {
-        Ok(v) => v,
-        Err(e) => T::try_from(e.to_kernel_errno()).unwrap(),
-    }
-}
-
-macro_rules! from_kernel_result {
-    ($($tt:tt)*) => {{
-        from_kernel_result((|| {
-            $($tt)*
-        })())
-    }};
 }
 
 unsafe extern "C" fn open_callback<A: FileOpenAdapter, T: FileOpener<A::Arg>>(


### PR DESCRIPTION
This macro is well-suited for use elsewhere in the Rust core.
Move it out to a suitable place, error.rs.

(I'd like to use this in #254)

## v1 -> v2
- split up in logically consistent commits (ojeda)
- add commit to improve safety and eliminate possible panics (TheSven73)