### PR TITLE
rust: CStr overhaul

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -10,7 +10,7 @@
 use alloc::{boxed::Box, sync::Arc};
 use core::pin::Pin;
 use kernel::{
-    cstr,
+    c_str,
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, GetLinksWrapped, Links},
     miscdev::Registration,
@@ -111,7 +111,7 @@ impl KernelModule for BinderModule {
         let pinned_ctx = Context::new()?;
         let ctx = unsafe { Pin::into_inner_unchecked(pinned_ctx) };
         let reg = Registration::<Arc<Context>>::new_pinned::<process::Process>(
-            cstr!("rust_binder"),
+            c_str!("rust_binder"),
             None,
             ctx,
         )?;

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -9,7 +9,7 @@ use alloc::boxed::Box;
 use core::pin::Pin;
 use kernel::of::OfMatchTable;
 use kernel::prelude::*;
-use kernel::{cstr, platdev};
+use kernel::{c_str, platdev};
 
 module! {
     type: RngModule,
@@ -25,7 +25,7 @@ struct RngModule {
 
 impl KernelModule for RngModule {
     fn init() -> Result<Self> {
-        let of_match_tbl = OfMatchTable::new(&cstr!("brcm,bcm2835-rng"))?;
+        let of_match_tbl = OfMatchTable::new(&c_str!("brcm,bcm2835-rng"))?;
 
         let pdev = platdev::Registration::new_pinned(
             cstr!("bcm2835-rng-rust"),

--- a/rust/kernel/c_types.rs
+++ b/rust/kernel/c_types.rs
@@ -117,18 +117,3 @@ mod c {
 }
 
 pub use c::*;
-
-/// Reads string until null byte is reached and returns slice excluding the
-/// terminating null.
-///
-/// # Safety
-///
-/// The data from the pointer until the null terminator must be valid for reads
-/// and not mutated for all of `'a`. The length of the string must also be less
-/// than `isize::MAX`. See the documentation on
-/// [`core::slice::from_raw_parts()`] for further details on safety of
-/// converting a pointer to a slice.
-pub unsafe fn c_string_bytes<'a>(ptr: *const crate::c_types::c_char) -> &'a [u8] {
-    let length = crate::bindings::strlen(ptr) as usize;
-    &core::slice::from_raw_parts(ptr as *const u8, length)
-}

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -17,7 +17,7 @@ use crate::bindings;
 use crate::c_types;
 use crate::error::{Error, Result};
 use crate::file_operations;
-use crate::types::CStr;
+use crate::str::CStr;
 
 /// Character device.
 ///
@@ -87,7 +87,7 @@ struct RegistrationInner<const N: usize> {
 ///
 /// May contain up to a fixed number (`N`) of devices. Must be pinned.
 pub struct Registration<const N: usize> {
-    name: CStr<'static>,
+    name: &'static CStr,
     minors_start: u16,
     this_module: &'static crate::ThisModule,
     inner: Option<RegistrationInner<N>>,
@@ -104,7 +104,7 @@ impl<const N: usize> Registration<{ N }> {
     /// are going to pin the registration right away, call
     /// [`Self::new_pinned()`] instead.
     pub fn new(
-        name: CStr<'static>,
+        name: &'static CStr,
         minors_start: u16,
         this_module: &'static crate::ThisModule,
     ) -> Self {
@@ -120,7 +120,7 @@ impl<const N: usize> Registration<{ N }> {
     ///
     /// This does *not* register the device: see [`Self::register()`].
     pub fn new_pinned(
-        name: CStr<'static>,
+        name: &'static CStr,
         minors_start: u16,
         this_module: &'static crate::ThisModule,
     ) -> Result<Pin<Box<Self>>> {
@@ -146,7 +146,7 @@ impl<const N: usize> Registration<{ N }> {
                     &mut dev,
                     this.minors_start.into(),
                     N.try_into()?,
-                    this.name.as_ptr() as *const c_types::c_char,
+                    this.name.as_char_ptr(),
                 )
             };
             if res != 0 {

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -20,6 +20,7 @@
     const_mut_refs,
     const_panic,
     const_raw_ptr_deref,
+    const_unreachable_unchecked,
     try_reserve
 )]
 #![deny(clippy::complexity)]

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -19,6 +19,7 @@
     const_fn,
     const_mut_refs,
     const_panic,
+    const_raw_ptr_deref,
     try_reserve
 )]
 #![deny(clippy::complexity)]
@@ -44,6 +45,7 @@ pub mod file;
 pub mod file_operations;
 pub mod miscdev;
 pub mod pages;
+pub mod str;
 
 pub mod linked_list;
 mod raw_list;
@@ -72,7 +74,7 @@ pub mod user_ptr;
 pub use build_error::build_error;
 
 pub use crate::error::{Error, Result};
-pub use crate::types::{CStr, Mode};
+pub use crate::types::Mode;
 
 /// Page size defined in terms of the `PAGE_SHIFT` macro from C.
 ///

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -6,9 +6,10 @@
 //!
 //! Reference: <https://www.kernel.org/doc/html/latest/driver-api/misc_devices.html>
 
+use crate::bindings;
 use crate::error::{Error, Result};
 use crate::file_operations::{FileOpenAdapter, FileOpener, FileOperationsVtable};
-use crate::{bindings, c_types, CStr};
+use crate::str::CStr;
 use alloc::boxed::Box;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
@@ -41,7 +42,7 @@ impl<T: Sync> Registration<T> {
     ///
     /// Returns a pinned heap-allocated representation of the registration.
     pub fn new_pinned<F: FileOpener<T>>(
-        name: CStr<'static>,
+        name: &'static CStr,
         minor: Option<i32>,
         context: T,
     ) -> Result<Pin<Box<Self>>> {
@@ -56,7 +57,7 @@ impl<T: Sync> Registration<T> {
     /// self-referential. If a minor is not given, the kernel allocates a new one if possible.
     pub fn register<F: FileOpener<T>>(
         self: Pin<&mut Self>,
-        name: CStr<'static>,
+        name: &'static CStr,
         minor: Option<i32>,
     ) -> Result {
         // SAFETY: We must ensure that we never move out of `this`.
@@ -68,7 +69,7 @@ impl<T: Sync> Registration<T> {
 
         // SAFETY: The adapter is compatible with `misc_register`.
         this.mdev.fops = unsafe { FileOperationsVtable::<Self, F>::build() };
-        this.mdev.name = name.as_ptr() as *const c_types::c_char;
+        this.mdev.name = name.as_char_ptr();
         this.mdev.minor = minor.unwrap_or(bindings::MISC_DYNAMIC_MINOR as i32);
 
         let ret = unsafe { bindings::misc_register(&mut this.mdev) };

--- a/rust/kernel/module_param.rs
+++ b/rust/kernel/module_param.rs
@@ -4,6 +4,7 @@
 //!
 //! C header: [`include/linux/moduleparam.h`](../../../include/linux/moduleparam.h)
 
+use crate::str::CStr;
 use core::fmt::Write;
 
 /// Types that can be used for module parameters.
@@ -70,7 +71,7 @@ pub trait ModuleParam: core::fmt::Display + core::marker::Sized {
         let arg = if val.is_null() {
             None
         } else {
-            Some(crate::c_types::c_string_bytes(val))
+            Some(CStr::from_char_ptr(val).as_bytes())
         };
         match Self::try_from_param_arg(arg) {
             Some(new_value) => {

--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -9,8 +9,8 @@ use alloc::boxed::Box;
 use crate::{
     bindings, c_types,
     error::{Error, Result},
+    str::CStr,
     types::PointerWrapper,
-    CStr,
 };
 
 use core::mem::transmute;
@@ -32,7 +32,7 @@ pub struct OfMatchTable(InnerTable);
 
 impl OfMatchTable {
     /// Creates a [`OfMatchTable`] from a single `compatible` string.
-    pub fn new(compatible: &CStr<'static>) -> Result<Self> {
+    pub fn new(compatible: &'static CStr) -> Result<Self> {
         let tbl = Box::try_new([
             Self::new_of_device_id(compatible)?,
             bindings::of_device_id::default(),
@@ -43,7 +43,7 @@ impl OfMatchTable {
         Ok(Self(tbl))
     }
 
-    fn new_of_device_id(compatible: &CStr<'static>) -> Result<bindings::of_device_id> {
+    fn new_of_device_id(compatible: &'static CStr) -> Result<bindings::of_device_id> {
         let mut buf = [0_u8; 128];
         if compatible.len() > buf.len() {
             return Err(Error::EINVAL);

--- a/rust/kernel/platdev.rs
+++ b/rust/kernel/platdev.rs
@@ -11,8 +11,8 @@ use crate::{
     error::{Error, Result},
     of::OfMatchTable,
     pr_info,
+    str::CStr,
     types::PointerWrapper,
-    CStr,
 };
 use alloc::boxed::Box;
 use core::{marker::PhantomPinned, pin::Pin};
@@ -43,7 +43,7 @@ extern "C" fn remove_callback(_pdev: *mut bindings::platform_device) -> c_types:
 impl Registration {
     fn register(
         self: Pin<&mut Self>,
-        name: CStr<'static>,
+        name: &'static CStr,
         of_match_table: Option<OfMatchTable>,
         module: &'static crate::ThisModule,
     ) -> Result {
@@ -53,7 +53,7 @@ impl Registration {
             // Already registered.
             return Err(Error::EINVAL);
         }
-        this.pdrv.driver.name = name.as_ptr() as *const c_types::c_char;
+        this.pdrv.driver.name = name.as_char_ptr();
         if let Some(tbl) = of_match_table {
             let ptr = tbl.into_pointer();
             this.of_table = Some(ptr);
@@ -82,7 +82,7 @@ impl Registration {
     ///
     /// Returns a pinned heap-allocated representation of the registration.
     pub fn new_pinned(
-        name: CStr<'static>,
+        name: &'static CStr,
         of_match_tbl: Option<OfMatchTable>,
         module: &'static crate::ThisModule,
     ) -> Result<Pin<Box<Self>>> {

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -6,7 +6,8 @@
 //! variable.
 
 use super::{Guard, Lock, NeedsLockClass};
-use crate::{bindings, CStr};
+use crate::bindings;
+use crate::str::CStr;
 use core::{cell::UnsafeCell, marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
 
 extern "C" {
@@ -130,7 +131,7 @@ impl CondVar {
 }
 
 impl NeedsLockClass for CondVar {
-    unsafe fn init(self: Pin<&Self>, name: CStr<'static>, key: *mut bindings::lock_class_key) {
-        bindings::__init_waitqueue_head(self.wait_list.get(), name.as_ptr() as _, key);
+    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
+        bindings::__init_waitqueue_head(self.wait_list.get(), name.as_char_ptr(), key);
     }
 }

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -17,7 +17,8 @@
 //! }
 //! ```
 
-use crate::{bindings, c_types, CStr};
+use crate::str::CStr;
+use crate::{bindings, c_types};
 use core::pin::Pin;
 
 mod arc;
@@ -51,7 +52,7 @@ macro_rules! init_with_lockdep {
         // SAFETY: `CLASS` is never used by Rust code directly; the kernel may change it though.
         #[allow(unused_unsafe)]
         unsafe {
-            $crate::sync::NeedsLockClass::init($obj, $crate::cstr!($name), CLASS.as_mut_ptr())
+            $crate::sync::NeedsLockClass::init($obj, $crate::c_str!($name), CLASS.as_mut_ptr())
         };
     }};
 }
@@ -69,7 +70,7 @@ pub trait NeedsLockClass {
     /// # Safety
     ///
     /// `key` must point to a valid memory location as it will be used by the kernel.
-    unsafe fn init(self: Pin<&Self>, name: CStr<'static>, key: *mut bindings::lock_class_key);
+    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key);
 }
 
 /// Determines if a signal is pending on the current process.

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -5,7 +5,8 @@
 //! This module allows Rust code to use the kernel's [`struct mutex`].
 
 use super::{Guard, Lock, NeedsLockClass};
-use crate::{bindings, CStr};
+use crate::bindings;
+use crate::str::CStr;
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
 
 /// Safely initialises a [`Mutex`] with the given name, generating a new lock class.
@@ -71,8 +72,8 @@ impl<T: ?Sized> Mutex<T> {
 }
 
 impl<T: ?Sized> NeedsLockClass for Mutex<T> {
-    unsafe fn init(self: Pin<&Self>, name: CStr<'static>, key: *mut bindings::lock_class_key) {
-        bindings::__mutex_init(self.mutex.get(), name.as_ptr() as _, key);
+    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
+        bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key);
     }
 }
 

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -7,7 +7,8 @@
 //! See <https://www.kernel.org/doc/Documentation/locking/spinlocks.txt>.
 
 use super::{Guard, Lock, NeedsLockClass};
-use crate::{bindings, c_types, CStr};
+use crate::str::CStr;
+use crate::{bindings, c_types};
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
 
 extern "C" {
@@ -85,8 +86,8 @@ impl<T: ?Sized> SpinLock<T> {
 }
 
 impl<T: ?Sized> NeedsLockClass for SpinLock<T> {
-    unsafe fn init(self: Pin<&Self>, name: CStr<'static>, key: *mut bindings::lock_class_key) {
-        rust_helper_spin_lock_init(self.spin_lock.get(), name.as_ptr() as _, key);
+    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
+        rust_helper_spin_lock_init(self.spin_lock.get(), name.as_char_ptr(), key);
     }
 }
 

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -31,51 +31,6 @@ impl Mode {
     }
 }
 
-/// A string that is guaranteed to have exactly one `NUL` byte, which is at the
-/// end.
-///
-/// Used for interoperability with kernel APIs that take C strings.
-#[repr(transparent)]
-pub struct CStr<'a>(&'a str);
-
-impl CStr<'_> {
-    /// Creates a [`CStr`] from a [`str`] without performing any additional
-    /// checks.
-    ///
-    /// # Safety
-    ///
-    /// `data` *must* end with a `NUL` byte, and should only have only a single
-    /// `NUL` byte (or the string will be truncated).
-    pub const unsafe fn new_unchecked(data: &str) -> CStr {
-        CStr(data)
-    }
-}
-
-impl Deref for CStr<'_> {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        self.0
-    }
-}
-
-/// Creates a new `CStr` from a string literal.
-///
-/// The string literal should not contain any `NUL` bytes.
-///
-/// # Examples
-///
-/// ```rust,no_run
-/// const MY_CSTR: CStr<'static> = cstr!("My awesome CStr!");
-/// ```
-#[macro_export]
-macro_rules! cstr {
-    ($str:expr) => {{
-        let s = concat!($str, "\x00");
-        unsafe { $crate::CStr::new_unchecked(s) }
-    }};
-}
-
 /// Used to convert an object into a raw pointer that represents it.
 ///
 /// It can eventually be converted back into the object. This is used to store objects as pointers

--- a/rust/module.rs
+++ b/rust/module.rs
@@ -821,7 +821,7 @@ pub fn module_misc_device(ts: TokenStream) -> TokenStream {
                 fn init() -> kernel::Result<Self> {{
                     Ok(Self {{
                         _dev: kernel::miscdev::Registration::new_pinned::<{type_}>(
-                            kernel::cstr!(\"{name}\"),
+                            kernel::c_str!(\"{name}\"),
                             None,
                             (),
                         )?,

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -8,7 +8,7 @@
 use alloc::boxed::Box;
 use core::pin::Pin;
 use kernel::prelude::*;
-use kernel::{chrdev, cstr, file_operations::FileOperations};
+use kernel::{c_str, chrdev, file_operations::FileOperations};
 
 module! {
     type: RustChrdev,
@@ -34,7 +34,7 @@ impl KernelModule for RustChrdev {
         pr_info!("Rust character device sample (init)\n");
 
         let mut chrdev_reg =
-            chrdev::Registration::new_pinned(cstr!("rust_chrdev"), 0, &THIS_MODULE)?;
+            chrdev::Registration::new_pinned(c_str!("rust_chrdev"), 0, &THIS_MODULE)?;
 
         // Register the same kind of device twice, we're just demonstrating
         // that you can use multiple minors. There are two minors in this case

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -9,7 +9,7 @@ use alloc::{boxed::Box, sync::Arc};
 use core::pin::Pin;
 use kernel::prelude::*;
 use kernel::{
-    cstr,
+    c_str,
     file::File,
     file_operations::{FileOpener, FileOperations},
     io_buffer::{IoBufferReader, IoBufferWriter},
@@ -135,7 +135,7 @@ impl KernelModule for RustMiscdev {
         let state = SharedState::try_new()?;
 
         Ok(RustMiscdev {
-            _dev: miscdev::Registration::new_pinned::<Token>(cstr!("rust_miscdev"), None, state)?,
+            _dev: miscdev::Registration::new_pinned::<Token>(c_str!("rust_miscdev"), None, state)?,
         })
     }
 }

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -22,7 +22,7 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 use kernel::{
-    condvar_init, cstr, declare_file_operations,
+    c_str, condvar_init, declare_file_operations,
     file::File,
     file_operations::{FileOpener, FileOperations, IoctlCommand, IoctlHandler},
     io_buffer::{IoBufferReader, IoBufferWriter},
@@ -140,7 +140,7 @@ impl KernelModule for RustSemaphore {
         mutex_init!(Pin::new_unchecked(&sema.inner), "Semaphore::inner");
 
         Ok(Self {
-            _dev: Registration::new_pinned::<FileState>(cstr!("rust_semaphore"), None, sema)?,
+            _dev: Registration::new_pinned::<FileState>(c_str!("rust_semaphore"), None, sema)?,
         })
     }
 }


### PR DESCRIPTION
`CStr` is overhauled to make using it more similar to use a `str`.

This is split from #258, without procedural macros and `CBoundedStr` and does not depend on `build_assert!`.

Some additional improvements:
* Added a `BStr` which is just `[u8]` but provide an extra semantical annotation;
* Make `CStr` deref to`BStr` so many functions could be used;
* Add `AsRef<BStr>` for `CStr`, combining with deref this allows CStr to be used when `&BStr` is exepcted;
* Allow `CStr` to be sliced like a `[u8]`;
* Change `c_string_bytes` to `CStr::from_char_ptr`

r? @ojeda @wedsonaf 