### PR TITLE
Simple Rust driver that touches real hardware: PR 5

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -67,7 +67,7 @@ impl PlatformDriver for RngDriver {
 }
 
 struct RngModule {
-    _pdev: Pin<Box<platdev::Registration>>,
+    _pdev: platdev::Registration,
 }
 
 impl KernelModule for RngModule {
@@ -75,7 +75,7 @@ impl KernelModule for RngModule {
         const OF_MATCH_TBL: ConstOfMatchTable<1> =
             ConstOfMatchTable::new_const([&c_str!("brcm,bcm2835-rng")]);
 
-        let pdev = platdev::Registration::new_pinned::<RngDriver>(
+        let pdev = platdev::Registration::new::<RngDriver>(
             c_str!("bcm2835-rng-rust"),
             Some(&OF_MATCH_TBL),
             &THIS_MODULE,


### PR DESCRIPTION
#### Simple Rust driver that touches real h/w: step 5

@alex and @ojeda suggested that #254 should be split into smaller PRs, so they can be reviewed and merged individually.

Roadmap:

- [x] platform_device
- [x] devicetree (of) matching
- [x] probe
- [x] DrvData
- [ ] **`Pin`ning cleanup (you are here)**
- [ ] `DrvData` references in `PlatformDriver` trait
- [ ] regmap/iomem