### PR TITLE
binder: fix clippy warnings when rust_2018_idioms is enabled.

### DIFF
--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 
-extern crate alloc;
-
 use kernel::{
     bindings,
     prelude::*,

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -248,12 +248,16 @@ impl Node {
 
     pub(crate) fn next_death(
         &self,
-        guard: &mut Guard<Mutex<ProcessInner>>,
+        guard: &mut Guard<'_, Mutex<ProcessInner>>,
     ) -> Option<Arc<NodeDeath>> {
         self.inner.access_mut(guard).death_list.pop_front()
     }
 
-    pub(crate) fn add_death(&self, death: Arc<NodeDeath>, guard: &mut Guard<Mutex<ProcessInner>>) {
+    pub(crate) fn add_death(
+        &self,
+        death: Arc<NodeDeath>,
+        guard: &mut Guard<'_, Mutex<ProcessInner>>,
+    ) {
         self.inner.access_mut(guard).death_list.push_back(death);
     }
 
@@ -306,7 +310,7 @@ impl Node {
     pub(crate) fn populate_counts(
         &self,
         out: &mut BinderNodeInfoForRef,
-        guard: &Guard<Mutex<ProcessInner>>,
+        guard: &Guard<'_, Mutex<ProcessInner>>,
     ) {
         let inner = self.inner.access(guard);
         out.strong_count = inner.strong.count as _;
@@ -316,7 +320,7 @@ impl Node {
     pub(crate) fn populate_debug_info(
         &self,
         out: &mut BinderNodeDebugInfo,
-        guard: &Guard<Mutex<ProcessInner>>,
+        guard: &Guard<'_, Mutex<ProcessInner>>,
     ) {
         out.ptr = self.ptr as _;
         out.cookie = self.cookie as _;
@@ -329,7 +333,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn force_has_count(&self, guard: &mut Guard<Mutex<ProcessInner>>) {
+    pub(crate) fn force_has_count(&self, guard: &mut Guard<'_, Mutex<ProcessInner>>) {
         let inner = self.inner.access_mut(guard);
         inner.strong.has_count = true;
         inner.weak.has_count = true;

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -541,7 +541,7 @@ impl Process {
         Ok(())
     }
 
-    pub(crate) fn buffer_alloc(&self, size: usize) -> BinderResult<Allocation> {
+    pub(crate) fn buffer_alloc(&self, size: usize) -> BinderResult<Allocation<'_>> {
         let mut inner = self.inner.lock();
         let mapping = inner.mapping.as_mut().ok_or_else(BinderError::new_dead)?;
 
@@ -556,7 +556,7 @@ impl Process {
     }
 
     // TODO: Review if we want an Option or a Result.
-    pub(crate) fn buffer_get(&self, ptr: usize) -> Option<Allocation> {
+    pub(crate) fn buffer_get(&self, ptr: usize) -> Option<Allocation<'_>> {
         let mut inner = self.inner.lock();
         let mapping = inner.mapping.as_mut()?;
         let offset = ptr.checked_sub(mapping.address)?;
@@ -953,7 +953,7 @@ impl<'a> Registration<'a> {
     fn new(
         process: &'a Process,
         thread: &'a Arc<Thread>,
-        guard: &mut Guard<Mutex<ProcessInner>>,
+        guard: &mut Guard<'_, Mutex<ProcessInner>>,
     ) -> Self {
         guard.ready_threads.push_back(thread.clone());
         Self { process, thread }

--- a/drivers/android/range_alloc.rs
+++ b/drivers/android/range_alloc.rs
@@ -70,7 +70,7 @@ impl<T> RangeAllocator<T> {
         Ok(desc.offset)
     }
 
-    fn free_with_cursor(cursor: &mut CursorMut<Box<Descriptor<T>>>) -> Result {
+    fn free_with_cursor(cursor: &mut CursorMut<'_, Box<Descriptor<T>>>) -> Result {
         let mut size = match cursor.current() {
             None => return Err(Error::EINVAL),
             Some(ref mut entry) => {
@@ -105,7 +105,7 @@ impl<T> RangeAllocator<T> {
         Ok(())
     }
 
-    fn find_at_offset(&mut self, offset: usize) -> Option<CursorMut<Box<Descriptor<T>>>> {
+    fn find_at_offset(&mut self, offset: usize) -> Option<CursorMut<'_, Box<Descriptor<T>>>> {
         let mut cursor = self.list.cursor_front_mut();
         while let Some(desc) = cursor.current() {
             if desc.offset == offset {

--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -6,8 +6,6 @@
 
 #![no_std]
 #![feature(global_asm, try_reserve, allocator_api, concat_idents)]
-// TODO: clean these up
-#![allow(rust_2018_idioms)]
 
 use alloc::{boxed::Box, sync::Arc};
 use core::pin::Pin;

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -373,7 +373,7 @@ impl Thread {
     fn translate_object(
         &self,
         index_offset: usize,
-        view: &mut AllocationView,
+        view: &mut AllocationView<'_, '_>,
         allow_fds: bool,
     ) -> BinderResult {
         let offset = view.alloc.read(index_offset)?;
@@ -422,7 +422,7 @@ impl Thread {
 
     fn translate_objects(
         &self,
-        alloc: &mut Allocation,
+        alloc: &mut Allocation<'_>,
         start: usize,
         end: usize,
         allow_fds: bool,


### PR DESCRIPTION
These were originally disabled for drivers, enabling them caused
warnings to be issued for binder. This commit fixes them.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>