### PR TITLE
rust: kernel: clean `rustdoc` warnings

### DIFF
--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -12,7 +12,7 @@ use core::{mem::ManuallyDrop, ops::Deref};
 ///
 /// # Invariants
 ///
-/// The pointer [`File::ptr`] is non-null and valid. Its reference count is also non-zero.
+/// The pointer `File::ptr` is non-null and valid. Its reference count is also non-zero.
 pub struct File {
     pub(crate) ptr: *mut bindings::file,
 }

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -25,7 +25,7 @@ use crate::{
 ///
 /// # Invariants
 ///
-/// The pointer [`PollTable::ptr`] is null or valid.
+/// The pointer `PollTable::ptr` is null or valid.
 pub struct PollTable {
     ptr: *mut bindings::poll_table_struct,
 }

--- a/rust/kernel/iov_iter.rs
+++ b/rust/kernel/iov_iter.rs
@@ -29,7 +29,7 @@ extern "C" {
 ///
 /// # Invariants
 ///
-/// The pointer [`IovIter::ptr`] is non-null and valid.
+/// The pointer `IovIter::ptr` is non-null and valid.
 pub struct IovIter {
     ptr: *mut bindings::iov_iter,
 }

--- a/rust/kernel/pages.rs
+++ b/rust/kernel/pages.rs
@@ -31,7 +31,7 @@ extern "C" {
 ///
 /// # Invariants
 ///
-/// The pointer [`Pages::pages`] is valid and points to 2^ORDER pages.
+/// The pointer `Pages::pages` is valid and points to 2^ORDER pages.
 pub struct Pages<const ORDER: u32> {
     pages: *mut bindings::page,
 }

--- a/rust/kernel/task.rs
+++ b/rust/kernel/task.rs
@@ -22,7 +22,7 @@ extern "C" {
 ///
 /// # Invariants
 ///
-/// The pointer [`Task::ptr`] is non-null and valid. Its reference count is also non-zero.
+/// The pointer `Task::ptr` is non-null and valid. Its reference count is also non-zero.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
e.g. https://github.com/Rust-for-Linux/linux/pull/402/checks#step:60:27