### PR TITLE
rust: add `UniqueRef`.

### DIFF
--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -31,7 +31,7 @@ mod locked_by;
 mod mutex;
 mod spinlock;
 
-pub use arc::{Ref, RefBorrow};
+pub use arc::{Ref, RefBorrow, UniqueRef};
 pub use condvar::CondVar;
 pub use guard::{Guard, Lock};
 pub use locked_by::LockedBy;


### PR DESCRIPTION
This allows a ref-counted object to be allocated but initialised later.
It is useful, for example, to allocate in one context (e.g., sleepable
context) and initialise in a different context (e.g., atomic context).

It can also be used to get mutable references to the inner object after
it has been allocated, but before it can be shared (in which case it
becomes pinned and there is no safe path to the mutable inner object).

It is the last remaining feature before we can remove all usages of
`Arc<T>` from Binder.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>