### PR TITLE
Printk improvements

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -92,7 +92,7 @@ pub use crate::types::{Mode, ScopeGuard};
 pub const PAGE_SIZE: usize = 1 << bindings::PAGE_SHIFT;
 
 /// Prefix to appear before log messages printed from within the kernel crate.
-const __LOG_PREFIX: &[u8] = b"rust_kernel\0";
+const __LOG_PREFIX: &str::CStr = c_str!("rust_kernel");
 
 /// The top level entrypoint to implementing a kernel module.
 ///

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -26,3 +26,7 @@ pub use super::static_assert;
 pub use super::{Error, KernelModule, Result};
 
 pub use crate::traits::TryPin;
+
+// Default log prefix to none so crates without `module!` can use printk macros.
+#[doc(hidden)]
+pub const __LOG_PREFIX: () = ();

--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -577,7 +577,7 @@ pub fn module(ts: TokenStream) -> TokenStream {
             /// The module name.
             ///
             /// Used by the printing macros, e.g. [`info!`].
-            const __LOG_PREFIX: &[u8] = b\"{name}\\0\";
+            const __LOG_PREFIX: &kernel::str::CStr = kernel::c_str!(\"{name}\");
 
             static mut __MOD: Option<{type_}> = None;
 


### PR DESCRIPTION
Summary:
* Add a `LogLevel` struct for log levels, which can be used with `printk!` for runtime level specification
* ~~Add  `printk_once` support (just add `once, ` before the macro call)~~
* Add a `LogTarget` trait. This allows user to use `pr_info!(target: (), "blah")` to opt out the default prefix. In the future we can add `LogTarget` impl to `struct device` binding to support `dev_printk`.