### PR TITLE
Prevent bindgen from generating `#[derive(Debug)]`

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -91,6 +91,7 @@ quiet_cmd_bindgen = BINDGEN $@
       cmd_bindgen = \
 	$(BINDGEN) $< $(shell grep -v '^\#\|^$$' $(srctree)/rust/bindgen_parameters) \
 		--use-core --with-derive-default --ctypes-prefix c_types \
+		--no-debug '.*' \
 		--size_t-is-usize -o $@ -- $(bindgen_c_flags_final) -DMODULE
 
 $(objtree)/rust/bindings_generated.rs: $(srctree)/rust/kernel/bindings_helper.h \


### PR DESCRIPTION
Bindgen generates `#[derive(Debug)]` for all bindings by default.
We never use these, and probably it didn't make sense to use them
at all. But as we currently do not have LTO enabled, and all the
bindings are exported via `pub mod bindings`, these `Debug`
implementations take a lot of space.

On my config this saves 400 KB of space:

```
   text	   data	    bss	    dec	    hex	filename
6388276	2284324	 292872	8965472	 88cd60	vmlinux (with `Debug`)
6079475	2200836	 292872	8573183	 82d0ff	vmlinux (without `Debug`)
```

Discovered by a tiny static analysis tool that I am writing :)