### PR TITLE
Simple Rust driver that touches real hardware: PR 3/6

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -8,6 +8,7 @@
 use alloc::boxed::Box;
 use core::pin::Pin;
 use kernel::of::OfMatchTable;
+use kernel::platdev::PlatformDriver;
 use kernel::prelude::*;
 use kernel::{c_str, platdev};
 
@@ -19,6 +20,20 @@ module! {
     license: b"GPL v2",
 }
 
+struct RngDriver;
+
+impl PlatformDriver for RngDriver {
+    fn probe(device_id: i32) -> Result {
+        pr_info!("probing discovered hwrng with id {}\n", device_id);
+        Ok(())
+    }
+
+    fn remove(device_id: i32) -> Result {
+        pr_info!("removing hwrng with id {}\n", device_id);
+        Ok(())
+    }
+}
+
 struct RngModule {
     _pdev: Pin<Box<platdev::Registration>>,
 }
@@ -27,7 +42,7 @@ impl KernelModule for RngModule {
     fn init() -> Result<Self> {
         let of_match_tbl = OfMatchTable::new(&c_str!("brcm,bcm2835-rng"))?;
 
-        let pdev = platdev::Registration::new_pinned(
+        let pdev = platdev::Registration::new_pinned::<RngDriver>(
             c_str!("bcm2835-rng-rust"),
             Some(of_match_tbl),
             &THIS_MODULE,


### PR DESCRIPTION
#### Simple Rust driver that touches real h/w: step 3 of 6

@alex and @ojeda suggested that #254 should be split into smaller PRs, so they can be reviewed and merged individually.

Roadmap:

- [x] platform_device
- [x] devicetree (of) matching
- [ ] **probe (you are here)**
- [ ] DrvData
- [ ] regmap/iomem
- [ ] finally the actual hwrng driver