### PR TITLE
[Discussion] Use NonNull more prevalently

### DIFF
--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -6,14 +6,15 @@
 //! [`include/linux/file.h`](../../../../include/linux/file.h)
 
 use crate::bindings;
+use core::ptr::NonNull;
 
 /// Wraps the kernel's `struct file`.
 ///
 /// # Invariants
 ///
-/// The pointer [`File::ptr`] is non-null and valid.
+/// The pointer [`File::ptr`] is valid.
 pub struct File {
-    pub(crate) ptr: *const bindings::file,
+    pub(crate) ptr: NonNull<bindings::file>,
 }
 
 impl File {
@@ -21,8 +22,8 @@ impl File {
     ///
     /// # Safety
     ///
-    /// The pointer `ptr` must be non-null and valid for the lifetime of the object.
-    pub(crate) unsafe fn from_ptr(ptr: *const bindings::file) -> File {
+    /// The pointer `ptr` must be valid for the lifetime of the object.
+    pub(crate) unsafe fn from_ptr(ptr: NonNull<bindings::file>) -> File {
         // INVARIANTS: the safety contract ensures the type invariant will hold.
         File { ptr }
     }
@@ -30,12 +31,12 @@ impl File {
     /// Returns the current seek/cursor/pointer position (`struct file::f_pos`).
     pub fn pos(&self) -> u64 {
         // SAFETY: `File::ptr` is guaranteed to be valid by the type invariants.
-        unsafe { (*self.ptr).f_pos as u64 }
+        unsafe { self.ptr.as_ref().f_pos as u64 }
     }
 
     /// Returns whether the file is in blocking mode.
     pub fn is_blocking(&self) -> bool {
         // SAFETY: `File::ptr` is guaranteed to be valid by the type invariants.
-        unsafe { (*self.ptr).f_flags & bindings::O_NONBLOCK == 0 }
+        unsafe { self.ptr.as_ref().f_flags & bindings::O_NONBLOCK == 0 }
     }
 }

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -112,7 +112,7 @@ unsafe extern "C" fn read_callback<T: FileOperations>(
 ) -> c_types::c_ssize_t {
     from_kernel_result! {
         let file = NonNull::new_unchecked(file);
-        let offset = NonNull::new_unchecked(offset).as_mut();
+        let offset = &mut *offset;
 
         let mut data = UserSlicePtr::new(buf as *mut c_types::c_void, len).writer();
         let f: &T = get_file_private_data(file);
@@ -130,7 +130,7 @@ unsafe extern "C" fn read_iter_callback<T: FileOperations>(
 ) -> isize {
     from_kernel_result! {
         let raw_iter = NonNull::new_unchecked(raw_iter);
-        let iocb = NonNull::new_unchecked(iocb).as_mut();
+        let iocb = &mut *iocb;
         let file = NonNull::new_unchecked(iocb.ki_filp);
 
         let mut iter = IovIter::from_ptr(raw_iter);
@@ -150,7 +150,7 @@ unsafe extern "C" fn write_callback<T: FileOperations>(
 ) -> c_types::c_ssize_t {
     from_kernel_result! {
         let file = NonNull::new_unchecked(file);
-        let offset = NonNull::new_unchecked(offset).as_mut();
+        let offset = &mut *offset;
 
         // TODO: why is it okay to upgrade the mutability of `buf` here?
         let mut data = UserSlicePtr::new(buf as *mut c_types::c_void, len).reader();
@@ -169,7 +169,7 @@ unsafe extern "C" fn write_iter_callback<T: FileOperations>(
 ) -> isize {
     from_kernel_result! {
         let raw_iter = NonNull::new_unchecked(raw_iter);
-        let iocb = NonNull::new_unchecked(iocb).as_mut();
+        let iocb = &mut *iocb;
 
         let file = NonNull::new_unchecked(iocb.ki_filp);
         let mut iter = IovIter::from_ptr(raw_iter);

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -5,7 +5,10 @@
 //! C header: [`include/linux/fs.h`](../../../../include/linux/fs.h)
 
 use core::convert::{TryFrom, TryInto};
-use core::{marker, mem, ptr};
+use core::{
+    marker, mem,
+    ptr::{self, NonNull},
+};
 
 use alloc::boxed::Box;
 
@@ -25,9 +28,9 @@ use crate::{
 ///
 /// # Invariants
 ///
-/// The pointer [`PollTable::ptr`] is null or valid.
+/// The pointer [`PollTable::ptr`] is valid.
 pub struct PollTable {
-    ptr: *mut bindings::poll_table_struct,
+    ptr: Option<NonNull<bindings::poll_table_struct>>,
 }
 
 impl PollTable {
@@ -37,7 +40,9 @@ impl PollTable {
     ///
     /// The pointer `ptr` must be either null or a valid pointer for the lifetime of the object.
     unsafe fn from_ptr(ptr: *mut bindings::poll_table_struct) -> Self {
-        Self { ptr }
+        Self {
+            ptr: NonNull::new(ptr),
+        }
     }
 
     /// Associates the given file and condition variable to this poll table. It means notifying the
@@ -51,16 +56,13 @@ impl PollTable {
     /// If the condition variable is destroyed before the file, then [`CondVar::free_waiters`] must
     /// be called to ensure that all waiters are flushed out.
     pub unsafe fn register_wait<'a>(&self, file: &'a File, cv: &'a CondVar) {
-        if self.ptr.is_null() {
-            return;
-        }
-
-        // SAFETY: `PollTable::ptr` is guaranteed to be valid by the type invariants and the null
-        // check above.
-        let table = &*self.ptr;
-        if let Some(proc) = table._qproc {
-            // SAFETY: All pointers are known to be valid.
-            proc(file.ptr as _, cv.wait_list.get(), self.ptr)
+        if let Some(ptr) = self.ptr {
+            // SAFETY: `PollTable::ptr` is guaranteed to be valid by the type invariants.
+            let table = ptr.as_ref();
+            if let Some(proc) = table._qproc {
+                // SAFETY: All pointers are known to be valid.
+                proc(file.ptr.as_ptr(), cv.wait_list.get(), ptr.as_ptr())
+            }
         }
     }
 }
@@ -84,11 +86,22 @@ unsafe extern "C" fn open_callback<A: FileOpenAdapter, T: FileOpener<A::Arg>>(
     file: *mut bindings::file,
 ) -> c_types::c_int {
     from_kernel_result! {
-        let arg = A::convert(inode, file);
+        let mut file = NonNull::new_unchecked(file);
+
+        let arg = A::convert(inode, file.as_ptr());
         let ptr = T::open(&*arg)?.into_pointer();
-        (*file).private_data = ptr as *mut c_types::c_void;
+        file.as_mut().private_data = ptr as *mut c_types::c_void;
         Ok(0)
     }
+}
+
+/// Creates a shared reference to a file's `private_data` field interpreted as `T`
+///
+/// # SAFETY
+/// - `file` must point to a valid [`bindings::file`]
+/// - the [`bindings::file`]'s `private_data` field must point to a valid `T` that lives for `'a`
+unsafe fn get_file_private_data<'a, T>(file: NonNull<bindings::file>) -> &'a T {
+    &*file.as_ref().private_data.cast::<T>()
 }
 
 unsafe extern "C" fn read_callback<T: FileOperations>(
@@ -98,12 +111,15 @@ unsafe extern "C" fn read_callback<T: FileOperations>(
     offset: *mut bindings::loff_t,
 ) -> c_types::c_ssize_t {
     from_kernel_result! {
+        let file = NonNull::new_unchecked(file);
+        let offset = NonNull::new_unchecked(offset).as_mut();
+
         let mut data = UserSlicePtr::new(buf as *mut c_types::c_void, len).writer();
-        let f = &*((*file).private_data as *const T);
+        let f: &T = get_file_private_data(file);
         // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
         // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
         let read = f.read(&File::from_ptr(file), &mut data, (*offset).try_into()?)?;
-        (*offset) += bindings::loff_t::try_from(read).unwrap();
+        *offset += bindings::loff_t::try_from(read).unwrap();
         Ok(read as _)
     }
 }
@@ -113,12 +129,15 @@ unsafe extern "C" fn read_iter_callback<T: FileOperations>(
     raw_iter: *mut bindings::iov_iter,
 ) -> isize {
     from_kernel_result! {
+        let raw_iter = NonNull::new_unchecked(raw_iter);
+        let iocb = NonNull::new_unchecked(iocb).as_mut();
+        let file = NonNull::new_unchecked(iocb.ki_filp);
+
         let mut iter = IovIter::from_ptr(raw_iter);
-        let file = (*iocb).ki_filp;
-        let offset = (*iocb).ki_pos;
-        let f = &*((*file).private_data as *const T);
+        let offset = iocb.ki_pos;
+        let f: &T = get_file_private_data(file);
         let read = f.read(&File::from_ptr(file), &mut iter, offset.try_into()?)?;
-        (*iocb).ki_pos += bindings::loff_t::try_from(read).unwrap();
+        iocb.ki_pos += bindings::loff_t::try_from(read).unwrap();
         Ok(read as _)
     }
 }
@@ -130,12 +149,16 @@ unsafe extern "C" fn write_callback<T: FileOperations>(
     offset: *mut bindings::loff_t,
 ) -> c_types::c_ssize_t {
     from_kernel_result! {
+        let file = NonNull::new_unchecked(file);
+        let offset = NonNull::new_unchecked(offset).as_mut();
+
+        // TODO: why is it okay to upgrade the mutability of `buf` here?
         let mut data = UserSlicePtr::new(buf as *mut c_types::c_void, len).reader();
-        let f = &*((*file).private_data as *const T);
+        let f: &T = get_file_private_data(file);
         // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
         // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
         let written = f.write(&File::from_ptr(file), &mut data, (*offset).try_into()?)?;
-        (*offset) += bindings::loff_t::try_from(written).unwrap();
+        *offset += bindings::loff_t::try_from(written).unwrap();
         Ok(written as _)
     }
 }
@@ -145,12 +168,16 @@ unsafe extern "C" fn write_iter_callback<T: FileOperations>(
     raw_iter: *mut bindings::iov_iter,
 ) -> isize {
     from_kernel_result! {
+        let raw_iter = NonNull::new_unchecked(raw_iter);
+        let iocb = NonNull::new_unchecked(iocb).as_mut();
+
+        let file = NonNull::new_unchecked(iocb.ki_filp);
         let mut iter = IovIter::from_ptr(raw_iter);
-        let file = (*iocb).ki_filp;
-        let offset = (*iocb).ki_pos;
-        let f = &*((*file).private_data as *const T);
+
+        let offset = iocb.ki_pos;
+        let f: &T = get_file_private_data(file);
         let written = f.write(&File::from_ptr(file), &mut iter, offset.try_into()?)?;
-        (*iocb).ki_pos += bindings::loff_t::try_from(written).unwrap();
+        iocb.ki_pos += bindings::loff_t::try_from(written).unwrap();
         Ok(written as _)
     }
 }
@@ -159,7 +186,9 @@ unsafe extern "C" fn release_callback<T: FileOperations>(
     _inode: *mut bindings::inode,
     file: *mut bindings::file,
 ) -> c_types::c_int {
-    let ptr = mem::replace(&mut (*file).private_data, ptr::null_mut());
+    let mut file = NonNull::new_unchecked(file);
+
+    let ptr = mem::replace(&mut file.as_mut().private_data, ptr::null_mut());
     T::release(T::Wrapper::from_pointer(ptr as _), &File::from_ptr(file));
     0
 }
@@ -170,13 +199,15 @@ unsafe extern "C" fn llseek_callback<T: FileOperations>(
     whence: c_types::c_int,
 ) -> bindings::loff_t {
     from_kernel_result! {
+        let file = NonNull::new_unchecked(file);
+
         let off = match whence as u32 {
             bindings::SEEK_SET => SeekFrom::Start(offset.try_into()?),
             bindings::SEEK_CUR => SeekFrom::Current(offset),
             bindings::SEEK_END => SeekFrom::End(offset),
             _ => return Err(Error::EINVAL),
         };
-        let f = &*((*file).private_data as *const T);
+        let f: &T = get_file_private_data(file);
         let off = f.seek(&File::from_ptr(file), off)?;
         Ok(off as bindings::loff_t)
     }
@@ -188,7 +219,9 @@ unsafe extern "C" fn unlocked_ioctl_callback<T: FileOperations>(
     arg: c_types::c_ulong,
 ) -> c_types::c_long {
     from_kernel_result! {
-        let f = &*((*file).private_data as *const T);
+        let file = NonNull::new_unchecked(file);
+
+        let f: &T = get_file_private_data(file);
         // SAFETY: This function is called by the kernel, so it must set `fs` appropriately.
         let mut cmd = IoctlCommand::new(cmd as _, arg as _);
         let ret = f.ioctl(&File::from_ptr(file), &mut cmd)?;
@@ -202,7 +235,9 @@ unsafe extern "C" fn compat_ioctl_callback<T: FileOperations>(
     arg: c_types::c_ulong,
 ) -> c_types::c_long {
     from_kernel_result! {
-        let f = &*((*file).private_data as *const T);
+        let file = NonNull::new_unchecked(file);
+
+        let f: &T = get_file_private_data(file);
         // SAFETY: This function is called by the kernel, so it must set `fs` appropriately.
         let mut cmd = IoctlCommand::new(cmd as _, arg as _);
         let ret = f.compat_ioctl(&File::from_ptr(file), &mut cmd)?;
@@ -215,8 +250,11 @@ unsafe extern "C" fn mmap_callback<T: FileOperations>(
     vma: *mut bindings::vm_area_struct,
 ) -> c_types::c_int {
     from_kernel_result! {
-        let f = &*((*file).private_data as *const T);
-        f.mmap(&File::from_ptr(file), &mut *vma)?;
+        let file = NonNull::new_unchecked(file);
+        let mut vma = NonNull::new_unchecked(vma);
+
+        let f: &T = get_file_private_data(file);
+        f.mmap(&File::from_ptr(file), vma.as_mut())?;
         Ok(0)
     }
 }
@@ -228,10 +266,13 @@ unsafe extern "C" fn fsync_callback<T: FileOperations>(
     datasync: c_types::c_int,
 ) -> c_types::c_int {
     from_kernel_result! {
+        let file = NonNull::new_unchecked(file);
+
         let start = start.try_into()?;
         let end = end.try_into()?;
         let datasync = datasync != 0;
-        let f = &*((*file).private_data as *const T);
+
+        let f: &T = get_file_private_data(file);
         let res = f.fsync(&File::from_ptr(file), start, end, datasync)?;
         Ok(res.try_into().unwrap())
     }
@@ -241,11 +282,11 @@ unsafe extern "C" fn poll_callback<T: FileOperations>(
     file: *mut bindings::file,
     wait: *mut bindings::poll_table_struct,
 ) -> bindings::__poll_t {
-    let f = &*((*file).private_data as *const T);
-    match f.poll(&File::from_ptr(file), &PollTable::from_ptr(wait)) {
-        Ok(v) => v,
-        Err(_) => bindings::POLLERR,
-    }
+    let file = NonNull::new_unchecked(file);
+
+    let f: &T = get_file_private_data(file);
+    f.poll(&File::from_ptr(file), &PollTable::from_ptr(wait))
+        .unwrap_or(bindings::POLLERR)
 }
 
 pub(crate) struct FileOperationsVtable<A, T>(marker::PhantomData<A>, marker::PhantomData<T>);
@@ -497,6 +538,7 @@ pub trait FileOpenAdapter {
     ///
     /// This function must be called only when [`struct file_operations::open`] is being called for
     /// a file that was registered by the implementer.
+    // TODO: are these pointers guaranteed to be `NonNull`?
     unsafe fn convert(_inode: *mut bindings::inode, _file: *mut bindings::file)
         -> *const Self::Arg;
 }

--- a/rust/kernel/linked_list.rs
+++ b/rust/kernel/linked_list.rs
@@ -29,7 +29,7 @@ pub trait Wrapper<T: ?Sized> {
 
 impl<T: ?Sized> Wrapper<T> for Box<T> {
     fn into_pointer(self) -> NonNull<T> {
-        NonNull::new(Box::into_raw(self)).unwrap()
+        NonNull::from(Box::leak(self))
     }
 
     unsafe fn from_pointer(ptr: NonNull<T>) -> Self {
@@ -43,7 +43,8 @@ impl<T: ?Sized> Wrapper<T> for Box<T> {
 
 impl<T: ?Sized> Wrapper<T> for Arc<T> {
     fn into_pointer(self) -> NonNull<T> {
-        NonNull::new(Arc::into_raw(self) as _).unwrap()
+        // SAFETY: `Arc::into_raw` can't return a null pointer
+        unsafe { NonNull::new_unchecked(Arc::into_raw(self) as *mut _) }
     }
 
     unsafe fn from_pointer(ptr: NonNull<T>) -> Self {

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -105,7 +105,13 @@ impl<T: RefCounted + ?Sized> Ref<T> {
     /// can only be called once for each previous call to [``Ref::into_raw`].
     pub unsafe fn from_raw(ptr: *const T) -> Self {
         Ref {
-            ptr: NonNull::new(ptr as _).unwrap(),
+            ptr: if cfg!(debug_assertions) {
+                NonNull::new(ptr as _).unwrap()
+            } else {
+                // SAFETY: since `ptr` must have been returned by a previous call to `Ref::into_raw`
+                // it cannot be null.
+                NonNull::new_unchecked(ptr as _)
+            },
         }
     }
 }


### PR DESCRIPTION
This is an experiment to use `NonNull` basically everywhere where it's applicable in the kernel crate.

Some of these uses may not be fully warranted but in my opinion some of the cases are significant improvements.
Especially the ones where we do a `.is_null()` check anyways or where the `SAFETY` comment requires a pointer not to be null.

Generally where a `NonNull::new_unchecked` was added the code previously used the pointer without checking it and where a `NonNull::new` was added the code previously did an explicit `NULL` check.

I mostly opened this PR to start some discussion on if this is something we want to encourage using in the kernel and if we do, to what extent.

In my opinion the safety, encoding if a pointer can be `NULL` in the type system gives us, is exactly one of the reasons for using Rust over C. Additionally I think having a single `NonNull::new_unchecked` at the top of a function with a safety comment makes it easier to reason about dereferences being safe.