### PR TITLE
GitHub: add some issue template categories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,54 @@
+---
+name: Bug
+about: Related to runtime bugs, panics, warnings...
+labels: bug
+---
+**Description**
+<!-- What the bug is and/or how to reproduce it.
+
+Some common details that are typically useful to know are below -- please fill/remove as needed.
+
+Other details that may be useful to know, if relevant:
+  - Deterministic or not?
+  - Does it happen under QEMU, a VM, a real machine, etc.?
+-->
+
+
+**Architecture(s)**
+  - `arm`
+  - `arm64`
+  - `ppc64le`
+  - `riscv64`
+  - `x86_64`
+
+
+**Toolchain versions**
+  - `rustc`:
+  - `bindgen`:
+  - LLVM/Clang:
+  - GCC:
+  - QEMU:
+
+
+**Kernel log**
+<details><summary><strong>Kernel log</strong></summary>
+<p>
+
+```text
+Paste it here -- feel free to reduce it to the relevant parts.
+```
+
+</p>
+</details>
+
+
+**Kernel config**
+<details><summary><strong>Kernel config</strong></summary>
+<p>
+
+```text
+Paste it here -- feel free to reduce it to the relevant parts.
+```
+
+</p>
+</details>

--- a/.github/ISSUE_TEMPLATE/building.md
+++ b/.github/ISSUE_TEMPLATE/building.md
@@ -1,0 +1,5 @@
+---
+name: Building
+about: Related to building the kernel, `make`, `Kbuild`, `Kconfig` options...
+labels: • kbuild
+---

--- a/.github/ISSUE_TEMPLATE/code.md
+++ b/.github/ISSUE_TEMPLATE/code.md
@@ -1,0 +1,4 @@
+---
+name: Code
+about: Related to code, `rust/`, `drivers/`...
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: true
 
 contact_links:
-  - name: General discussions, help, feedback, etc.
+  - name: Questions, help, feedback, etc.
     url: https://github.com/Rust-for-Linux/linux/blob/rust/README.md
     about: Please use the mailing list or the Zulip chat.
 
-  - name: Report a security vulnerability
+  - name: Security vulnerability
     url: https://www.kernel.org/doc/html/latest/admin-guide/security-bugs.html
     about: If the code is already in mainline, read this link.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,5 @@
+---
+name: Documentation
+about: Related to documentation, `rustdoc`, `Documentation/rust/`, `samples/`, typos...
+labels: • docs
+---


### PR DESCRIPTION
The blank issue link only appears at the bottom, so we need to have
some choices added. Let's take the chance to create a few.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>