### PR TITLE
rust: update FileOperations to use arbitrary type from `PointerWrapper`.

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -37,7 +37,7 @@ impl FileOpener<()> for RngDevice {
 impl FileOperations for RngDevice {
     kernel::declare_file_operations!(read);
 
-    fn read<T: IoBufferWriter>(&self, _: &File, data: &mut T, offset: u64) -> Result<usize> {
+    fn read<T: IoBufferWriter>(_: &Self, _: &File, data: &mut T, offset: u64) -> Result<usize> {
         // Succeed if the caller doesn't provide a buffer or if not at the start.
         if data.is_empty() || offset != 0 {
             return Ok(0);

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -21,7 +21,7 @@ struct RandomFile;
 impl FileOperations for RandomFile {
     kernel::declare_file_operations!(read, write, read_iter, write_iter);
 
-    fn read<T: IoBufferWriter>(&self, file: &File, buf: &mut T, _offset: u64) -> Result<usize> {
+    fn read<T: IoBufferWriter>(_this: &Self, file: &File, buf: &mut T, _: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
 
@@ -39,7 +39,7 @@ impl FileOperations for RandomFile {
         Ok(total_len)
     }
 
-    fn write<T: IoBufferReader>(&self, _file: &File, buf: &mut T, _offset: u64) -> Result<usize> {
+    fn write<T: IoBufferReader>(_this: &Self, _file: &File, buf: &mut T, _: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
         while !buf.is_empty() {


### PR DESCRIPTION
This allows `FileOperations` implementers to have arbitrary (wrapped)
values as `private_data` (as opposed to only wrapped `Self`).

It also allows wrappers to dictate the borrowed type. For now all
wrappers of `T` just borrow `&T`, but in a subsequent PR `Ref<T>` will
borrow to `&Ref<T>`, which allows implementations to increment the
refcount.

This is based on #386.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>