### PR TITLE
rust: add `Ref::into_raw` and `Ref::from_raw`.

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -21,6 +21,7 @@
     const_raw_ptr_deref,
     const_unreachable_unchecked,
     doc_cfg,
+    ptr_metadata,
     receiver_trait,
     coerce_unsized,
     dispatch_from_dyn,


### PR DESCRIPTION
This is meant to be used in intrusive data structures like `LinkedList`
when `T` doesn't have a known size at compile time. In such cases, the
raw pointer is wide and therefore doesn't fit in a single `usize`.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>