### PR TITLE
rust: globally warn on `unsafe_op_in_unsafe_fn`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,7 +515,8 @@ KBUILD_RUSTC_TARGET := $(srctree)/arch/$(SRCARCH)/rust/target.json
 KBUILD_RUSTCFLAGS := --emit=dep-info,obj,metadata --edition=2018 \
 		     -Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
 		     -Cforce-unwind-tables=n -Ccodegen-units=1 \
-		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0
+		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
+		     -W unsafe_op_in_unsafe_fn
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
 KBUILD_RUSTCFLAGS_KERNEL :=


### PR DESCRIPTION
This includes non-`rust/` code.

As soon as the warnings are cleaned up, we can move it to a hard error.

Fixes: https://github.com/Rust-for-Linux/linux/issues/285

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>