### PR TITLE
[RFC] A fallible from_kernel_errno with Result<Error> return

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -62,21 +62,16 @@ impl Error {
 
     /// Creates an [`Error`] from a kernel error code.
     ///
-    /// It is a bug to pass an out-of-range `errno`. `EINVAL` would
+    /// It is a bug to pass an out-of-range `errno`. Err(`EINVAL`) would
     /// be returned in such a case.
-    pub(crate) fn from_kernel_errno(errno: c_types::c_int) -> Error {
+    pub(crate) fn from_kernel_errno(errno: c_types::c_int) -> Result<Error> {
         if errno < -(bindings::MAX_ERRNO as i32) || errno >= 0 {
-            // TODO: make it a `WARN_ONCE` once available.
-            crate::pr_warn!(
-                "attempted to create `Error` with out of range `errno`: {}",
-                errno
-            );
-            return Error::EINVAL;
+            return Err(Error::EINVAL);
         }
 
         // INVARIANT: the check above ensures the type invariant
         // will hold.
-        Error(errno)
+        Ok(Error(errno))
     }
 
     /// Creates an [`Error`] from a kernel error code.


### PR DESCRIPTION
Currently, `from_kernel_errno()` is an infallible function acting as a constructor for Error. In order to achieve its type invariant, We add a check in it which will prompt a warning and return `Error::EINVL` when `errno` given is invalid.

While this approach ensures type invariant, it brings great ambiguities. When `Error::EINVL` is returned, the caller has no way to recognize whether it is a valid `errno` coming from the kernel or an error issued by the check. This tricky behavior may confuse developers and introduce subtle bugs. Since Error will be used in all respects of the kernel, It's definitely not
a sound solution.

This RFC proposes that we make `from_kernel_errno()` return a `Result<Error>`. Thus, we have an explicit, clear, and fallible version of `from_kernel_errno()` by which callers are able to know what really happened behind the scene. And it also provides certain flexibility. We pass the power to callers, they can decide how to deal with invalid `errno` case by case.

Note:

- The commit is a proposal that can't be compiled at this moment. Because a few other codes rely on it, they need to be changed as well.
- Another approach @ojeda mentioned [here](https://github.com/Rust-for-Linux/linux/pull/324#issuecomment-853703108) is to propose upstream to have a dedicated `errno` (e.g. `EBUG` or `EIKE`). This is also viable, however:  1) it needs interaction with upstream 2) `from_kernel_errno` is still an infallible function that can fail.


Reference:
#324 #283 

May influence:
#335 