### PR TITLE
rust-core/of: remove unnecessary explicit type annotation

### DIFF
--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -33,7 +33,7 @@ pub struct OfMatchTable(InnerTable);
 impl OfMatchTable {
     /// Creates a [`OfMatchTable`] from a single `compatible` string.
     pub fn new(compatible: &CStr<'static>) -> Result<Self> {
-        let tbl: InnerTable = Box::try_new([
+        let tbl = Box::try_new([
             Self::new_of_device_id(compatible)?,
             bindings::of_device_id::default(),
         ])?;


### PR DESCRIPTION
If Rust is able to automatically infer a type, then an explicit type
annotation is unnecessary, and can be removed.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>