### PR TITLE
rust: allow state to be saved in lock guards.

### DIFF
--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -81,12 +81,12 @@ impl CondVar {
         }
 
         // SAFETY: The guard is evidence that the caller owns the lock.
-        unsafe { lock.unlock() };
+        unsafe { lock.unlock(&mut guard.context) };
 
         // SAFETY: No arguments, switches to another thread.
         unsafe { bindings::schedule() };
 
-        lock.lock_noguard();
+        guard.context = lock.lock_noguard();
 
         // SAFETY: Both `wait` and `wait_list` point to valid memory.
         unsafe { bindings::finish_wait(self.wait_list.get(), wait.as_mut_ptr()) };


### PR DESCRIPTION
No functional changes are expected.

This is in preparation for adding spinlocks that disable interrupts when
locking and restore interrupt state when unlocking. We need to save the
interrupt state to be stored.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>