### PR TITLE
Disable stack probes

### DIFF
--- a/arch/arm64/rust/target.json
+++ b/arch/arm64/rust/target.json
@@ -26,12 +26,7 @@
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {
-    "kind": "inline-or-call",
-    "min-llvm-version-for-inline": [
-      11,
-      0,
-      1
-    ]
+    "kind": "none"
   },
   "target-c-int-width": "32",
   "target-endian": "little",

--- a/arch/riscv/rust/rv32ima.json
+++ b/arch/riscv/rust/rv32ima.json
@@ -28,12 +28,7 @@
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {
-    "kind": "inline-or-call",
-    "min-llvm-version-for-inline": [
-      11,
-      0,
-      1
-    ]
+    "kind": "none"
   },
   "target-c-int-width": "32",
   "target-endian": "little",

--- a/arch/riscv/rust/rv32imac.json
+++ b/arch/riscv/rust/rv32imac.json
@@ -28,12 +28,7 @@
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {
-    "kind": "inline-or-call",
-    "min-llvm-version-for-inline": [
-      11,
-      0,
-      1
-    ]
+    "kind": "none"
   },
   "target-c-int-width": "32",
   "target-endian": "little",

--- a/arch/riscv/rust/rv64ima.json
+++ b/arch/riscv/rust/rv64ima.json
@@ -28,12 +28,7 @@
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {
-    "kind": "inline-or-call",
-    "min-llvm-version-for-inline": [
-      11,
-      0,
-      1
-    ]
+    "kind": "none"
   },
   "target-c-int-width": "32",
   "target-endian": "little",

--- a/arch/riscv/rust/rv64imac.json
+++ b/arch/riscv/rust/rv64imac.json
@@ -28,12 +28,7 @@
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {
-    "kind": "inline-or-call",
-    "min-llvm-version-for-inline": [
-      11,
-      0,
-      1
-    ]
+    "kind": "none"
   },
   "target-c-int-width": "32",
   "target-endian": "little",

--- a/arch/x86/rust/target.json
+++ b/arch/x86/rust/target.json
@@ -28,12 +28,7 @@
   "relocation-model": "static",
   "relro-level": "full",
   "stack-probes": {
-    "kind": "inline-or-call",
-    "min-llvm-version-for-inline": [
-      11,
-      0,
-      1
-    ]
+    "kind": "none"
   },
   "target-c-int-width": "32",
   "target-endian": "little",

--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -42,10 +42,6 @@ macro_rules! define_panicking_intrinsics(
     }
 );
 
-define_panicking_intrinsics!("non-inline stack probes should not be used", {
-    __rust_probestack,
-});
-
 define_panicking_intrinsics!("`f32` should not be used", {
     __addsf3,
     __addsf3vfp,


### PR DESCRIPTION
We do not support function-call stack probes, and LLVM inline asm
stack probe is currently broken [1] [2]. Switching target's `stack-probes`
to "none" allows us to avoid broken codegen and the intrinsic call.
We could switch the `stack-probes` property to `inline` if we want once
the LLVM codegen issue is resolved.

[1]: https://bugs.llvm.org/show_bug.cgi?id=50165
[2]: https://github.com/rust-lang/rust/issues/84667
