### PR TITLE
Add `ScopeGuard` and use it in Binder.

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -77,7 +77,7 @@ pub mod user_ptr;
 pub use build_error::build_error;
 
 pub use crate::error::{Error, Result};
-pub use crate::types::Mode;
+pub use crate::types::{Mode, ScopeGuard};
 
 /// Page size defined in terms of the `PAGE_SHIFT` macro from C.
 ///


### PR DESCRIPTION
This is in preparation for introducing additional error paths that
require sending an error reply to the transaction issuer, but return a
success result to the function caller.