### PR TITLE
rust: Removes alloc_error_handler feature

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -14,7 +14,6 @@
 #![no_std]
 #![feature(
     allocator_api,
-    alloc_error_handler,
     associated_type_defaults,
     const_fn_trait_bound,
     const_mut_refs,


### PR DESCRIPTION
Closes #431 

Signed-off-by: Dariusz Sosnowski <dsosnowski@dsosnowski.pl