### PR TITLE
binder: Export more constants via the `defs` module.

### DIFF
--- a/drivers/android/allocation.rs
+++ b/drivers/android/allocation.rs
@@ -5,6 +5,7 @@ use core::mem::{size_of, MaybeUninit};
 use kernel::{bindings, pages::Pages, prelude::*, user_ptr::UserSlicePtrReader, Error};
 
 use crate::{
+    defs::*,
     node::NodeRef,
     process::{AllocationInfo, Process},
     thread::{BinderError, BinderResult},
@@ -117,9 +118,9 @@ impl<'a> Allocation<'a> {
         let header = view.read::<bindings::binder_object_header>(offset)?;
         // TODO: Handle other types.
         match header.type_ {
-            bindings::BINDER_TYPE_WEAK_BINDER | bindings::BINDER_TYPE_BINDER => {
+            BINDER_TYPE_WEAK_BINDER | BINDER_TYPE_BINDER => {
                 let obj = view.read::<bindings::flat_binder_object>(offset)?;
-                let strong = header.type_ == bindings::BINDER_TYPE_BINDER;
+                let strong = header.type_ == BINDER_TYPE_BINDER;
                 // SAFETY: The type is `BINDER_TYPE_{WEAK_}BINDER`, so the `binder` field is
                 // populated.
                 let ptr = unsafe { obj.__bindgen_anon_1.binder } as usize;
@@ -127,9 +128,9 @@ impl<'a> Allocation<'a> {
                 self.process.update_node(ptr, cookie, strong, false);
                 Ok(())
             }
-            bindings::BINDER_TYPE_WEAK_HANDLE | bindings::BINDER_TYPE_HANDLE => {
+            BINDER_TYPE_WEAK_HANDLE | BINDER_TYPE_HANDLE => {
                 let obj = view.read::<bindings::flat_binder_object>(offset)?;
-                let strong = header.type_ == bindings::BINDER_TYPE_HANDLE;
+                let strong = header.type_ == BINDER_TYPE_HANDLE;
                 // SAFETY: The type is `BINDER_TYPE_{WEAK_}HANDLE`, so the `handle` field is
                 // populated.
                 let handle = unsafe { obj.__bindgen_anon_1.handle } as _;
@@ -203,9 +204,9 @@ impl<'a> AllocationView<'a> {
             let newobj = bindings::flat_binder_object {
                 hdr: bindings::binder_object_header {
                     type_: if strong {
-                        bindings::BINDER_TYPE_BINDER
+                        BINDER_TYPE_BINDER
                     } else {
-                        bindings::BINDER_TYPE_WEAK_BINDER
+                        BINDER_TYPE_WEAK_BINDER
                     },
                 },
                 flags: obj.flags,
@@ -228,9 +229,9 @@ impl<'a> AllocationView<'a> {
             let newobj = bindings::flat_binder_object {
                 hdr: bindings::binder_object_header {
                     type_: if strong {
-                        bindings::BINDER_TYPE_HANDLE
+                        BINDER_TYPE_HANDLE
                     } else {
-                        bindings::BINDER_TYPE_WEAK_HANDLE
+                        BINDER_TYPE_WEAK_HANDLE
                     },
                 },
                 flags: obj.flags,

--- a/drivers/android/defs.rs
+++ b/drivers/android/defs.rs
@@ -51,6 +51,13 @@ pub_no_prefix!(
     BC_DEAD_BINDER_DONE
 );
 
+pub_no_prefix!(transaction_flags_, TF_ONE_WAY, TF_ACCEPT_FDS);
+
+pub(crate) use bindings::{
+    BINDER_TYPE_BINDER, BINDER_TYPE_FD, BINDER_TYPE_HANDLE, BINDER_TYPE_WEAK_BINDER,
+    BINDER_TYPE_WEAK_HANDLE, FLAT_BINDER_FLAG_ACCEPTS_FDS,
+};
+
 macro_rules! decl_wrapper {
     ($newname:ident, $wrapped:ty) => {
         #[derive(Copy, Clone, Default)]

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -383,8 +383,8 @@ impl Thread {
         let header = view.read::<bindings::binder_object_header>(offset)?;
         // TODO: Handle other types.
         match header.type_ {
-            bindings::BINDER_TYPE_WEAK_BINDER | bindings::BINDER_TYPE_BINDER => {
-                let strong = header.type_ == bindings::BINDER_TYPE_BINDER;
+            BINDER_TYPE_WEAK_BINDER | BINDER_TYPE_BINDER => {
+                let strong = header.type_ == BINDER_TYPE_BINDER;
                 view.transfer_binder_object(offset, strong, |obj| {
                     // SAFETY: The type is `BINDER_TYPE_{WEAK_}BINDER`, so `binder` is populated.
                     let ptr = unsafe { obj.__bindgen_anon_1.binder } as _;
@@ -392,8 +392,8 @@ impl Thread {
                     Ok(self.process.get_node(ptr, cookie, strong, Some(self))?)
                 })?;
             }
-            bindings::BINDER_TYPE_WEAK_HANDLE | bindings::BINDER_TYPE_HANDLE => {
-                let strong = header.type_ == bindings::BINDER_TYPE_HANDLE;
+            BINDER_TYPE_WEAK_HANDLE | BINDER_TYPE_HANDLE => {
+                let strong = header.type_ == BINDER_TYPE_HANDLE;
                 view.transfer_binder_object(offset, strong, |obj| {
                     // SAFETY: The type is `BINDER_TYPE_{WEAK_}HANDLE`, so `handle` is populated.
                     let handle = unsafe { obj.__bindgen_anon_1.handle } as _;
@@ -615,7 +615,7 @@ impl Thread {
             match reader.read::<u32>()? {
                 BC_TRANSACTION => {
                     let tr = reader.read::<BinderTransactionData>()?;
-                    if tr.flags & bindings::transaction_flags_TF_ONE_WAY != 0 {
+                    if tr.flags & TF_ONE_WAY != 0 {
                         self.transaction(&tr, Self::oneway_transaction_inner)
                     } else {
                         self.transaction(&tr, Self::transaction_inner)

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -3,7 +3,7 @@
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, Ordering};
 use kernel::{
-    bindings, io_buffer::IoBufferWriter, linked_list::Links, prelude::*, sync::Ref,
+    io_buffer::IoBufferWriter, linked_list::Links, prelude::*, sync::Ref,
     user_ptr::UserSlicePtrWriter,
 };
 
@@ -179,7 +179,7 @@ impl DeliverToRead for Transaction {
 
         // When this is not a reply and not an async transaction, update `current_transaction`. If
         // it's a reply, `current_transaction` has already been updated appropriately.
-        if self.node_ref.is_some() && tr.flags & bindings::transaction_flags_TF_ONE_WAY == 0 {
+        if self.node_ref.is_some() && tr.flags & TF_ONE_WAY == 0 {
             thread.set_current_transaction(self);
         }
 


### PR DESCRIPTION
This to reduce the usage of the `bindings` module.

Introducing TF_ACCEPT_FDS, FLAT_BINDER_FLAG_ACCEPTS_FDS, and
BINDER_TYPE_FD. They will be used in a subsequent commit that adds
support for transferring FDs.

No behaviour change is intended with this PR.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>