### PR TITLE
rust: update `Ref` to use the kernel's `refcount_t`.

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -146,6 +146,24 @@ rust_helper_platform_set_drvdata(struct platform_device *pdev,
 }
 EXPORT_SYMBOL_GPL(rust_helper_platform_set_drvdata);
 
+refcount_t rust_helper_refcount_new(void)
+{
+	return (refcount_t)REFCOUNT_INIT(1);
+}
+EXPORT_SYMBOL_GPL(rust_helper_refcount_new);
+
+void rust_helper_refcount_inc(refcount_t *r)
+{
+	refcount_inc(r);
+}
+EXPORT_SYMBOL_GPL(rust_helper_refcount_inc);
+
+bool rust_helper_refcount_dec_and_test(refcount_t *r)
+{
+	return refcount_dec_and_test(r);
+}
+EXPORT_SYMBOL_GPL(rust_helper_refcount_dec_and_test);
+
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust
  * expects a usize like slice (array) indices. usize is defined to be

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -21,6 +21,7 @@
     const_panic,
     const_raw_ptr_deref,
     const_unreachable_unchecked,
+    receiver_trait,
     try_reserve
 )]
 #![deny(clippy::complexity)]

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -29,7 +29,7 @@ mod locked_by;
 mod mutex;
 mod spinlock;
 
-pub use arc::{Ref, RefCount, RefCounted};
+pub use arc::{Ref, RefBorrow};
 pub use condvar::CondVar;
 pub use guard::{Guard, Lock};
 pub use locked_by::LockedBy;


### PR DESCRIPTION
Saturate the refcount instead of panicking. It also leverages existing C
code instead of reimplementing functionality.

This is the first step to deprecate `Arc` (that aborts on overflow) and `BTreeMap` (that panics on allocation failure).

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>