### PR TITLE
docs: rust: GDB 10.2 and Binutils 2.36 come with v0 support

### DIFF
--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -208,11 +208,7 @@ If you use GDB/Binutils and Rust symbols aren't getting demangled, the reason
 is your toolchain doesn't support Rust's new v0 mangling scheme yet. There are
 a few ways out:
 
-  - If you don't mind building your own tools, we provide the following fork
-    with the support cherry-picked from GCC:
-
-        https://github.com/Rust-for-Linux/binutils-gdb/releases/tag/gdb-10.1-release-rust
-        https://github.com/Rust-for-Linux/binutils-gdb/releases/tag/binutils-2_35_1-rust
+  - Install a newer release (GDB >= 10.2, Binutils >= 2.36).
 
   - If you only need GDB and can enable ``CONFIG_DEBUG_INFO``, do so:
     some versions of GDB (e.g. vanilla GDB 10.1) are able to use


### PR DESCRIPTION
Thus we can archive the repo with the backported support.

Link: https://lore.kernel.org/lkml/CANiq72mronNX4MfKGvzQTe0R3Fd=2M32bX8acdaij9sGopmerg@mail.gmail.com/
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>