### PR TITLE
follow conventions for to_* methods

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -62,7 +62,7 @@ impl Error {
     }
 
     /// Returns the kernel error code.
-    pub fn to_kernel_errno(&self) -> c_types::c_int {
+    pub fn to_kernel_errno(self) -> c_types::c_int {
         self.0
     }
 }


### PR DESCRIPTION
`Error` is `Copy`, so no changes are required to callers

This becomes a clippy warning in https://github.com/Rust-for-Linux/linux/pull/288