### PR TITLE
Use zero-cost method to construct `Error`s

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -295,4 +295,38 @@ pub(crate) unsafe fn from_kernel_int_result(retval: c_types::c_int) -> Result {
     }
     Ok(())
 }
+
+/// Transform a kernel integer result to a [`Result<c_types::c_uint>`].
+///
+/// Some kernel C API functions return a result in the form of an integer:
+/// zero or positive if ok, a negative errno on error. This function converts
+/// such a return value into an idiomatic [`Result<c_types::c_uint>`].
+///
+/// Use this function when the C function returns a useful, positive value
+/// on success, or negative on error. If the C function only returns 0 on
+/// success, use [`from_kernel_int_result`] instead.
+///
+/// # Safety
+///
+/// `retval` must be non-negative or a valid negative errno (i.e. `retval` must
+/// be in `[-MAX_ERRNO..]`).
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// let fd = unsafe { bindings::get_unused_fd_flags(flags) };
+/// // SAFETY: `bindings::get_unused_fd_flags()` returns a non-negative
+/// // `fd` on success, or a valid negative `errno` on error.
+/// let fd = unsafe { from_kernel_int_result_uint(fd)? };
+/// ```
+pub(crate) unsafe fn from_kernel_int_result_uint(
+    retval: c_types::c_int,
+) -> Result<c_types::c_uint> {
+    if retval < 0 {
+        // SAFETY: This condition together with the function precondition
+        // guarantee that `errno` is a valid negative `errno`.
+        return Err(unsafe { Error::from_kernel_errno_unchecked(retval) });
+    }
+    // CAST: a non-negative `c_types::c_int` always fits in a `c_types::c_uint`.
+    Ok(retval as c_types::c_uint)
 }

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -64,6 +64,8 @@ impl Error {
     ///
     /// It is a bug to pass an out-of-range `errno`. `EINVAL` would
     /// be returned in such a case.
+    // TODO: remove `dead_code` marker once an in-kernel client is available.
+    #[allow(dead_code)]
     pub(crate) fn from_kernel_errno(errno: c_types::c_int) -> Error {
         if errno < -(bindings::MAX_ERRNO as i32) || errno >= 0 {
             // TODO: make it a `WARN_ONCE` once available.

--- a/rust/kernel/platdev.rs
+++ b/rust/kernel/platdev.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     bindings, c_types,
-    error::{Error, Result},
+    error::{from_kernel_int_result, Error, Result},
     from_kernel_result,
     of::OfMatchTable,
     str::CStr,
@@ -83,8 +83,10 @@ impl Registration {
         //       `bindings::platform_driver_unregister()`, or
         //      - null.
         let ret = unsafe { bindings::__platform_driver_register(&mut this.pdrv, module.0) };
-        if ret < 0 {
-            return Err(Error::from_kernel_errno(ret));
+        // SAFETY: `bindings::__platform_driver_register()` returns zero on
+        // success, or a valid negative `errno` on error.
+        unsafe {
+            from_kernel_int_result(ret)?;
         }
         this.registered = true;
         Ok(())


### PR DESCRIPTION
When constructing an `Error`, avoid the runtime check which verifies the `errno` invariant, by:
- trusting that negative return values from certain kernel C functions always satisfy the invariant, and
- using pre-constructed `const` `Error`s if an error return is needed in Rust code.

For the time being, no explicit `Error` invariant runtime checks are used or required anywhere, so we can eliminate the function which carries out the check.