### PR TITLE
rename RUSTCFLAGS to RUSTFLAGS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
       - if: matrix.sysroot == 'custom'
         run: |
           echo 'RUSTC_SYSROOT=--sysroot=$HOME/sysroot' >> $GITHUB_ENV
-          echo "MAKE_SYSROOT=KRUSTCFLAGS=--sysroot=$HOME/sysroot" >> $GITHUB_ENV
+          echo "MAKE_SYSROOT=KRUSTFLAGS=--sysroot=$HOME/sysroot" >> $GITHUB_ENV
 
       # Setup: custom pre-built binaries folder
       - run: |

--- a/Documentation/kbuild/kbuild.rst
+++ b/Documentation/kbuild/kbuild.rst
@@ -57,7 +57,7 @@ CFLAGS_MODULE
 -------------
 Additional module specific options to use for $(CC).
 
-KRUSTCFLAGS
+KRUSTFLAGS
 -----------
 Additional options to the Rust compiler (for built-in and modules).
 

--- a/Makefile
+++ b/Makefile
@@ -488,11 +488,11 @@ CHECKFLAGS     := -D__linux__ -Dlinux -D__STDC__ -Dunix -D__unix__ \
 		  -Wbitwise -Wno-return-void -Wno-unknown-attribute $(CF)
 NOSTDINC_FLAGS :=
 CFLAGS_MODULE   =
-RUSTCFLAGS_MODULE =
+RUSTFLAGS_MODULE =
 AFLAGS_MODULE   =
 LDFLAGS_MODULE  =
 CFLAGS_KERNEL	=
-RUSTCFLAGS_KERNEL =
+RUSTFLAGS_KERNEL =
 AFLAGS_KERNEL	=
 LDFLAGS_vmlinux =
 
@@ -521,8 +521,8 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -Werror=return-type -Wno-format-security \
 		   -std=gnu89
 KBUILD_CPPFLAGS := -D__KERNEL__
-KBUILD_RUSTC_TARGET := $(srctree)/arch/$(SRCARCH)/rust/target.json
-KBUILD_RUSTCFLAGS := --emit=dep-info,obj,metadata --edition=2018 \
+KBUILD_RUST_TARGET := $(srctree)/arch/$(SRCARCH)/rust/target.json
+KBUILD_RUSTFLAGS := --emit=dep-info,obj,metadata --edition=2018 \
 		     -Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
 		     -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
@@ -532,10 +532,10 @@ KBUILD_CLIPPYFLAGS := -Dclippy::correctness -Dclippy::style \
 		      -Dclippy::complexity -Dclippy::perf
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
-KBUILD_RUSTCFLAGS_KERNEL :=
+KBUILD_RUSTFLAGS_KERNEL :=
 KBUILD_AFLAGS_MODULE  := -DMODULE
 KBUILD_CFLAGS_MODULE  := -DMODULE
-KBUILD_RUSTCFLAGS_MODULE := --cfg MODULE
+KBUILD_RUSTFLAGS_MODULE := --cfg MODULE
 KBUILD_LDFLAGS_MODULE :=
 KBUILD_LDFLAGS :=
 CLANG_FLAGS :=
@@ -563,10 +563,10 @@ export KBUILD_HOSTCXXFLAGS KBUILD_HOSTLDFLAGS KBUILD_HOSTLDLIBS LDFLAGS_MODULE
 
 export KBUILD_CPPFLAGS NOSTDINC_FLAGS LINUXINCLUDE OBJCOPYFLAGS KBUILD_LDFLAGS
 export KBUILD_CFLAGS CFLAGS_KERNEL CFLAGS_MODULE
-export KBUILD_RUSTC_TARGET KBUILD_RUSTCFLAGS RUSTCFLAGS_KERNEL RUSTCFLAGS_MODULE
+export KBUILD_RUST_TARGET KBUILD_RUSTFLAGS RUSTFLAGS_KERNEL RUSTFLAGS_MODULE
 export KBUILD_AFLAGS AFLAGS_KERNEL AFLAGS_MODULE
-export KBUILD_AFLAGS_MODULE KBUILD_CFLAGS_MODULE KBUILD_RUSTCFLAGS_MODULE KBUILD_LDFLAGS_MODULE
-export KBUILD_AFLAGS_KERNEL KBUILD_CFLAGS_KERNEL KBUILD_RUSTCFLAGS_KERNEL
+export KBUILD_AFLAGS_MODULE KBUILD_CFLAGS_MODULE KBUILD_RUSTFLAGS_MODULE KBUILD_LDFLAGS_MODULE
+export KBUILD_AFLAGS_KERNEL KBUILD_CFLAGS_KERNEL KBUILD_RUSTFLAGS_KERNEL
 
 # Files to ignore in find ... statements
 
@@ -793,42 +793,42 @@ KBUILD_CFLAGS	+= $(call cc-disable-warning, format-overflow)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, address-of-packed-member)
 
 ifdef CONFIG_RUST_DEBUG_ASSERTIONS
-KBUILD_RUSTCFLAGS += -Cdebug-assertions=y
+KBUILD_RUSTFLAGS += -Cdebug-assertions=y
 else
-KBUILD_RUSTCFLAGS += -Cdebug-assertions=n
+KBUILD_RUSTFLAGS += -Cdebug-assertions=n
 endif
 
 ifdef CONFIG_RUST_OVERFLOW_CHECKS
-KBUILD_RUSTCFLAGS += -Coverflow-checks=y
+KBUILD_RUSTFLAGS += -Coverflow-checks=y
 else
-KBUILD_RUSTCFLAGS += -Coverflow-checks=n
+KBUILD_RUSTFLAGS += -Coverflow-checks=n
 endif
 
 ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
 KBUILD_CFLAGS += -O2
-KBUILD_RUSTCFLAGS_OPT_LEVEL_MAP := 2
+KBUILD_RUSTFLAGS_OPT_LEVEL_MAP := 2
 else ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE_O3
 KBUILD_CFLAGS += -O3
-KBUILD_RUSTCFLAGS_OPT_LEVEL_MAP := 3
+KBUILD_RUSTFLAGS_OPT_LEVEL_MAP := 3
 else ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
 KBUILD_CFLAGS += -Os
-KBUILD_RUSTCFLAGS_OPT_LEVEL_MAP := z
+KBUILD_RUSTFLAGS_OPT_LEVEL_MAP := z
 endif
 
 ifdef CONFIG_RUST_OPT_LEVEL_SIMILAR_AS_CHOSEN_FOR_C
-KBUILD_RUSTCFLAGS += -Copt-level=$(KBUILD_RUSTCFLAGS_OPT_LEVEL_MAP)
+KBUILD_RUSTFLAGS += -Copt-level=$(KBUILD_RUSTFLAGS_OPT_LEVEL_MAP)
 else ifdef CONFIG_RUST_OPT_LEVEL_0
-KBUILD_RUSTCFLAGS += -Copt-level=0
+KBUILD_RUSTFLAGS += -Copt-level=0
 else ifdef CONFIG_RUST_OPT_LEVEL_1
-KBUILD_RUSTCFLAGS += -Copt-level=1
+KBUILD_RUSTFLAGS += -Copt-level=1
 else ifdef CONFIG_RUST_OPT_LEVEL_2
-KBUILD_RUSTCFLAGS += -Copt-level=2
+KBUILD_RUSTFLAGS += -Copt-level=2
 else ifdef CONFIG_RUST_OPT_LEVEL_3
-KBUILD_RUSTCFLAGS += -Copt-level=3
+KBUILD_RUSTFLAGS += -Copt-level=3
 else ifdef CONFIG_RUST_OPT_LEVEL_S
-KBUILD_RUSTCFLAGS += -Copt-level=s
+KBUILD_RUSTFLAGS += -Copt-level=s
 else ifdef CONFIG_RUST_OPT_LEVEL_Z
-KBUILD_RUSTCFLAGS += -Copt-level=z
+KBUILD_RUSTFLAGS += -Copt-level=z
 endif
 
 # Tell gcc to never replace conditional load with a non-conditional one
@@ -878,7 +878,7 @@ KBUILD_CFLAGS += $(call cc-disable-warning, unused-but-set-variable)
 KBUILD_CFLAGS += $(call cc-disable-warning, unused-const-variable)
 ifdef CONFIG_FRAME_POINTER
 KBUILD_CFLAGS	+= -fno-omit-frame-pointer -fno-optimize-sibling-calls
-KBUILD_RUSTCFLAGS += -Cforce-frame-pointers=y
+KBUILD_RUSTFLAGS += -Cforce-frame-pointers=y
 else
 # Some targets (ARM with Thumb2, for example), can't be built with frame
 # pointers.  For those, we don't have FUNCTION_TRACER automatically
@@ -916,7 +916,7 @@ ifdef CONFIG_CC_IS_GCC
 DEBUG_CFLAGS	+= $(call cc-ifversion, -lt, 0500, $(call cc-option, -fno-var-tracking-assignments))
 endif
 
-DEBUG_RUSTCFLAGS :=
+DEBUG_RUSTFLAGS :=
 
 ifdef CONFIG_DEBUG_INFO
 
@@ -929,9 +929,9 @@ endif
 ifneq ($(LLVM_IAS),1)
 KBUILD_AFLAGS	+= -Wa,-gdwarf-2
 ifdef CONFIG_DEBUG_INFO_REDUCED
-DEBUG_RUSTCFLAGS += -Cdebuginfo=1
+DEBUG_RUSTFLAGS += -Cdebuginfo=1
 else
-DEBUG_RUSTCFLAGS += -Cdebuginfo=2
+DEBUG_RUSTFLAGS += -Cdebuginfo=2
 endif
 endif
 
@@ -957,8 +957,8 @@ endif # CONFIG_DEBUG_INFO
 KBUILD_CFLAGS += $(DEBUG_CFLAGS)
 export DEBUG_CFLAGS
 
-KBUILD_RUSTCFLAGS += $(DEBUG_RUSTCFLAGS)
-export DEBUG_RUSTCFLAGS
+KBUILD_RUSTFLAGS += $(DEBUG_RUSTFLAGS)
+export DEBUG_RUSTFLAGS
 
 ifdef CONFIG_FUNCTION_TRACER
 ifdef CONFIG_FTRACE_MCOUNT_USE_CC
@@ -1115,11 +1115,11 @@ include $(addprefix $(srctree)/, $(include-y))
 # Do not add $(call cc-option,...) below this line. When you build the kernel
 # from the clean source tree, the GCC plugins do not exist at this point.
 
-# Add user supplied CPPFLAGS, AFLAGS, CFLAGS and RUSTCFLAGS as the last assignments
+# Add user supplied CPPFLAGS, AFLAGS, CFLAGS and RUSTFLAGS as the last assignments
 KBUILD_CPPFLAGS += $(KCPPFLAGS)
 KBUILD_AFLAGS   += $(KAFLAGS)
 KBUILD_CFLAGS   += $(KCFLAGS)
-KBUILD_RUSTCFLAGS += $(KRUSTCFLAGS)
+KBUILD_RUSTFLAGS += $(KRUSTFLAGS)
 
 KBUILD_LDFLAGS_MODULE += --build-id=sha1
 LDFLAGS_vmlinux += --build-id=sha1

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -54,7 +54,7 @@ riscv-march-$(CONFIG_FPU)		:= $(riscv-march-y)fd
 riscv-march-$(CONFIG_RISCV_ISA_C)	:= $(riscv-march-y)c
 KBUILD_CFLAGS += -march=$(subst fd,,$(riscv-march-y))
 KBUILD_AFLAGS += -march=$(riscv-march-y)
-KBUILD_RUSTC_TARGET := $(srctree)/arch/riscv/rust/$(subst fd,,$(riscv-march-y)).json
+KBUILD_RUST_TARGET := $(srctree)/arch/riscv/rust/$(subst fd,,$(riscv-march-y)).json
 
 KBUILD_CFLAGS += -mno-save-restore
 KBUILD_CFLAGS += -DCONFIG_PAGE_OFFSET=$(CONFIG_PAGE_OFFSET)

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -31,7 +31,7 @@ endif
 quiet_cmd_rustdoc = RUSTDOC $(if $(rustdoc_host),H, ) $<
       cmd_rustdoc = \
 	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
-	$(RUSTDOC) $(if $(rustdoc_host),,$(rustc_cross_flags)) \
+	$(RUSTDOC) $(if $(rustdoc_host),,$(rust_cross_flags)) \
 		$(filter-out -Cpanic=abort, $(filter-out --emit=%, $(rustc_flags))) \
 		$(rustc_target_flags) -L $(objtree)/rust \
 		--output $(objtree)/rust/doc --crate-name $(subst rustdoc-,,$@) \
@@ -267,7 +267,7 @@ quiet_cmd_rustc_library = $(if $(skip_clippy),RUSTC,$(RUSTC_OR_CLIPPY_QUIET)) L 
       cmd_rustc_library = \
 	RUST_BINDINGS_FILE=$(abspath $(objtree)/rust/bindings_generated.rs) \
 	$(if $(skip_clippy),$(RUSTC),$(RUSTC_OR_CLIPPY)) \
-		$(rustc_flags) $(rustc_cross_flags) $(rustc_target_flags) \
+		$(rustc_flags) $(rust_cross_flags) $(rustc_target_flags) \
 		--crate-type rlib --out-dir $(objtree)/rust/ -L $(objtree)/rust/ \
 		--crate-name $(patsubst %.o,%,$(notdir $@)) $<; \
 	mv $(objtree)/rust/$(patsubst %.o,%,$(notdir $@)).d $(depfile); \

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -26,7 +26,7 @@ EXTRA_CPPFLAGS :=
 EXTRA_LDFLAGS  :=
 asflags-y  :=
 ccflags-y  :=
-rustcflags-y :=
+rustflags-y :=
 cppflags-y :=
 ldflags-y  :=
 
@@ -294,12 +294,12 @@ $(obj)/%.lst: $(src)/%.c FORCE
 
 # Need to use absolute path here and have symbolic links resolved;
 # otherwise rustdoc and rustc compute different hashes for the target.
-rustc_cross_flags := --target=$(realpath $(KBUILD_RUSTC_TARGET))
+rust_cross_flags := --target=$(realpath $(KBUILD_RUST_TARGET))
 
 quiet_cmd_rustc_o_rs = $(RUSTC_OR_CLIPPY_QUIET) $(quiet_modtag) $@
       cmd_rustc_o_rs = \
 	RUST_MODFILE=$(modfile) \
-	$(RUSTC_OR_CLIPPY) $(rustc_flags) $(rustc_cross_flags) \
+	$(RUSTC_OR_CLIPPY) $(rustc_flags) $(rust_cross_flags) \
 		-Zallow-features=allocator_api,bench_black_box,concat_idents,global_asm,try_reserve \
 		--extern alloc --extern kernel \
 		--crate-type rlib --out-dir $(obj) -L $(objtree)/rust/ \

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -8,7 +8,7 @@ ldflags-y  += $(EXTRA_LDFLAGS)
 # flags that take effect in current and sub directories
 KBUILD_AFLAGS += $(subdir-asflags-y)
 KBUILD_CFLAGS += $(subdir-ccflags-y)
-KBUILD_RUSTCFLAGS += $(subdir-rustcflags-y)
+KBUILD_RUSTFLAGS += $(subdir-rustflags-y)
 
 # Figure out what we need to build from the various variables
 # ===========================================================================
@@ -134,10 +134,10 @@ _c_flags       = $(filter-out $(CFLAGS_REMOVE_$(target-stem).o), \
                      $(filter-out $(ccflags-remove-y), \
                          $(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS) $(ccflags-y)) \
                      $(CFLAGS_$(target-stem).o))
-_rustc_flags    = $(filter-out $(RUSTCFLAGS_REMOVE_$(target-stem).o), \
-                     $(filter-out $(rustcflags-remove-y), \
-                         $(KBUILD_RUSTCFLAGS) $(rustcflags-y)) \
-                     $(RUSTCFLAGS_$(target-stem).o))
+_rustc_flags    = $(filter-out $(RUSTFLAGS_REMOVE_$(target-stem).o), \
+                     $(filter-out $(rustflags-remove-y), \
+                         $(KBUILD_RUSTFLAGS) $(rustflags-y)) \
+                     $(RUSTFLAGS_$(target-stem).o))
 _a_flags       = $(filter-out $(AFLAGS_REMOVE_$(target-stem).o), \
                      $(filter-out $(asflags-remove-y), \
                          $(KBUILD_CPPFLAGS) $(KBUILD_AFLAGS) $(asflags-y)) \
@@ -207,10 +207,10 @@ modkern_cflags =                                          \
 		$(KBUILD_CFLAGS_MODULE) $(CFLAGS_MODULE), \
 		$(KBUILD_CFLAGS_KERNEL) $(CFLAGS_KERNEL) $(modfile_flags))
 
-modkern_rustcflags =                                              \
+modkern_rustflags =                                              \
 	$(if $(part-of-module),                                   \
-		$(KBUILD_RUSTCFLAGS_MODULE) $(RUSTCFLAGS_MODULE), \
-		$(KBUILD_RUSTCFLAGS_KERNEL) $(RUSTCFLAGS_KERNEL))
+		$(KBUILD_RUSTFLAGS_MODULE) $(RUSTFLAGS_MODULE), \
+		$(KBUILD_RUSTFLAGS_KERNEL) $(RUSTFLAGS_KERNEL))
 
 modkern_aflags = $(if $(part-of-module),				\
 			$(KBUILD_AFLAGS_MODULE) $(AFLAGS_MODULE),	\
@@ -221,7 +221,7 @@ c_flags        = -Wp,-MMD,$(depfile) $(NOSTDINC_FLAGS) $(LINUXINCLUDE)     \
 		 $(_c_flags) $(modkern_cflags)                           \
 		 $(basename_flags) $(modname_flags)
 
-rustc_flags     = $(_rustc_flags) $(modkern_rustcflags) @$(objtree)/include/generated/rustc_cfg
+rustc_flags     = $(_rustc_flags) $(modkern_rustflags) @$(objtree)/include/generated/rustc_cfg
 
 a_flags        = -Wp,-MMD,$(depfile) $(NOSTDINC_FLAGS) $(LINUXINCLUDE)     \
 		 $(_a_flags) $(modkern_aflags)


### PR DESCRIPTION
Cargo uses `RUSTFLAGS` and `rustflags` while currently the name in
Kbuild is `RUSTCFLAGS` and `rustcflags`. Rename the flags to be
consistent with Rust ecosystem to reduce potential confusion in the
future.

I think it's important to have this changed before the next LKML drop.

Fixes #327