### PR TITLE
rust: require mutable references when initialising sync primitives.

### DIFF
--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -37,7 +37,7 @@ impl Context {
         let ctx = Arc::get_mut(&mut ctx_ref).unwrap();
 
         // SAFETY: `manager` is also pinned when `ctx` is.
-        let manager = unsafe { Pin::new_unchecked(&ctx.manager) };
+        let manager = unsafe { Pin::new_unchecked(&mut ctx.manager) };
         kernel::mutex_init!(manager, "Context::manager");
 
         // SAFETY: `ctx_ref` is pinned behind the `Arc` reference.

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -94,9 +94,9 @@ impl NodeDeath {
         }
     }
 
-    pub(crate) fn init(self: Pin<&Self>) {
+    pub(crate) fn init(self: Pin<&mut Self>) {
         // SAFETY: `inner` is pinned when `self` is.
-        let inner = unsafe { self.map_unchecked(|s| &s.inner) };
+        let inner = unsafe { self.map_unchecked_mut(|n| &mut n.inner) };
         kernel::spinlock_init!(inner, "NodeDeath::inner");
     }
 

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -78,7 +78,7 @@ impl Transaction {
         let mut_tr = Arc::get_mut(&mut tr).ok_or(Error::EINVAL)?;
 
         // SAFETY: `inner` is pinned behind `Arc`.
-        let pinned = unsafe { Pin::new_unchecked(&mut_tr.inner) };
+        let pinned = unsafe { Pin::new_unchecked(&mut mut_tr.inner) };
         kernel::spinlock_init!(pinned, "Transaction::inner");
         Ok(tr)
     }
@@ -112,7 +112,7 @@ impl Transaction {
         let mut_tr = Arc::get_mut(&mut tr).ok_or(Error::EINVAL)?;
 
         // SAFETY: `inner` is pinned behind `Arc`.
-        let pinned = unsafe { Pin::new_unchecked(&mut_tr.inner) };
+        let pinned = unsafe { Pin::new_unchecked(&mut mut_tr.inner) };
         kernel::spinlock_init!(pinned, "Transaction::inner");
         Ok(tr)
     }

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -131,7 +131,7 @@ impl CondVar {
 }
 
 impl NeedsLockClass for CondVar {
-    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
+    unsafe fn init(self: Pin<&mut Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
         unsafe { bindings::__init_waitqueue_head(self.wait_list.get(), name.as_char_ptr(), key) };
     }
 }

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -11,9 +11,11 @@
 //! # use kernel::prelude::*;
 //! # use kernel::mutex_init;
 //! # use kernel::sync::Mutex;
+//! # use alloc::boxed::Box;
+//! # use core::pin::Pin;
 //! // SAFETY: `init` is called below.
-//! let data = alloc::sync::Arc::pin(unsafe { Mutex::new(0) });
-//! mutex_init!(data.as_ref(), "test::data");
+//! let mut data = Pin::from(Box::new(unsafe { Mutex::new(0) }));
+//! mutex_init!(data.as_mut(), "test::data");
 //! *data.lock() = 10;
 //! pr_info!("{}\n", *data.lock());
 //! ```
@@ -73,7 +75,7 @@ pub trait NeedsLockClass {
     /// # Safety
     ///
     /// `key` must point to a valid memory location as it will be used by the kernel.
-    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key);
+    unsafe fn init(self: Pin<&mut Self>, name: &'static CStr, key: *mut bindings::lock_class_key);
 }
 
 /// Determines if a signal is pending on the current process.

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -72,7 +72,7 @@ impl<T: ?Sized> Mutex<T> {
 }
 
 impl<T: ?Sized> NeedsLockClass for Mutex<T> {
-    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
+    unsafe fn init(self: Pin<&mut Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
         unsafe { bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key) };
     }
 }

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -86,7 +86,7 @@ impl<T: ?Sized> SpinLock<T> {
 }
 
 impl<T: ?Sized> NeedsLockClass for SpinLock<T> {
-    unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
+    unsafe fn init(self: Pin<&mut Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
         unsafe { rust_helper_spin_lock_init(self.spin_lock.get(), name.as_char_ptr(), key) };
     }
 }

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -131,13 +131,13 @@ impl KernelModule for RustSemaphore {
                     })
                 },
             },
-            |sema| {
+            |mut sema| {
                 // SAFETY: `changed` is pinned when `sema` is.
-                let pinned = unsafe { Pin::new_unchecked(&sema.changed) };
+                let pinned = unsafe { sema.as_mut().map_unchecked_mut(|s| &mut s.changed) };
                 condvar_init!(pinned, "Semaphore::changed");
 
                 // SAFETY: `inner` is pinned when `sema` is.
-                let pinned = unsafe { Pin::new_unchecked(&sema.inner) };
+                let pinned = unsafe { sema.as_mut().map_unchecked_mut(|s| &mut s.inner) };
                 mutex_init!(pinned, "Semaphore::inner");
             },
         )?;

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -30,14 +30,15 @@ impl KernelModule for RustSync {
         // Test mutexes.
         {
             // SAFETY: `init` is called below.
-            let data = Pin::from(Box::try_new(unsafe { Mutex::new(0) })?);
-            mutex_init!(data.as_ref(), "RustSync::init::data1");
+            let mut data = Pin::from(Box::try_new(unsafe { Mutex::new(0) })?);
+            mutex_init!(data.as_mut(), "RustSync::init::data1");
             *data.lock() = 10;
             pr_info!("Value: {}\n", *data.lock());
 
             // SAFETY: `init` is called below.
-            let cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
-            condvar_init!(cv.as_ref(), "RustSync::init::cv1");
+            let mut cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
+            condvar_init!(cv.as_mut(), "RustSync::init::cv1");
+
             {
                 let mut guard = data.lock();
                 while *guard != 10 {
@@ -52,14 +53,14 @@ impl KernelModule for RustSync {
         // Test spinlocks.
         {
             // SAFETY: `init` is called below.
-            let data = Pin::from(Box::try_new(unsafe { SpinLock::new(0) })?);
-            spinlock_init!(data.as_ref(), "RustSync::init::data2");
+            let mut data = Pin::from(Box::try_new(unsafe { SpinLock::new(0) })?);
+            spinlock_init!(data.as_mut(), "RustSync::init::data2");
             *data.lock() = 10;
             pr_info!("Value: {}\n", *data.lock());
 
             // SAFETY: `init` is called below.
-            let cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
-            condvar_init!(cv.as_ref(), "RustSync::init::cv2");
+            let mut cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
+            condvar_init!(cv.as_mut(), "RustSync::init::cv2");
             {
                 let mut guard = data.lock();
                 while *guard != 10 {


### PR DESCRIPTION
This prevents initialising synchronisation primitives when there are
multiple references to them.

Based on #391.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>