### PR TITLE
binder: Store node flags on creation.

### DIFF
--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -212,13 +212,14 @@ pub(crate) struct Node {
     pub(crate) global_id: u64,
     ptr: usize,
     cookie: usize,
+    pub(crate) flags: u32,
     pub(crate) owner: Ref<Process>,
     inner: LockedBy<NodeInner, Mutex<ProcessInner>>,
     links: Links<dyn DeliverToRead>,
 }
 
 impl Node {
-    pub(crate) fn new(ptr: usize, cookie: usize, owner: Ref<Process>) -> Self {
+    pub(crate) fn new(ptr: usize, cookie: usize, flags: u32, owner: Ref<Process>) -> Self {
         static NEXT_ID: AtomicU64 = AtomicU64::new(1);
         let inner = LockedBy::new(
             &owner.inner,
@@ -232,6 +233,7 @@ impl Node {
             global_id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
             ptr,
             cookie,
+            flags,
             owner,
             inner,
             links: Links::new(),

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -389,7 +389,10 @@ impl Thread {
                     // SAFETY: The type is `BINDER_TYPE_{WEAK_}BINDER`, so `binder` is populated.
                     let ptr = unsafe { obj.__bindgen_anon_1.binder } as _;
                     let cookie = obj.cookie as _;
-                    Ok(self.process.get_node(ptr, cookie, strong, Some(self))?)
+                    let flags = obj.flags as _;
+                    Ok(self
+                        .process
+                        .get_node(ptr, cookie, flags, strong, Some(self))?)
                 })?;
             }
             bindings::BINDER_TYPE_WEAK_HANDLE | bindings::BINDER_TYPE_HANDLE => {


### PR DESCRIPTION
We'll need these flags to determine if a node allows file descriptors to
be transferred through them.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>