### PR TITLE
rust: generate bindings for helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1834,6 +1834,7 @@ rustfmt:
 		-o -path $(abs_objtree)/rust/test -prune \
 		| grep -Fv $(abs_srctree)/rust/alloc \
 		| grep -Fv $(abs_objtree)/rust/test \
+		| grep -Fv generated \
 		| xargs $(RUSTFMT) $(rustfmt_flags)
 
 rustfmtcheck: rustfmt_flags = --check

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 
 bindings_generated.rs
+bindings_helpers_generated.rs
 exports_*_generated.h
 doc/
 test/

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -5,7 +5,7 @@ extra-$(CONFIG_RUST) += exports_core_generated.h
 
 extra-$(CONFIG_RUST) += libmacros.so
 
-extra-$(CONFIG_RUST) += bindings_generated.rs
+extra-$(CONFIG_RUST) += bindings_generated.rs bindings_helpers_generated.rs
 obj-$(CONFIG_RUST) += alloc.o kernel.o
 extra-$(CONFIG_RUST) += exports_alloc_generated.h exports_kernel_generated.h
 
@@ -30,7 +30,7 @@ endif
 
 quiet_cmd_rustdoc = RUSTDOC $(if $(rustdoc_host),H, ) $<
       cmd_rustdoc = \
-	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
+	OBJTREE=$(abspath $(objtree)) \
 	$(RUSTDOC) $(if $(rustdoc_host),,$(rust_cross_flags)) \
 		$(filter-out -Cpanic=abort, $(filter-out --emit=%, $(rust_flags))) \
 		$(rustc_target_flags) -L $(objtree)/rust \
@@ -73,12 +73,13 @@ rustdoc-kernel: private rustc_target_flags = --extern alloc \
     --extern macros=$(objtree)/rust/libmacros.so
 rustdoc-kernel: $(srctree)/rust/kernel/lib.rs rustdoc-core \
     rustdoc-macros rustdoc-compiler_builtins rustdoc-alloc \
-    $(objtree)/rust/libmacros.so $(objtree)/rust/bindings_generated.rs FORCE
+    $(objtree)/rust/libmacros.so $(objtree)/rust/bindings_generated.rs \
+    $(objtree)/rust/bindings_helpers_generated.rs FORCE
 	$(call if_changed,rustdoc)
 
 quiet_cmd_rustc_test_library = RUSTC TL $<
       cmd_rustc_test_library = \
-	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
+	OBJTREE=$(abspath $(objtree)) \
 	$(RUSTC) $(filter-out --sysroot=%, $(filter-out -Cpanic=abort, $(filter-out --emit=%, $(rust_flags)))) \
 		$(rustc_target_flags) --crate-type $(if $(rustc_test_library_proc),proc-macro,rlib) \
 		--out-dir $(objtree)/rust/test/ --cfg testlib \
@@ -95,7 +96,7 @@ rusttestlib-macros: $(srctree)/rust/macros/lib.rs rusttest-prepare FORCE
 
 quiet_cmd_rustdoc_test = RUSTDOC T $<
       cmd_rustdoc_test = \
-	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
+	OBJTREE=$(abspath $(objtree)) \
 	$(RUSTDOC) --test $(filter-out --sysroot=%, $(filter-out -Cpanic=abort, $(filter-out --emit=%, $(rust_flags)))) \
 		$(rustc_target_flags) $(rustdoc_test_target_flags) \
 		--sysroot $(objtree)/rust/test/sysroot $(rustdoc_test_quiet) \
@@ -107,7 +108,7 @@ quiet_cmd_rustdoc_test = RUSTDOC T $<
 # so for the moment we skip `-Cpanic=abort`.
 quiet_cmd_rustc_test = RUSTC T  $<
       cmd_rustc_test = \
-	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
+	OBJTREE=$(abspath $(objtree)) \
 	$(RUSTC) --test $(filter-out --sysroot=%, $(filter-out -Cpanic=abort, $(filter-out --emit=%, $(rust_flags)))) \
 		$(rustc_target_flags) --out-dir $(objtree)/rust/test \
 		--sysroot $(objtree)/rust/test/sysroot \
@@ -230,6 +231,19 @@ $(objtree)/rust/bindings_generated.rs: $(srctree)/rust/kernel/bindings_helper.h 
 	$(srctree)/rust/bindgen_parameters FORCE
 	$(call if_changed_dep,bindgen)
 
+quiet_cmd_bindgen_helper = BINDGEN $@
+      cmd_bindgen_helper = \
+	$(BINDGEN) $< --blacklist-type '.*' --whitelist-var '' \
+		--whitelist-function 'rust_helper_.*' \
+		--use-core --with-derive-default --ctypes-prefix c_types \
+		--no-debug '.*' \
+		--size_t-is-usize -o $@ -- $(bindgen_c_flags_final) \
+		-I$(objtree)/rust/ -DMODULE; \
+	sed -Ei 's/pub fn rust_helper_([a-zA-Z0-9_]*)/\#[link_name="rust_helper_\1"]\n    pub fn \1/g' $@
+
+$(objtree)/rust/bindings_helpers_generated.rs: $(srctree)/rust/helpers.c FORCE
+	$(call if_changed_dep,bindgen_helper)
+
 quiet_cmd_exports = EXPORTS $@
       cmd_exports = \
 	$(NM) -p --defined-only $< \
@@ -267,7 +281,7 @@ $(objtree)/rust/libmacros.so: $(srctree)/rust/macros/lib.rs \
 
 quiet_cmd_rustc_library = $(if $(skip_clippy),RUSTC,$(RUSTC_OR_CLIPPY_QUIET)) L $@
       cmd_rustc_library = \
-	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
+	OBJTREE=$(abspath $(objtree)) \
 	$(if $(skip_clippy),$(RUSTC),$(RUSTC_OR_CLIPPY)) \
 		$(rust_flags) $(rust_cross_flags) $(rustc_target_flags) \
 		--crate-type rlib --out-dir $(objtree)/rust/ -L $(objtree)/rust/ \
@@ -305,7 +319,8 @@ $(objtree)/rust/kernel.o: private rustc_target_flags = --extern alloc \
     --extern macros=$(objtree)/rust/libmacros.so
 $(objtree)/rust/kernel.o: $(srctree)/rust/kernel/lib.rs $(objtree)/rust/alloc.o \
     $(objtree)/rust/build_error.o \
-    $(objtree)/rust/libmacros.so $(objtree)/rust/bindings_generated.rs FORCE
+    $(objtree)/rust/libmacros.so $(objtree)/rust/bindings_generated.rs \
+    $(objtree)/rust/bindings_helpers_generated.rs FORCE
 	$(call if_changed_dep,rustc_library)
 
 # Targets that need to expand twice

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -13,7 +13,7 @@
 #include <linux/security.h>
 #include <asm/io.h>
 
-void rust_helper_BUG(void)
+__noreturn void rust_helper_BUG(void)
 {
 	BUG();
 }
@@ -91,8 +91,8 @@ void rust_helper_writeq(u64 value, volatile void __iomem *addr)
 EXPORT_SYMBOL_GPL(rust_helper_writeq);
 #endif
 
-void rust_helper_spin_lock_init(spinlock_t *lock, const char *name,
-				struct lock_class_key *key)
+void rust_helper___spin_lock_init(spinlock_t *lock, const char *name,
+				  struct lock_class_key *key)
 {
 #ifdef CONFIG_DEBUG_SPINLOCK
 	__spin_lock_init(lock, name, key);
@@ -100,7 +100,7 @@ void rust_helper_spin_lock_init(spinlock_t *lock, const char *name,
 	spin_lock_init(lock);
 #endif
 }
-EXPORT_SYMBOL_GPL(rust_helper_spin_lock_init);
+EXPORT_SYMBOL_GPL(rust_helper___spin_lock_init);
 
 void rust_helper_spin_lock(spinlock_t *lock)
 {
@@ -162,22 +162,23 @@ size_t rust_helper_copy_to_iter(const void *addr, size_t bytes, struct iov_iter 
 }
 EXPORT_SYMBOL_GPL(rust_helper_copy_to_iter);
 
-bool rust_helper_is_err(__force const void *ptr)
+bool rust_helper_IS_ERR(__force const void *ptr)
 {
 	return IS_ERR(ptr);
 }
-EXPORT_SYMBOL_GPL(rust_helper_is_err);
+EXPORT_SYMBOL_GPL(rust_helper_IS_ERR);
 
-long rust_helper_ptr_err(__force const void *ptr)
+long rust_helper_PTR_ERR(__force const void *ptr)
 {
 	return PTR_ERR(ptr);
 }
-EXPORT_SYMBOL_GPL(rust_helper_ptr_err);
+EXPORT_SYMBOL_GPL(rust_helper_PTR_ERR);
 
 const char *rust_helper_errname(int err)
 {
 	return errname(err);
 }
+EXPORT_SYMBOL_GPL(rust_helper_errname);
 
 void rust_helper_mutex_lock(struct mutex *lock)
 {
@@ -200,11 +201,11 @@ rust_helper_platform_set_drvdata(struct platform_device *pdev,
 }
 EXPORT_SYMBOL_GPL(rust_helper_platform_set_drvdata);
 
-refcount_t rust_helper_refcount_new(void)
+refcount_t rust_helper_REFCOUNT_INIT(int n)
 {
-	return (refcount_t)REFCOUNT_INIT(1);
+	return (refcount_t)REFCOUNT_INIT(n);
 }
-EXPORT_SYMBOL_GPL(rust_helper_refcount_new);
+EXPORT_SYMBOL_GPL(rust_helper_REFCOUNT_INIT);
 
 void rust_helper_refcount_inc(refcount_t *r)
 {

--- a/rust/kernel/bindings.rs
+++ b/rust/kernel/bindings.rs
@@ -8,8 +8,7 @@
 #![cfg_attr(test, allow(deref_nullptr))]
 #![cfg_attr(test, allow(unaligned_references))]
 #![cfg_attr(test, allow(unsafe_op_in_unsafe_fn))]
-
-#[allow(
+#![allow(
     clippy::all,
     non_camel_case_types,
     non_upper_case_globals,
@@ -17,10 +16,29 @@
     improper_ctypes,
     unsafe_op_in_unsafe_fn
 )]
+
 mod bindings_raw {
+    // Use glob import here to expose all helpers.
+    // Symbols defined within the module will take precedence to the glob import.
+    pub use super::bindings_helper::*;
     use crate::c_types;
-    include!(env!("RUST_BINDINGS_FILE"));
+    include!(concat!(env!("OBJTREE"), "/rust/bindings_generated.rs"));
 }
+
+// When both a directly exposed symbol and a helper exists for the same function,
+// the directly exposed symbol is preferred and the helper becomes dead code, so
+// ignore the warning here.
+#[allow(dead_code)]
+mod bindings_helper {
+    // Import the generated bindings for types.
+    use super::bindings_raw::*;
+    use crate::c_types;
+    include!(concat!(
+        env!("OBJTREE"),
+        "/rust/bindings_helpers_generated.rs"
+    ));
+}
+
 pub use bindings_raw::*;
 
 pub const GFP_KERNEL: gfp_t = BINDINGS_GFP_KERNEL;

--- a/rust/kernel/iov_iter.rs
+++ b/rust/kernel/iov_iter.rs
@@ -5,25 +5,11 @@
 //! C header: [`include/linux/uio.h`](../../../../include/linux/uio.h)
 
 use crate::{
-    bindings, c_types,
+    bindings,
     error::Error,
     io_buffer::{IoBufferReader, IoBufferWriter},
     Result,
 };
-
-extern "C" {
-    fn rust_helper_copy_to_iter(
-        addr: *const c_types::c_void,
-        bytes: usize,
-        i: *mut bindings::iov_iter,
-    ) -> usize;
-
-    fn rust_helper_copy_from_iter(
-        addr: *mut c_types::c_void,
-        bytes: usize,
-        i: *mut bindings::iov_iter,
-    ) -> usize;
-}
 
 /// Wraps the kernel's `struct iov_iter`.
 ///
@@ -70,7 +56,7 @@ impl IoBufferWriter for IovIter {
     }
 
     unsafe fn write_raw(&mut self, data: *const u8, len: usize) -> Result {
-        let res = unsafe { rust_helper_copy_to_iter(data as _, len, self.ptr) };
+        let res = unsafe { bindings::copy_to_iter(data as _, len, self.ptr) };
         if res != len {
             Err(Error::EFAULT)
         } else {
@@ -85,7 +71,7 @@ impl IoBufferReader for IovIter {
     }
 
     unsafe fn read_raw(&mut self, out: *mut u8, len: usize) -> Result {
-        let res = unsafe { rust_helper_copy_from_iter(out as _, len, self.ptr) };
+        let res = unsafe { bindings::copy_from_iter(out as _, len, self.ptr) };
         if res != len {
             Err(Error::EFAULT)
         } else {

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -232,10 +232,11 @@ macro_rules! container_of {
 #[cfg(not(any(testlib, test)))]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
-    extern "C" {
-        fn rust_helper_BUG() -> !;
-    }
     pr_emerg!("{}\n", info);
     // SAFETY: FFI call.
-    unsafe { rust_helper_BUG() };
+    unsafe { bindings::BUG() };
+    // Bindgen currently does not recognize `__noreturn` so `BUG` returns `()`
+    // instead of `!`.
+    // https://github.com/rust-lang/rust-bindgen/issues/2094
+    loop {}
 }

--- a/rust/kernel/platdev.rs
+++ b/rust/kernel/platdev.rs
@@ -29,19 +29,6 @@ pub struct Registration {
 // (it is fine for multiple threads to have a shared reference to it).
 unsafe impl Sync for Registration {}
 
-extern "C" {
-    #[allow(improper_ctypes)]
-    fn rust_helper_platform_get_drvdata(
-        pdev: *const bindings::platform_device,
-    ) -> *mut c_types::c_void;
-
-    #[allow(improper_ctypes)]
-    fn rust_helper_platform_set_drvdata(
-        pdev: *mut bindings::platform_device,
-        data: *mut c_types::c_void,
-    );
-}
-
 extern "C" fn probe_callback<P: PlatformDriver>(
     pdev: *mut bindings::platform_device,
 ) -> c_types::c_int {
@@ -52,7 +39,7 @@ extern "C" fn probe_callback<P: PlatformDriver>(
         let drv_data = drv_data.into_pointer() as *mut c_types::c_void;
         // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
         unsafe {
-            rust_helper_platform_set_drvdata(pdev, drv_data);
+            bindings::platform_set_drvdata(pdev, drv_data);
         }
         Ok(0)
     }
@@ -65,7 +52,7 @@ extern "C" fn remove_callback<P: PlatformDriver>(
         // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
         let device_id = unsafe { (*pdev).id };
         // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
-        let ptr = unsafe { rust_helper_platform_get_drvdata(pdev) };
+        let ptr = unsafe { bindings::platform_get_drvdata(pdev) };
         // SAFETY:
         //   - we allocated this pointer using `P::DrvData::into_pointer`,
         //     so it is safe to turn back into a `P::DrvData`.

--- a/rust/kernel/power.rs
+++ b/rust/kernel/power.rs
@@ -7,11 +7,6 @@
 use crate::{bindings, c_types, from_kernel_result, sync::Ref, types::PointerWrapper, Result};
 use core::{marker::PhantomData, ops::Deref};
 
-extern "C" {
-    #[allow(improper_ctypes)]
-    fn rust_helper_dev_get_drvdata(dev: *mut bindings::device) -> *mut c_types::c_void;
-}
-
 /// Corresponds to the kernel's `struct dev_pm_ops`.
 ///
 /// It is meant to be implemented by drivers that support power-management operations.
@@ -47,7 +42,7 @@ macro_rules! pm_callback {
         ) -> c_types::c_int {
             from_kernel_result! {
                 // SAFETY: `dev` is valid as it was passed in by the C portion.
-                let ptr = unsafe { rust_helper_dev_get_drvdata(dev) };
+                let ptr = unsafe { bindings::dev_get_drvdata(dev) };
                 // SAFETY: By the safety requirements of `OpsTable::build`, we know that `ptr` came
                 // from a previous call to `T::Data::into_pointer`.
                 let data = unsafe { T::Data::borrow(ptr) };

--- a/rust/kernel/rbtree.rs
+++ b/rust/kernel/rbtree.rs
@@ -16,14 +16,6 @@ use core::{
     ptr::{addr_of_mut, NonNull},
 };
 
-extern "C" {
-    fn rust_helper_rb_link_node(
-        node: *mut bindings::rb_node,
-        parent: *const bindings::rb_node,
-        rb_link: *mut *mut bindings::rb_node,
-    );
-}
-
 struct Node<K, V> {
     links: bindings::rb_node,
     key: K,
@@ -289,7 +281,7 @@ impl<K, V> RBTree<K, V> {
         // "forgot" it with `Box::into_raw`.
         // SAFETY: All pointers are non-null and valid (`*new_link` is null, but `new_link` is a
         // mutable reference).
-        unsafe { rust_helper_rb_link_node(node_links, parent, new_link) };
+        unsafe { bindings::rb_link_node(node_links, parent, new_link) };
 
         // SAFETY: All pointers are valid. `node` has just been inserted into the tree.
         unsafe { bindings::rb_insert_color(node_links, &mut self.root) };

--- a/rust/kernel/security.rs
+++ b/rust/kernel/security.rs
@@ -4,36 +4,13 @@
 //!
 //! C header: [`include/linux/security.h`](../../../../include/linux/security.h).
 
-use crate::{bindings, c_types, error::Error, file::File, task::Task, Result};
-
-extern "C" {
-    #[allow(improper_ctypes)]
-    fn rust_helper_security_binder_set_context_mgr(
-        mgr: *mut bindings::task_struct,
-    ) -> c_types::c_int;
-    #[allow(improper_ctypes)]
-    fn rust_helper_security_binder_transaction(
-        from: *mut bindings::task_struct,
-        to: *mut bindings::task_struct,
-    ) -> c_types::c_int;
-    #[allow(improper_ctypes)]
-    fn rust_helper_security_binder_transfer_binder(
-        from: *mut bindings::task_struct,
-        to: *mut bindings::task_struct,
-    ) -> c_types::c_int;
-    #[allow(improper_ctypes)]
-    fn rust_helper_security_binder_transfer_file(
-        from: *mut bindings::task_struct,
-        to: *mut bindings::task_struct,
-        file: *mut bindings::file,
-    ) -> c_types::c_int;
-}
+use crate::{bindings, error::Error, file::File, task::Task, Result};
 
 /// Calls the security modules to determine if the given task can become the manager of a binder
 /// context.
 pub fn binder_set_context_mgr(mgr: &Task) -> Result {
     // SAFETY: By the `Task` invariants, `mgr.ptr` is valid.
-    let ret = unsafe { rust_helper_security_binder_set_context_mgr(mgr.ptr) };
+    let ret = unsafe { bindings::security_binder_set_context_mgr(mgr.ptr) };
     if ret != 0 {
         Err(Error::from_kernel_errno(ret))
     } else {
@@ -45,7 +22,7 @@ pub fn binder_set_context_mgr(mgr: &Task) -> Result {
 /// task `to`.
 pub fn binder_transaction(from: &Task, to: &Task) -> Result {
     // SAFETY: By the `Task` invariants, `from.ptr` and `to.ptr` are valid.
-    let ret = unsafe { rust_helper_security_binder_transaction(from.ptr, to.ptr) };
+    let ret = unsafe { bindings::security_binder_transaction(from.ptr, to.ptr) };
     if ret != 0 {
         Err(Error::from_kernel_errno(ret))
     } else {
@@ -57,7 +34,7 @@ pub fn binder_transaction(from: &Task, to: &Task) -> Result {
 /// (owned by itself or other processes) to task `to` through a binder transaction.
 pub fn binder_transfer_binder(from: &Task, to: &Task) -> Result {
     // SAFETY: By the `Task` invariants, `from.ptr` and `to.ptr` are valid.
-    let ret = unsafe { rust_helper_security_binder_transfer_binder(from.ptr, to.ptr) };
+    let ret = unsafe { bindings::security_binder_transfer_binder(from.ptr, to.ptr) };
     if ret != 0 {
         Err(Error::from_kernel_errno(ret))
     } else {
@@ -70,7 +47,7 @@ pub fn binder_transfer_binder(from: &Task, to: &Task) -> Result {
 pub fn binder_transfer_file(from: &Task, to: &Task, file: &File) -> Result {
     // SAFETY: By the `Task` invariants, `from.ptr` and `to.ptr` are valid. Similarly, by the
     // `File` invariants, `file.ptr` is also valid.
-    let ret = unsafe { rust_helper_security_binder_transfer_file(from.ptr, to.ptr, file.ptr) };
+    let ret = unsafe { bindings::security_binder_transfer_file(from.ptr, to.ptr, file.ptr) };
     if ret != 0 {
         Err(Error::from_kernel_errno(ret))
     } else {

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -9,10 +9,6 @@ use super::{Guard, Lock, NeedsLockClass};
 use crate::{bindings, str::CStr, task::Task};
 use core::{cell::UnsafeCell, marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
 
-extern "C" {
-    fn rust_helper_init_wait(wq: *mut bindings::wait_queue_entry);
-}
-
 /// Safely initialises a [`CondVar`] with the given name, generating a new lock class.
 #[macro_export]
 macro_rules! condvar_init {
@@ -69,7 +65,7 @@ impl CondVar {
         let mut wait = MaybeUninit::<bindings::wait_queue_entry>::uninit();
 
         // SAFETY: `wait` points to valid memory.
-        unsafe { rust_helper_init_wait(wait.as_mut_ptr()) };
+        unsafe { bindings::init_wait(wait.as_mut_ptr()) };
 
         // SAFETY: Both `wait` and `wait_list` point to valid memory.
         unsafe {

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -20,8 +20,8 @@
 //! pr_info!("{}\n", *data.lock());
 //! ```
 
+use crate::bindings;
 use crate::str::CStr;
-use crate::{bindings, c_types};
 use core::pin::Pin;
 
 mod arc;
@@ -37,10 +37,6 @@ pub use guard::{Guard, Lock};
 pub use locked_by::LockedBy;
 pub use mutex::Mutex;
 pub use spinlock::SpinLock;
-
-extern "C" {
-    fn rust_helper_cond_resched() -> c_types::c_int;
-}
 
 /// Safely initialises an object that has an `init` function that takes a name and a lock class as
 /// arguments, examples of these are [`Mutex`] and [`SpinLock`]. Each of them also provides a more
@@ -80,5 +76,5 @@ pub trait NeedsLockClass {
 /// Reschedules the caller's task if needed.
 pub fn cond_resched() -> bool {
     // SAFETY: No arguments, reschedules `current` if needed.
-    unsafe { rust_helper_cond_resched() != 0 }
+    unsafe { bindings::cond_resched() != 0 }
 }

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -77,17 +77,15 @@ impl<T: ?Sized> NeedsLockClass for Mutex<T> {
     }
 }
 
-extern "C" {
-    fn rust_helper_mutex_lock(mutex: *mut bindings::mutex);
-}
-
 impl<T: ?Sized> Lock for Mutex<T> {
     type Inner = T;
     type GuardContext = ();
 
     fn lock_noguard(&self) {
         // SAFETY: `mutex` points to valid memory.
-        unsafe { rust_helper_mutex_lock(self.mutex.get()) };
+        unsafe {
+            bindings::mutex_lock(self.mutex.get());
+        }
     }
 
     unsafe fn unlock(&self, _: &mut ()) {


### PR DESCRIPTION
Helper functions are now only compiled if the wrapped function is not
made directly available via bindgen. For the compiled helper functions,
bindings for them are automatically generated via a second invocation
to bindgen, and the corresponding binding will have its `rust_helper_`
prefix removed, so Rust code can call `bindings::foo` regardless
whether `foo` is directly exposed or exposed via a helper.

Details about how this works:
* `bindings_generated.rs` is first created via bindgen;
* List of functions are extracted from `bindings_generated.rs` and a
  `rust_helper_foo` macro is generated for each function directly
  exposed this way;
* `helpers.c` can then use C preprocessor to conditionally compile
  helpers only if they are not directly exposed.
* bindgen invokes again to create bindings for `helpers.c`.
* bindgen output is then postprocessed to remove the `rust_helper`
  prefix and add `#[link_name = ""]`.

Related #352