### PR TITLE
rust: fix bug where unsafe expressions didn't require unsafe block.

### DIFF
--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -78,7 +78,8 @@ impl Transaction {
         let mut_tr = Arc::get_mut(&mut tr).ok_or(Error::EINVAL)?;
 
         // SAFETY: `inner` is pinned behind `Arc`.
-        kernel::spinlock_init!(Pin::new_unchecked(&mut_tr.inner), "Transaction::inner");
+        let pinned = unsafe { Pin::new_unchecked(&mut_tr.inner) };
+        kernel::spinlock_init!(pinned, "Transaction::inner");
         Ok(tr)
     }
 
@@ -111,7 +112,8 @@ impl Transaction {
         let mut_tr = Arc::get_mut(&mut tr).ok_or(Error::EINVAL)?;
 
         // SAFETY: `inner` is pinned behind `Arc`.
-        kernel::spinlock_init!(Pin::new_unchecked(&mut_tr.inner), "Transaction::inner");
+        let pinned = unsafe { Pin::new_unchecked(&mut_tr.inner) };
+        kernel::spinlock_init!(pinned, "Transaction::inner");
         Ok(tr)
     }
 

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -50,10 +50,12 @@ macro_rules! init_with_lockdep {
     ($obj:expr, $name:literal) => {{
         static mut CLASS: core::mem::MaybeUninit<$crate::bindings::lock_class_key> =
             core::mem::MaybeUninit::uninit();
+        let obj = $obj;
+        let name = $crate::c_str!($name);
         // SAFETY: `CLASS` is never used by Rust code directly; the kernel may change it though.
         #[allow(unused_unsafe)]
         unsafe {
-            $crate::sync::NeedsLockClass::init($obj, $crate::c_str!($name), CLASS.as_mut_ptr())
+            $crate::sync::NeedsLockClass::init(obj, name, CLASS.as_mut_ptr())
         };
     }};
 }

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -133,10 +133,12 @@ impl KernelModule for RustSemaphore {
             },
             |sema| {
                 // SAFETY: `changed` is pinned when `sema` is.
-                condvar_init!(Pin::new_unchecked(&sema.changed), "Semaphore::changed");
+                let pinned = unsafe { Pin::new_unchecked(&sema.changed) };
+                condvar_init!(pinned, "Semaphore::changed");
 
                 // SAFETY: `inner` is pinned when `sema` is.
-                mutex_init!(Pin::new_unchecked(&sema.inner), "Semaphore::inner");
+                let pinned = unsafe { Pin::new_unchecked(&sema.inner) };
+                mutex_init!(pinned, "Semaphore::inner");
             },
         )?;
 


### PR DESCRIPTION
In the `init_with_lockdep` macro, the macros were evaluated inside an
unsafe block, so they could contain unsafe operations without requiring
an explicit unsafe block on the call site.

Fixed by evaluating `$obj` and `$name` outside an unsafe block.

Reported-by: Sven Van Asbroeck <thesven73@gmail.com>
Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>