### PR TITLE
rust: add unsafe annotations in of.rs and types.rs

### DIFF
--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -69,6 +69,7 @@ impl PointerWrapper for OfMatchTable {
     }
 
     unsafe fn from_pointer(p: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`InnerTable::into_pointer()`].
         Self(unsafe { InnerTable::from_pointer(p) })
     }
 }

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -54,6 +54,7 @@ impl<T> PointerWrapper for Box<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
         unsafe { Box::from_raw(ptr as _) }
     }
 }
@@ -64,6 +65,7 @@ impl<T: RefCounted> PointerWrapper for Ref<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
         unsafe { Ref::from_raw(ptr as _) }
     }
 }
@@ -74,6 +76,7 @@ impl<T> PointerWrapper for Arc<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
         unsafe { Arc::from_raw(ptr as _) }
     }
 }
@@ -87,7 +90,8 @@ impl<T: PointerWrapper + Deref> PointerWrapper for Pin<T> {
     }
 
     unsafe fn from_pointer(p: *const c_types::c_void) -> Self {
-        // TODO: Review: SAFETY: The object was originally pinned.
+        // SAFETY: The object was originally pinned.
+        // The passed pointer comes from a previous call to `inner::into_pointer()`.
         unsafe { Pin::new_unchecked(T::from_pointer(p)) }
     }
 }


### PR DESCRIPTION
See #340

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>