### PR TITLE
rust/kernel/of: apply additional documentation suggestions

### DIFF
--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -73,8 +73,8 @@ impl<const N: usize> ConstOfMatchTable<N> {
         let compatible = compatible.as_bytes_with_nul();
         let mut i = 0;
         while i < compatible.len() {
-            // if `compatible` does not fit in `id.compatible`, an
-            // "index out of bounds" build time exception will be triggered.
+            // If `compatible` does not fit in `id.compatible`, an
+            // "index out of bounds" build time error will be triggered.
             id.compatible[i] = compatible[i] as c_types::c_char;
             i += 1;
         }
@@ -90,6 +90,7 @@ impl<const N: usize> Deref for ConstOfMatchTable<N> {
         // as per the `ConstOfMatchTable` type invariant, therefore
         // `&OfMatchTable`'s inner reference will point to a sentinel-terminated C array.
         let head = &self.table[0] as *const bindings::of_device_id as *const OfMatchTable;
+
         // SAFETY: The returned reference must remain valid for the lifetime of `self`.
         // The raw pointer `head` points to memory inside `self`. So the reference created
         // from this raw pointer has the same lifetime as `self`.

--- a/rust/kernel/platdev.rs
+++ b/rust/kernel/platdev.rs
@@ -103,7 +103,7 @@ impl Registration {
         //   - `module.0` lives at least as long as the module.
         //   - `probe()` and `remove()` are static functions.
         //   - `of_match_table` is either a raw pointer with static lifetime,
-        //      as guaranteed by the [`of::OfMatchTable::as_ptr()`] invariant,
+        //      as guaranteed by the [`of::OfMatchTable::as_ptr()`] return type,
         //      or null.
         let ret = unsafe { bindings::__platform_driver_register(&mut this.pdrv, module.0) };
         if ret < 0 {


### PR DESCRIPTION
Some documentation suggestions on Rust-for-Linux#380 were not applied
when that PR was merged. Apply them in this PR instead.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>