### PR TITLE
MAINTAINERS: we can claim `Supported` now

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15899,7 +15899,7 @@ M:	Miguel Ojeda <ojeda@kernel.org>
 M:	Alex Gaynor <alex.gaynor@gmail.com>
 M:	Wedson Almeida Filho <wedsonaf@google.com>
 L:	rust-for-linux@vger.kernel.org
-S:	Maintained
+S:	Supported
 W:	https://github.com/Rust-for-Linux/linux
 B:	https://github.com/Rust-for-Linux/linux/issues
 T:	git https://github.com/Rust-for-Linux/linux.git rust-next


### PR DESCRIPTION
Link: https://lore.kernel.org/lkml/CAKwvOdniKs+cNKS9qHgq3xR6cmJ7xdiVpAzxaQEN372HY6xc7w@mail.gmail.com/
Suggested-by: Nick Desaulniers <ndesaulniers@google.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>