### PR TITLE
Support generating all docs, introduce `doc_cfg` and `doc_all`

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -20,6 +20,7 @@
     const_panic,
     const_raw_ptr_deref,
     const_unreachable_unchecked,
+    doc_cfg,
     receiver_trait,
     try_reserve
 )]

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -64,7 +64,8 @@ pub mod random;
 mod static_assert;
 pub mod sync;
 
-#[cfg(CONFIG_SYSCTL)]
+#[cfg(any(CONFIG_SYSCTL, doc))]
+#[doc(cfg(CONFIG_SYSCTL))]
 pub mod sysctl;
 
 pub mod io_buffer;


### PR DESCRIPTION
See individual commits for details.

See https://github.com/Rust-for-Linux/linux/issues/442 for more details.