### PR TITLE
Fix link to Quick Start guide in Index doc

### DIFF
--- a/Documentation/rust/index.rst
+++ b/Documentation/rust/index.rst
@@ -2,7 +2,7 @@ Rust
 ====
 
 Documentation related to Rust within the kernel. If you are starting out,
-read the :ref:`Documentation/rust/quick-start.rst <rust_quick_start>` guide.
+read the [Quick Start](https://github.com/Rust-for-Linux/linux/blob/rust/Documentation/rust/quick-start.rst) guide.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Currently, /Documentation/rust/index.rst has a broken reference to the Quick Start guide. Fixing so that it links correctly to the Quick Start guide.
 
![image](https://user-images.githubusercontent.com/8989334/125145929-84854a00-e0f1-11eb-809b-af00a5c80e4b.png)

This is also my first contribution to the project. I hope I get to contribute a lot more substantially in the future. 