### PR TITLE
rust: add `pr_debug`.

### DIFF
--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -19,7 +19,7 @@ pub use macros::{module, module_misc_device};
 
 pub use super::build_assert;
 
-pub use super::{pr_alert, pr_crit, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
+pub use super::{pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
 
 pub use super::static_assert;
 

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -384,6 +384,35 @@ macro_rules! pr_info (
     )
 );
 
+/// Prints a debug-level message (level 7).
+///
+/// Use this level for debug messages.
+///
+/// Equivalent to the kernel's [`pr_debug`] macro, except that it doesn't support dynamic debug
+/// yet.
+///
+/// Mimics the interface of [`std::print!`]. See [`core::fmt`] and
+/// [`alloc::format!`] for information about the formatting syntax.
+///
+/// [`pr_debug`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html#c.pr_debug
+/// [`std::print!`]: https://doc.rust-lang.org/std/macro.print.html
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::prelude::*;
+/// pr_debug!("hello {}\n", "there");
+/// ```
+#[macro_export]
+#[doc(alias = "print")]
+macro_rules! pr_debug (
+    ($($arg:tt)*) => (
+        if cfg!(debug_assertions) {
+            $crate::print_macro!($crate::print::format_strings::DEBUG, false, $($arg)*)
+        }
+    )
+);
+
 /// Continues a previous log message in the same line.
 ///
 /// Use only when continuing a previous `pr_*!` macro (e.g. [`pr_info!`]).


### PR DESCRIPTION
This is used in the PL061 driver while we don't have `dev_` variants.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>