### PR TITLE
rust/Kconfig: disable Rust support if CONFIG_MODVERSIONS=y

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -2024,6 +2024,7 @@ config RUST
 	bool "Rust support"
 	depends on HAS_RUST
 	depends on !COMPILE_TEST
+	depends on !MODVERSIONS
 	default n
 	help
 	  Enables Rust support in the kernel.


### PR DESCRIPTION
In recent weeks, there have been a few reports of Rust build errors
for defconfigs which have CONFIG_MODVERSIONS=y. See #378 for example.

According to #59, Rust-for-Linux currently doesn't support MODVERSIONS.
To prevent confusion and build errors in the future, disable Rust
support if CONFIG_MODVERSIONS=y.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>