### PR TITLE
Makefile: enable Rust `float_arithmetic` Clippy lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,7 @@ KBUILD_RUSTFLAGS := --emit=dep-info,obj,metadata --edition=2018 \
 		     -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
 		     -Wmissing_docs
 KBUILD_CLIPPYFLAGS := -Dclippy::correctness -Dclippy::style \
-		      -Dclippy::complexity -Dclippy::perf
+		      -Dclippy::complexity -Dclippy::perf -Dclippy::float_arithmetic
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
 KBUILD_RUSTFLAGS_KERNEL :=


### PR DESCRIPTION
Suggested-by: Amanieu d'Antras <amanieu@gmail.com>
Suggested-by: Gary Guo <gary@garyguo.net>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>