### PR TITLE
Graduate `Box`, `Arc`, `Vec`, `Pin` and `Error`

### DIFF
--- a/drivers/android/allocation.rs
+++ b/drivers/android/allocation.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 
-use alloc::{boxed::Box, sync::Arc};
 use core::mem::{replace, size_of, MaybeUninit};
-use kernel::{
-    bindings, linked_list::List, pages::Pages, prelude::*, user_ptr::UserSlicePtrReader, Error,
-};
+use kernel::{bindings, linked_list::List, pages::Pages, prelude::*, user_ptr::UserSlicePtrReader};
 
 use crate::{
     defs::*,

--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -5,7 +5,6 @@ use kernel::{
     prelude::*,
     security,
     sync::{Mutex, Ref},
-    Error,
 };
 
 use crate::{

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-use alloc::sync::Arc;
-use core::{
-    pin::Pin,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use core::sync::atomic::{AtomicU64, Ordering};
 use kernel::{
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, Links, List},

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 
-use alloc::{sync::Arc, vec::Vec};
 use core::{
     mem::{take, MaybeUninit},
     ops::Range,
-    pin::Pin,
 };
 use kernel::{
     bindings, c_types,
@@ -18,7 +16,6 @@ use kernel::{
     sync::{Guard, Mutex, Ref},
     task::Task,
     user_ptr::{UserSlicePtr, UserSlicePtrReader},
-    Error,
 };
 
 use crate::{

--- a/drivers/android/range_alloc.rs
+++ b/drivers/android/range_alloc.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
-use alloc::boxed::Box;
 use core::ptr::NonNull;
 use kernel::{
     linked_list::{CursorMut, GetLinks, Links, List},
     prelude::*,
-    Error,
 };
 
 pub(crate) struct RangeAllocator<T> {

--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -7,8 +7,6 @@
 #![no_std]
 #![feature(global_asm, try_reserve, allocator_api, concat_idents)]
 
-use alloc::{boxed::Box, sync::Arc};
-use core::pin::Pin;
 use kernel::{
     c_str,
     io_buffer::IoBufferWriter,

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-use alloc::{boxed::Box, sync::Arc};
-use core::{alloc::AllocError, mem::size_of, pin::Pin};
+use core::{alloc::AllocError, mem::size_of};
 use kernel::{
     bindings,
     file::File,
@@ -12,7 +11,6 @@ use kernel::{
     security,
     sync::{CondVar, Ref, SpinLock},
     user_ptr::{UserSlicePtr, UserSlicePtrWriter},
-    Error,
 };
 
 use crate::{

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-use alloc::{boxed::Box, sync::Arc};
-use core::{
-    pin::Pin,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use core::sync::atomic::{AtomicBool, Ordering};
 use kernel::{
     bindings,
     file::{File, FileDescriptorReservation},
@@ -14,7 +10,7 @@ use kernel::{
     prelude::*,
     sync::{Ref, SpinLock},
     user_ptr::UserSlicePtrWriter,
-    Error, ScopeGuard,
+    ScopeGuard,
 };
 
 use crate::{

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -5,8 +5,6 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use alloc::boxed::Box;
-use core::pin::Pin;
 use kernel::{
     file::File,
     file_operations::{FileOpener, FileOperations},

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -13,7 +13,7 @@
 
 pub use core::pin::Pin;
 
-pub use alloc::{borrow::ToOwned, boxed::Box, string::String, sync::Arc, vec::Vec};
+pub use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 
 pub use macros::{module, module_misc_device};
 

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -11,7 +11,9 @@
 //! use kernel::prelude::*;
 //! ```
 
-pub use alloc::{borrow::ToOwned, string::String};
+pub use core::pin::Pin;
+
+pub use alloc::{borrow::ToOwned, boxed::Box, string::String, sync::Arc, vec::Vec};
 
 pub use super::build_assert;
 
@@ -21,6 +23,6 @@ pub use super::{pr_alert, pr_crit, pr_emerg, pr_err, pr_info, pr_notice, pr_warn
 
 pub use super::static_assert;
 
-pub use super::{KernelModule, Result};
+pub use super::{Error, KernelModule, Result};
 
 pub use crate::traits::TryPin;

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -15,9 +15,9 @@ pub use core::pin::Pin;
 
 pub use alloc::{borrow::ToOwned, boxed::Box, string::String, sync::Arc, vec::Vec};
 
-pub use super::build_assert;
-
 pub use macros::{module, module_misc_device};
+
+pub use super::build_assert;
 
 pub use super::{pr_alert, pr_crit, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
 

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -2,8 +2,8 @@
 
 //! The `kernel` prelude.
 //!
-//! These are most common items used by Rust code in the kernel, intended to
-//! be imported by all Rust code, for convenience.
+//! These are the most common items used by Rust code in the kernel,
+//! intended to be imported by all Rust code, for convenience.
 //!
 //! # Examples
 //!

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -5,8 +5,6 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use alloc::boxed::Box;
-use core::pin::Pin;
 use kernel::prelude::*;
 use kernel::{c_str, chrdev, file_operations::FileOperations};
 

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -5,8 +5,6 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use alloc::boxed::Box;
-use core::pin::Pin;
 use kernel::prelude::*;
 use kernel::{
     c_str,
@@ -15,7 +13,6 @@ use kernel::{
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
     sync::{CondVar, Mutex, Ref},
-    Error,
 };
 
 module! {

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -16,11 +16,7 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use alloc::boxed::Box;
-use core::{
-    pin::Pin,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use core::sync::atomic::{AtomicU64, Ordering};
 use kernel::{
     c_str, condvar_init, declare_file_operations,
     file::File,
@@ -31,7 +27,6 @@ use kernel::{
     prelude::*,
     sync::{CondVar, Mutex, Ref},
     user_ptr::{UserSlicePtrReader, UserSlicePtrWriter},
-    Error,
 };
 
 module! {

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -5,8 +5,6 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use alloc::boxed::Box;
-use core::pin::Pin;
 use kernel::prelude::*;
 use kernel::{
     condvar_init, mutex_init, spinlock_init,


### PR DESCRIPTION
A bunch of types that are common enough that we should graduate them to the prelude.

It also helps avoiding kernel modules using a similar name.