### PR TITLE
Simple Rust driver that touches real hardware: PR 4/6

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -7,10 +7,16 @@
 
 use alloc::boxed::Box;
 use core::pin::Pin;
-use kernel::of::OfMatchTable;
-use kernel::platdev::PlatformDriver;
-use kernel::prelude::*;
-use kernel::{c_str, platdev};
+use kernel::{
+    file::File,
+    file_operations::{FileOpener, FileOperations},
+    io_buffer::IoBufferWriter,
+    miscdev,
+    of::OfMatchTable,
+    platdev::PlatformDriver,
+    prelude::*,
+    {c_str, platdev},
+};
 
 module! {
     type: RngModule,
@@ -20,15 +26,41 @@ module! {
     license: b"GPL v2",
 }
 
+struct RngDevice;
+
+impl FileOpener<()> for RngDevice {
+    fn open(_state: &()) -> Result<Self::Wrapper> {
+        Ok(Box::try_new(RngDevice)?)
+    }
+}
+
+impl FileOperations for RngDevice {
+    kernel::declare_file_operations!(read);
+
+    fn read<T: IoBufferWriter>(&self, _: &File, data: &mut T, offset: u64) -> Result<usize> {
+        // Succeed if the caller doesn't provide a buffer or if not at the start.
+        if data.is_empty() || offset != 0 {
+            return Ok(0);
+        }
+
+        data.write(&0_u32)?;
+        Ok(4)
+    }
+}
+
 struct RngDriver;
 
 impl PlatformDriver for RngDriver {
-    fn probe(device_id: i32) -> Result {
+    type DrvData = Pin<Box<miscdev::Registration<()>>>;
+
+    fn probe(device_id: i32) -> Result<Self::DrvData> {
         pr_info!("probing discovered hwrng with id {}\n", device_id);
-        Ok(())
+        let drv_data =
+            miscdev::Registration::new_pinned::<RngDevice>(c_str!("rust_hwrng"), None, ())?;
+        Ok(drv_data)
     }
 
-    fn remove(device_id: i32) -> Result {
+    fn remove(device_id: i32, _drv_data: Self::DrvData) -> Result {
         pr_info!("removing hwrng with id {}\n", device_id);
         Ok(())
     }

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -9,6 +9,7 @@
 #include <linux/uio.h>
 #include <linux/errname.h>
 #include <linux/mutex.h>
+#include <linux/platform_device.h>
 
 void rust_helper_BUG(void)
 {
@@ -129,6 +130,21 @@ void rust_helper_mutex_lock(struct mutex *lock)
 	mutex_lock(lock);
 }
 EXPORT_SYMBOL_GPL(rust_helper_mutex_lock);
+
+void *
+rust_helper_platform_get_drvdata(const struct platform_device *pdev)
+{
+	return platform_get_drvdata(pdev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_platform_get_drvdata);
+
+void
+rust_helper_platform_set_drvdata(struct platform_device *pdev,
+				 void *data)
+{
+	return platform_set_drvdata(pdev, data);
+}
+EXPORT_SYMBOL_GPL(rust_helper_platform_set_drvdata);
 
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust


### PR DESCRIPTION
#### Simple Rust driver that touches real h/w: step 4 of 6

@alex and @ojeda suggested that #254 should be split into smaller PRs, so they can be reviewed and merged individually.

Roadmap:

- [x] platform_device
- [x] devicetree (of) matching
- [x] probe
- [ ] **DrvData (you are here)**
- [ ] regmap/iomem
- [ ] finally the actual hwrng driver