### PR TITLE
Remove `pr_cont` from prelude

### DIFF
--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -17,7 +17,7 @@ pub use super::build_assert;
 
 pub use module::{module, module_misc_device};
 
-pub use super::{pr_alert, pr_cont, pr_crit, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
+pub use super::{pr_alert, pr_crit, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
 
 pub use super::static_assert;
 

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -5,6 +5,7 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
+use kernel::pr_cont;
 use kernel::prelude::*;
 
 module! {


### PR DESCRIPTION
`pr_cont` is a discouraged feature. While we still support it in
print.rs, remove it from the prelude so it's less likely to get used.