### PR TITLE
rust: add support for trait objects in `Ref`s.

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -22,6 +22,9 @@
     const_unreachable_unchecked,
     doc_cfg,
     receiver_trait,
+    coerce_unsized,
+    dispatch_from_dyn,
+    unsize,
     try_reserve
 )]
 


### PR DESCRIPTION
This allows, for example, the automatic coercion from `Ref<T>` to
`Ref<dyn U>` when `U` is a trait implemented by `T`. It also allows
`Ref<dyn U>` to be used as the receiver in a trait object.

These traits are also implemented by `Arc`, and this is in preparation
for replacing all usages of `Arc` with `Ref`, which is needed before we
can remove `Arc` from the `alloc` crate.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>