### PR TITLE
rust: Run rustdoc for the target triple

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -13,10 +13,18 @@ obj-$(CONFIG_RUST) += exports.o
 
 RUSTDOC = rustdoc
 
+quiet_cmd_rustdoc_host = RUSTDOC $<
+      cmd_rustdoc_host = \
+	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
+	$(RUSTDOC) $(filter-out --emit=%, $(rustc_flags)) \
+		$(rustdoc_target_flags) -L $(objtree)/rust/ \
+		--output $(objtree)/rust/doc --crate-name $(subst rustdoc-,,$@) \
+		-Fmissing-docs @$(objtree)/include/generated/rustc_cfg $<
+
 quiet_cmd_rustdoc = RUSTDOC $<
       cmd_rustdoc = \
 	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
-	$(RUSTDOC) $(filter-out --emit=%, $(rustc_flags)) \
+	$(RUSTDOC) $(rustc_cross_flags) $(filter-out --emit=%, $(rustc_flags)) \
 		$(rustdoc_target_flags) -L $(objtree)/rust/ \
 		--output $(objtree)/rust/doc --crate-name $(subst rustdoc-,,$@) \
 		-Fmissing-docs @$(objtree)/include/generated/rustc_cfg $<
@@ -26,7 +34,7 @@ rustdoc: rustdoc-module rustdoc-compiler_builtins rustdoc-kernel
 rustdoc-module: private rustdoc_target_flags = --crate-type proc-macro \
     --extern proc_macro
 rustdoc-module: $(srctree)/rust/module.rs FORCE
-	$(call if_changed,rustdoc)
+	$(call if_changed,rustdoc_host)
 
 rustdoc-compiler_builtins: $(srctree)/rust/compiler_builtins.rs FORCE
 	$(call if_changed,rustdoc)

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -291,7 +291,9 @@ $(obj)/%.lst: $(src)/%.c FORCE
 # Compile Rust sources (.rs)
 # ---------------------------------------------------------------------------
 
-rustc_cross_flags := --target=$(KBUILD_RUSTC_TARGET)
+# Need to use absolute path here and have symbolic links resolved;
+# otherwise rustdoc and rustc compute different hashes for the target.
+rustc_cross_flags := --target=$(realpath $(KBUILD_RUSTC_TARGET))
 
 quiet_cmd_rustc_o_rs = $(RUSTC_OR_CLIPPY_QUIET) $(quiet_modtag) $@
       cmd_rustc_o_rs = \


### PR DESCRIPTION
As I mentioned in comment section of #258, if I just add `--target` to rustdoc command line, it will complain about target triple mismatch. It turns out for rustdoc we need to supply absolute path for the target json file.

Fix #261.

Signed-off-by: Gary Guo <gary@garyguo.net>