### PR TITLE
Update to a new nightly version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         arch: [arm, arm64, ppc64le, riscv64, x86_64]
         toolchain: [gcc, clang, llvm]
         config: [debug, release]
-        rustc: [2021-02-20]
+        rustc: [2021-05-29]
         output: [src] # [src, build]
         install: [rustup] # [rustup, standalone]
         sysroot: [common] # [common, custom]
@@ -37,7 +37,7 @@ jobs:
           - arch: arm64
             toolchain: gcc
             config: debug
-            rustc: 2021-02-20
+            rustc: 2021-05-29
             output: build
             install: rustup
             sysroot: custom
@@ -45,7 +45,7 @@ jobs:
           - arch: ppc64le
             toolchain: clang
             config: release
-            rustc: 2021-02-20
+            rustc: 2021-05-29
             output: build
             install: standalone
             sysroot: common
@@ -53,7 +53,7 @@ jobs:
           - arch: x86_64
             toolchain: llvm
             config: debug
-            rustc: 2021-02-20
+            rustc: 2021-05-29
             output: build
             install: standalone
             sysroot: custom

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -24,15 +24,12 @@ rustc
 *****
 
 A recent *nightly* Rust toolchain (with, at least, ``rustc``) is required,
-e.g. ``nightly-2021-02-20``. Our goal is to use a stable toolchain as soon
+e.g. ``nightly-2021-05-29``. Our goal is to use a stable toolchain as soon
 as possible, but for the moment we depend on a handful of nightly features.
 
 If you are using ``rustup``, run::
 
-    rustup default nightly-2021-02-20
-
-Please avoid the very latest nightlies (>= nightly-2021-03-05) until
-https://github.com/Rust-for-Linux/linux/issues/135 is resolved.
+    rustup default nightly-2021-05-29
 
 Otherwise, fetch a standalone installer or install ``rustup`` from:
 

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -16,7 +16,7 @@
     allocator_api,
     alloc_error_handler,
     associated_type_defaults,
-    const_fn,
+    const_fn_trait_bound,
     const_mut_refs,
     const_panic,
     const_raw_ptr_deref,

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 #![feature(allocator_api, global_asm)]
-#![feature(test)]
+#![feature(bench_black_box)]
 
 use kernel::prelude::*;
 


### PR DESCRIPTION
Includes rust-lang/rust#83592 and rust-lang/rust#85276 which were needed
to build correctly again after rustc's upgrade to LLVM 12.

Fixes https://github.com/Rust-for-Linux/linux/issues/135.