### PR TITLE
rust: implement `TryFrom<Vec<T>>` for `Ref<[T]>`.

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -6,7 +6,10 @@
 
 use crate::str::CStr;
 use crate::{bindings, c_types};
-use alloc::{alloc::AllocError, collections::TryReserveError};
+use alloc::{
+    alloc::{AllocError, LayoutError},
+    collections::TryReserveError,
+};
 use core::convert::From;
 use core::fmt;
 use core::num::TryFromIntError;
@@ -381,6 +384,12 @@ impl From<Utf8Error> for Error {
 
 impl From<TryReserveError> for Error {
     fn from(_: TryReserveError) -> Error {
+        Error::ENOMEM
+    }
+}
+
+impl From<LayoutError> for Error {
+    fn from(_: LayoutError) -> Error {
         Error::ENOMEM
     }
 }

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -16,11 +16,14 @@
 //! [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 
 use crate::{bindings, Error, Result};
-use alloc::alloc::{alloc, dealloc};
+use alloc::{
+    alloc::{alloc, dealloc},
+    vec::Vec,
+};
 use core::{
     alloc::Layout,
     cell::UnsafeCell,
-    convert::AsRef,
+    convert::{AsRef, TryFrom},
     marker::{PhantomData, Unsize},
     mem::ManuallyDrop,
     ops::Deref,
@@ -262,6 +265,44 @@ impl<T: ?Sized> Drop for Ref<T> {
             // SAFETY: The pointer was initialised from the result of a call to `alloc`.
             unsafe { dealloc(self.ptr.cast().as_ptr(), layout) };
         }
+    }
+}
+
+impl<T> TryFrom<Vec<T>> for Ref<[T]> {
+    type Error = Error;
+
+    fn try_from(mut v: Vec<T>) -> Result<Self> {
+        let value_layout = Layout::array::<T>(v.len())?;
+        let layout = Layout::new::<RefInner<()>>()
+            .extend(value_layout)?
+            .0
+            .pad_to_align();
+        // SAFETY: The layout size is guaranteed to be non-zero because `RefInner` contains the
+        // reference count.
+        let ptr = NonNull::new(unsafe { alloc(layout) }).ok_or(Error::ENOMEM)?;
+        let inner =
+            core::ptr::slice_from_raw_parts_mut(ptr.as_ptr() as _, v.len()) as *mut RefInner<[T]>;
+
+        // SAFETY: Just an FFI call that returns a `refcount_t` initialised to 1.
+        let count = UnsafeCell::new(unsafe { bindings::REFCOUNT_INIT(1) });
+        // SAFETY: `inner.refcount` is writable and properly aligned.
+        unsafe { core::ptr::addr_of_mut!((*inner).refcount).write(count) };
+        // SAFETY: The contents of `v` as readable and properly aligned; `inner.data` is writable
+        // and properly aligned. There is no overlap between the two because `inner` is a new
+        // allocation.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                v.as_ptr(),
+                core::ptr::addr_of_mut!((*inner).data) as *mut [T] as *mut T,
+                v.len(),
+            )
+        };
+        // SAFETY: We're setting the new length to zero, so it is <= to capacity, and old_len..0 is
+        // an empty range (so satisfies vacuously the requirement of being initialised).
+        unsafe { v.set_len(0) };
+        // SAFETY: We just created `inner` with a reference count of 1, which is owned by the new
+        // `Ref` object.
+        Ok(unsafe { Self::from_inner(NonNull::new(inner).unwrap()) })
     }
 }
 


### PR DESCRIPTION
 This allows the conversion from a vector to a reference-counted array. A
 similar conversion is currently used in binder to convert to an
 `Arc`-based array; we'll switch it to be `Ref`-based.

Based on #466 

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>