### PR TITLE
Fix dead_code in rust KParamGuard.

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -149,13 +149,21 @@ pub struct KParamGuard<'a> {
     this_module: &'a ThisModule,
 }
 
-#[cfg(CONFIG_SYSFS)]
 impl<'a> Drop for KParamGuard<'a> {
+    #[cfg(CONFIG_SYSFS)]
     fn drop(&mut self) {
         // SAFETY: `kernel_param_lock` will check if the pointer is null and
         // use the built-in mutex in that case. The existance of `self`
         // guarantees that the lock is held.
         unsafe { bindings::kernel_param_unlock(self.this_module.0) }
+    }
+
+    // This "empty" `Drop` implementation is kept so that the behavior remains
+    // the same with and without `CONFIG_SYSFS` with respect to `dropck`.
+    #[cfg(not(CONFIG_SYSFS))]
+    fn drop(&mut self) {
+        // Touches the `this_module` field, to prevent dead_code warnings.
+        let _ = self.this_module;
     }
 }
 


### PR DESCRIPTION
Noticed as part of #439 With disabled `CONFIG_SYSFS`