### PR TITLE
Replace all usages of `BTreeMap` with `RBTree`.

### DIFF
--- a/rust/kernel/rbtree.rs
+++ b/rust/kernel/rbtree.rs
@@ -197,7 +197,6 @@ struct Node<K, V> {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Default)]
 pub struct RBTree<K, V> {
     root: bindings::rb_root,
     _p: PhantomData<Node<K, V>>,
@@ -404,6 +403,12 @@ impl<K, V> RBTree<K, V> {
     /// Returns a mutable iterator over the values of the nodes in the tree, sorted by key.
     pub fn values_mut(&mut self) -> impl Iterator<Item = &'_ mut V> {
         self.iter_mut().map(|(_, v)| v)
+    }
+}
+
+impl<K, V> Default for RBTree<K, V> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
This is based on #400.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>
