### PR TITLE
rust: move to stable `rustc` release (`1.54.0`)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         arch: [arm, arm64, ppc64le, riscv64, x86_64]
         toolchain: [gcc, clang, llvm]
         config: [debug, release]
-        rustc: [2021-06-23]
+        rustc: [1.54.0]
         output: [src] # [src, build]
         install: [rustup] # [rustup, standalone]
         sysroot: [common] # [common, custom]
@@ -37,7 +37,7 @@ jobs:
           - arch: arm64
             toolchain: gcc
             config: debug
-            rustc: 2021-06-23
+            rustc: 1.54.0
             output: build
             install: rustup
             sysroot: custom
@@ -45,7 +45,7 @@ jobs:
           - arch: ppc64le
             toolchain: clang
             config: release
-            rustc: 2021-06-23
+            rustc: 1.54.0
             output: build
             install: standalone
             sysroot: common
@@ -53,7 +53,7 @@ jobs:
           - arch: x86_64
             toolchain: llvm
             config: debug
-            rustc: 2021-06-23
+            rustc: 1.54.0
             output: build
             install: standalone
             sysroot: custom
@@ -178,14 +178,12 @@ jobs:
       # Setup: rustc
       - if: matrix.install == 'rustup'
         run: |
-          rustup default beta-${{ matrix.rustc }}
+          rustup default ${{ matrix.rustc }}
           rustup component add rustfmt
       - if: matrix.install == 'standalone'
         run: |
-          # FIXME: there is no beta equivalent for https://static.rust-lang.org/dist/channel-rust-x.yy.z.toml,
-          # so just hardcode the URL/date for the moment, since we will moving to a stable release soon anyway.
-          curl https://static.rust-lang.org/dist/${{ matrix.rustc }}/rust-beta-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          rust-beta-x86_64-unknown-linux-gnu/install.sh --without=rust-docs --prefix=$HOME/rustc
+          curl https://static.rust-lang.org/dist/rust-${{ matrix.rustc }}-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          rust-${{ matrix.rustc }}-x86_64-unknown-linux-gnu/install.sh --without=rust-docs --prefix=$HOME/rustc
           echo $HOME/rustc/bin >> $GITHUB_PATH
 
       # Setup: rustc native libs

--- a/Documentation/process/changes.rst
+++ b/Documentation/process/changes.rst
@@ -36,7 +36,7 @@ know what you are doing, use the exact version listed here. Please see
 ====================== ===============  ========================================
 GNU C                  4.9              gcc --version
 Clang/LLVM (optional)  10.0.1           clang --version
-rustc (optional)       1.54.0-beta.1    rustc --version
+rustc (optional)       1.54.0           rustc --version
 bindgen (optional)     0.56.0           bindgen --version
 GNU make               3.81             make --version
 binutils               2.23             ld -v

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -23,14 +23,13 @@ at the time of writing, they are likely to not be recent enough.
 rustc
 *****
 
-A particular version (`1.54.0-beta.1`) of the Rust compiler is required.
-Newer versions may or may not work because, for the moment, we depend on
-some unstable Rust features.
+A particular version of the Rust compiler is required. Newer versions may or
+may not work because, for the moment, we depend on some unstable Rust features.
 
 If you are using ``rustup``, enter the checked out source code directory
 and run::
 
-    rustup override set beta-2021-06-23
+    rustup override set 1.54.0
 
 Otherwise, fetch a standalone installer or install ``rustup`` from:
 


### PR DESCRIPTION
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>