### PR TITLE
[RFC] Add Optional Safe-to-Use Flavours of `Mutex`/`CondVar`

### DIFF
--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -9,7 +9,7 @@ use kernel::{
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, Links, List},
     prelude::*,
-    sync::{Guard, LockedBy, Mutex, Ref, SpinLock},
+    sync::{BoxedMutex, Guard, LockedBy, Ref, SpinLock},
     user_ptr::UserSlicePtrWriter,
 };
 
@@ -216,7 +216,7 @@ pub(crate) struct Node {
     cookie: usize,
     pub(crate) flags: u32,
     pub(crate) owner: Ref<Process>,
-    inner: LockedBy<NodeInner, Mutex<ProcessInner>>,
+    inner: LockedBy<NodeInner, BoxedMutex<ProcessInner>>,
     links: Links<dyn DeliverToRead>,
 }
 
@@ -248,12 +248,16 @@ impl Node {
 
     pub(crate) fn next_death(
         &self,
-        guard: &mut Guard<Mutex<ProcessInner>>,
+        guard: &mut Guard<BoxedMutex<ProcessInner>>,
     ) -> Option<Arc<NodeDeath>> {
         self.inner.access_mut(guard).death_list.pop_front()
     }
 
-    pub(crate) fn add_death(&self, death: Arc<NodeDeath>, guard: &mut Guard<Mutex<ProcessInner>>) {
+    pub(crate) fn add_death(
+        &self,
+        death: Arc<NodeDeath>,
+        guard: &mut Guard<BoxedMutex<ProcessInner>>,
+    ) {
         self.inner.access_mut(guard).death_list.push_back(death);
     }
 
@@ -306,7 +310,7 @@ impl Node {
     pub(crate) fn populate_counts(
         &self,
         out: &mut BinderNodeInfoForRef,
-        guard: &Guard<Mutex<ProcessInner>>,
+        guard: &Guard<BoxedMutex<ProcessInner>>,
     ) {
         let inner = self.inner.access(guard);
         out.strong_count = inner.strong.count as _;
@@ -316,7 +320,7 @@ impl Node {
     pub(crate) fn populate_debug_info(
         &self,
         out: &mut BinderNodeDebugInfo,
-        guard: &Guard<Mutex<ProcessInner>>,
+        guard: &Guard<BoxedMutex<ProcessInner>>,
     ) {
         out.ptr = self.ptr as _;
         out.cookie = self.cookie as _;
@@ -329,7 +333,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn force_has_count(&self, guard: &mut Guard<Mutex<ProcessInner>>) {
+    pub(crate) fn force_has_count(&self, guard: &mut Guard<BoxedMutex<ProcessInner>>) {
         let inner = self.inner.access_mut(guard);
         inner.strong.has_count = true;
         inner.weak.has_count = true;

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -537,6 +537,9 @@ impl Process {
     pub(crate) fn buffer_get(&self, ptr: usize) -> Option<Allocation> {
         let mut inner = self.inner.lock();
         let mapping = inner.mapping.as_mut()?;
+        if ptr < mapping.address {
+            return None;
+        }
         let offset = ptr - mapping.address;
         let (size, odata) = mapping.alloc.reserve_existing(offset).ok()?;
         let mut alloc = Allocation::new(self, offset, size, ptr, mapping.pages.clone());
@@ -549,6 +552,9 @@ impl Process {
     pub(crate) fn buffer_raw_free(&self, ptr: usize) {
         let mut inner = self.inner.lock();
         if let Some(ref mut mapping) = &mut inner.mapping {
+            if ptr < mapping.address {
+                return;
+            }
             if mapping
                 .alloc
                 .reservation_abort(ptr - mapping.address)

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -153,7 +153,7 @@ pub struct BoxedCondVar {
     /// It contains a [`struct list_head`] that is self-referential, so
     /// it cannot be safely moved once it is initialised.
     /// We guarantee that it will never move, as per the invariant above.
-    wait_list: Box<UnsafeCell<bindings::wait_queue_head>>,
+    pub(crate) wait_list: Box<UnsafeCell<bindings::wait_queue_head>>,
 }
 
 // SAFETY: `CondVar` only uses a `struct wait_queue_head`, which is safe to use on any thread.

--- a/tools/testing/selftests/Makefile
+++ b/tools/testing/selftests/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 TARGETS = arm64
+TARGETS += binder
 TARGETS += bpf
 TARGETS += breakpoints
 TARGETS += capabilities

--- a/tools/testing/selftests/binder/Makefile
+++ b/tools/testing/selftests/binder/Makefile
@@ -5,6 +5,7 @@ CFLAGS += -g
 CFLAGS += -D_GNU_SOURCE
 CFLAGS += -Wall
 CFLAGS += -pthread
+CFLAGS += -static
 
 TEST_GEN_PROGS := ping_server ping_client
 

--- a/tools/testing/selftests/binder/Makefile
+++ b/tools/testing/selftests/binder/Makefile
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0
+
+CFLAGS += -I../../../../usr/include/
+CFLAGS += -g
+CFLAGS += -D_GNU_SOURCE
+CFLAGS += -Wall
+CFLAGS += -pthread
+
+TEST_GEN_PROGS := ping_server ping_client
+
+include ../lib.mk

--- a/tools/testing/selftests/binder/ping_client.c
+++ b/tools/testing/selftests/binder/ping_client.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdalign.h>
@@ -52,13 +53,17 @@ static size_t handle_read(int fd, struct binder_write_read *b)
 int main(int argc, char **argv)
 {
 	int ret;
-	size_t i;
 	struct timespec begin, end;
+	uint64_t iters = 1000000;
 
-	if (argc != 2) {
-		fprintf(stderr, "Usage: %s <binder-file-name>\n", argv[0]);
+	if (argc != 2 && argc != 3) {
+		fprintf(stderr, "Usage: %s <binder-file-name> [iters]\n",
+			argv[0]);
 		return 1;
 	}
+
+	if (argc >= 3)
+		iters = strtoull(argv[2], NULL, 10);
 
 	int fd = open(argv[1], O_RDWR);
 	if (fd == -1) {
@@ -100,7 +105,7 @@ int main(int argc, char **argv)
 	to_write.addr = handle_read(fd, &b);
 
 	clock_gettime(CLOCK_MONOTONIC, &begin);
-	for (i = 0; i < 1000000; i++) {
+	while (iters--) {
 		b.read_consumed = 0;
 		b.write_consumed = 0;
 		ret = ioctl(fd, BINDER_WRITE_READ, &b);

--- a/tools/testing/selftests/binder/ping_client.c
+++ b/tools/testing/selftests/binder/ping_client.c
@@ -1,0 +1,126 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdalign.h>
+#include <time.h>
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <linux/ioctl.h>
+#include <linux/android/binder.h>
+
+static size_t handle_read(int fd, struct binder_write_read *b)
+{
+	char *ptr = (char *)b->read_buffer;
+	char *limit = ptr + b->read_consumed;
+	struct binder_transaction_data *tr;
+	size_t ret = 0;
+
+	while (limit - ptr >= sizeof(uint32_t)) {
+		uint32_t v = *(uint32_t *)ptr;
+		ptr += sizeof(uint32_t);
+		switch (v) {
+		case BR_REPLY:
+			tr = (struct binder_transaction_data *)ptr;
+			ptr += sizeof(*tr);
+			if (ptr > limit) {
+				printf("Truncated transaction.\n");
+				break;
+			}
+			ret = tr->data.ptr.buffer;
+			break;
+
+		case BR_NOOP:
+			break;
+
+		case BR_TRANSACTION_COMPLETE:
+			break;
+
+		default:
+			printf("Unknown reply: 0x%x\n", v);
+			ptr = limit;
+		}
+	}
+
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	int ret;
+	size_t i;
+	struct timespec begin, end;
+
+	if (argc != 2) {
+		fprintf(stderr, "Usage: %s <binder-file-name>\n", argv[0]);
+		return 1;
+	}
+
+	int fd = open(argv[1], O_RDWR);
+	if (fd == -1) {
+		perror("open");
+		return 1;
+	}
+
+	void *shared_ptr = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (shared_ptr == MAP_FAILED) {
+		perror("mmap");
+		return 1;
+	}
+
+	uint32_t buf[512];
+	static struct __attribute__((__packed__)) {
+		uint32_t cmd0;
+		size_t addr;
+		uint32_t cmd1;
+		struct binder_transaction_data tr;
+	} to_write = {
+		.cmd0 = BC_FREE_BUFFER,
+		.addr = 0,
+		.cmd1 = BC_TRANSACTION,
+		.tr.target.handle = 0,
+		.tr.code = 0,
+	};
+	struct binder_write_read b = {
+		.write_buffer = (size_t)&to_write,
+		.write_size = sizeof(to_write),
+		.read_buffer = (size_t)&buf[0],
+		.read_size = sizeof(buf),
+	};
+	ret = ioctl(fd, BINDER_WRITE_READ, &b);
+	if (ret == -1) {
+		perror("ioctl");
+		return 1;
+	}
+
+	to_write.addr = handle_read(fd, &b);
+
+	clock_gettime(CLOCK_MONOTONIC, &begin);
+	for (i = 0; i < 1000000; i++) {
+		b.read_consumed = 0;
+		b.write_consumed = 0;
+		ret = ioctl(fd, BINDER_WRITE_READ, &b);
+		if (ret == -1) {
+			perror("ioctl");
+			return 1;
+		}
+		to_write.addr = handle_read(fd, &b);
+	}
+	clock_gettime(CLOCK_MONOTONIC, &end);
+
+	end.tv_sec -= begin.tv_sec;
+	if (begin.tv_nsec > end.tv_nsec) {
+		end.tv_sec--;
+		end.tv_nsec += 1000000000;
+	}
+	end.tv_nsec -= begin.tv_nsec;
+	printf("Total time: %lld.%.9ld\n", (long long)end.tv_sec, end.tv_nsec);
+
+	close(fd);
+
+	return 0;
+}

--- a/tools/testing/selftests/binder/ping_server.c
+++ b/tools/testing/selftests/binder/ping_server.c
@@ -1,0 +1,121 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdalign.h>
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <linux/ioctl.h>
+#include <linux/android/binder.h>
+
+static void handle_read(int fd, struct binder_write_read* b)
+{
+	static struct __attribute__((__packed__)) {
+		uint32_t cmd0;
+		size_t ptr;
+		uint32_t cmd1;
+		struct binder_transaction_data tr;
+	} to_write = {
+		.cmd0 = BC_FREE_BUFFER,
+		.cmd1 = BC_REPLY,
+		.tr.target.handle = 0,
+		.tr.code = 0,
+	};
+	char *ptr = (char *)b->read_buffer;
+	char *limit = ptr + b->read_consumed;
+	struct binder_transaction_data *tr;
+
+	while (limit - ptr >= sizeof(uint32_t)) {
+		uint32_t v = *(uint32_t *)ptr;
+		ptr += sizeof(uint32_t);
+		switch (v) {
+		case BR_TRANSACTION:
+			tr = (struct binder_transaction_data *)ptr;
+			ptr += sizeof(*tr);
+			if (ptr > limit) {
+				printf("Truncated transaction.\n");
+				break;
+			}
+
+			to_write.ptr = tr->data.ptr.buffer;
+			b->write_buffer = (size_t)&to_write;
+			b->write_size = sizeof(to_write);
+			b->write_consumed = 0;
+			break;
+
+		case BR_NOOP:
+			break;
+
+		case BR_TRANSACTION_COMPLETE:
+			break;
+
+		default:
+			printf("Unknown reply: 0x%x\n", v);
+			ptr = limit;
+		}
+	}
+}
+
+int main(int argc, char **argv)
+{
+	int ret;
+
+	if (argc != 2) {
+		fprintf(stderr, "Usage: %s <binder-file-name>\n", argv[0]);
+		return 1;
+	}
+
+	int fd = open(argv[1], O_RDWR);
+	if (fd == -1) {
+		perror("open");
+		return 1;
+	}
+
+	void *shared_ptr = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (shared_ptr == MAP_FAILED) {
+		perror("mmap");
+		return 1;
+	}
+
+	ret = ioctl(fd, BINDER_SET_CONTEXT_MGR, NULL);
+	if (ret == -1) {
+		perror("ioctl");
+		return 1;
+	}
+
+	{
+		uint32_t cmd = BC_ENTER_LOOPER;
+		struct binder_write_read b = {
+			.write_buffer = (size_t)&cmd,
+			.write_size = sizeof(cmd),
+		};
+		int ret = ioctl(fd, BINDER_WRITE_READ, &b);
+		if (ret == -1) {
+			perror("ioctl(BC_ENTER_LOOPER)");
+		}
+	}
+
+	uint32_t buf[512];
+	struct binder_write_read b = {
+		.read_buffer = (size_t)&buf[0],
+		.read_size = sizeof(buf),
+	};
+	for (;;) {
+		b.read_consumed = 0;
+		ret = ioctl(fd, BINDER_WRITE_READ, &b);
+		if (ret == -1) {
+			perror("ioctl");
+			continue;
+		}
+
+		handle_read(fd, &b);
+	}
+
+	close(fd);
+
+	return 0;
+}


### PR DESCRIPTION
**Request For Comments Only**
**Note that I am NOT proposing any changes to Binder**

Our `Mutex` and `CondVar` abstractions push a lot of `Pin` reasoning and unsafe blocks onto its users. This creates plenty of rope for less experienced driver writers to hang themselves, and is therefore not necessarily an improvement over C.

Try this one on for size:
https://github.com/Rust-for-Linux/linux/blob/5dd07d5d2ff5c606fb697adbf46f803d782fff44/samples/rust/rust_miscdev.rs#L40-L56

The proposed Optional Safe-to-Use flavours reduce this complexity, without requiring code changes anywhere else:
(actually code complexity will be reduced further, as there is no longer a need to `Pin` the returned structure)

```rust
impl SharedState {
    fn try_new() -> Result<Arc<Self>> {
        let state = Arc::try_new(Self {
            state_changed: boxed_condvar!("SharedState::state_changed")?,
            inner: boxed_mutex!(SharedStateInner { token_count: 0 }, "SharedState::inner")?,
        })?;
        Ok(state)
    }
}
```

The downside here is, obviously, the extra heap allocations, heap dereferences and loss of cache locality. But we only _guess_ these are problematic. How can we verify that in the real world?

Turns out that @wedsonaf's proposed Binder ping benchmark appears quite sensitive to `Mutex` performance, as witnessed by the fact that we can measure a regression when adding one extra function call overhead to `Mutex::lock`. See:
https://github.com/Rust-for-Linux/linux/pull/346#issuecomment-857310011
https://github.com/Rust-for-Linux/linux/pull/346#issuecomment-857284296

So I regression tested Wedson's benchmark on arm 32-bit (cortex-a9 + Raspberri Pi Zero) and... no apparent change in performance.

Perhaps we will see a performance regression on x86 or RISC-V? If so, are the safety gains worth it?