### PR TITLE
rust/kernel: remove config `#ifdef` in Error.rs file

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -7,6 +7,7 @@
 #include <linux/gfp.h>
 #include <linux/highmem.h>
 #include <linux/uio.h>
+#include <linux/errname.h>
 
 void rust_helper_BUG(void)
 {
@@ -116,6 +117,11 @@ long rust_helper_ptr_err(__force const void *ptr)
 	return PTR_ERR(ptr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_ptr_err);
+
+const char *rust_helper_errname(int err)
+{
+	return errname(err);
+}
 
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -98,11 +98,11 @@ impl Error {
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        extern "C" {
+            fn rust_helper_errname(err: c_types::c_int) -> *const c_types::c_char;
+        }
         // SAFETY: FFI call.
-        #[cfg(CONFIG_SYMBOLIC_ERRNAME)]
-        let name = unsafe { crate::bindings::errname(-self.0) };
-        #[cfg(not(CONFIG_SYMBOLIC_ERRNAME))]
-        let name: *const c_types::c_char = core::ptr::null();
+        let name = unsafe { rust_helper_errname(-self.0) };
 
         if name.is_null() {
             // Print out number if no name can be found.


### PR DESCRIPTION
The use of `#ifdef CONFIG_` statements in .c/.rs files is deprecated:
it makes the code much more unmaintainable over time. See:
https://lkml.org/lkml/2021/6/3/564

Use a Rust-C helper instead to leverage automatic `CONFIG` selection
in C kernel headers.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>