### PR TITLE
Improve safety with fallible version of `pointer::pin()`

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -47,6 +47,7 @@ pub mod file_operations;
 pub mod miscdev;
 pub mod pages;
 pub mod str;
+pub mod traits;
 
 pub mod linked_list;
 mod raw_list;

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -22,3 +22,5 @@ pub use super::{pr_alert, pr_cont, pr_crit, pr_emerg, pr_err, pr_info, pr_notice
 pub use super::static_assert;
 
 pub use super::{KernelModule, Result};
+
+pub use crate::traits::TryPin;

--- a/rust/kernel/traits.rs
+++ b/rust/kernel/traits.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Traits useful to drivers, and their implementations for common types.
+
+use core::{ops::Deref, pin::Pin};
+
+use alloc::{alloc::AllocError, sync::Arc};
+
+/// Trait which provides a fallible version of `pin()` for pointer types.
+///
+/// Common pointer types which implement a `pin()` method include [`Box`], [`Arc`] and [`Rc`].
+pub trait TryPin<P: Deref> {
+    /// Constructs a new `Pin<pointer<T>>`. If `T` does not implement [`Unpin`], then data
+    /// will be pinned in memory and unable to be moved. An error will be returned
+    /// if allocation fails.
+    fn try_pin(data: P::Target) -> core::result::Result<Pin<P>, AllocError>;
+}
+
+impl<T> TryPin<Arc<T>> for Arc<T> {
+    fn try_pin(data: T) -> core::result::Result<Pin<Arc<T>>, AllocError> {
+        // SAFETY: the data `T` is exposed only through a `Pin<Arc<T>>`, which
+        // does not allow data to move out of the `Arc`. Therefore it can
+        // never be moved.
+        Ok(unsafe { Pin::new_unchecked(Arc::try_new(data)?) })
+    }
+}


### PR DESCRIPTION
Introduce a fallible version of `pointer::pin()`, called `try_pin()`, which should improve safety by moving the `unsafe` block from the point where the pinned pointer is created, to a library function.

**I am not sure I understand pinning properly yet, please review carefully.**