### PR TITLE
binder: remove all usages of `Arc`.

### DIFF
--- a/drivers/android/allocation.rs
+++ b/drivers/android/allocation.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
 use core::mem::{replace, size_of, MaybeUninit};
-use kernel::{bindings, linked_list::List, pages::Pages, prelude::*, user_ptr::UserSlicePtrReader};
+use kernel::{
+    bindings, linked_list::List, pages::Pages, prelude::*, sync::Ref, user_ptr::UserSlicePtrReader,
+};
 
 use crate::{
     defs::*,
@@ -15,7 +17,7 @@ pub(crate) struct Allocation<'a> {
     pub(crate) offset: usize,
     size: usize,
     pub(crate) ptr: usize,
-    pages: Arc<[Pages<0>]>,
+    pages: Ref<[Pages<0>]>,
     pub(crate) process: &'a Process,
     allocation_info: Option<AllocationInfo>,
     free_on_drop: bool,
@@ -28,7 +30,7 @@ impl<'a> Allocation<'a> {
         offset: usize,
         size: usize,
         ptr: usize,
-        pages: Arc<[Pages<0>]>,
+        pages: Ref<[Pages<0>]>,
     ) -> Self {
         Self {
             process,

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -40,7 +40,7 @@ impl CountState {
 struct NodeInner {
     strong: CountState,
     weak: CountState,
-    death_list: List<Arc<NodeDeath>>,
+    death_list: List<Ref<NodeDeath>>,
 }
 
 struct NodeDeathInner {
@@ -55,7 +55,7 @@ struct NodeDeathInner {
 }
 
 pub(crate) struct NodeDeath {
-    node: Arc<Node>,
+    node: Ref<Node>,
     process: Ref<Process>,
     // TODO: Make this private.
     pub(crate) cookie: usize,
@@ -72,7 +72,7 @@ impl NodeDeath {
     /// # Safety
     ///
     /// The caller must call `NodeDeath::init` before using the notification object.
-    pub(crate) unsafe fn new(node: Arc<Node>, process: Ref<Process>, cookie: usize) -> Self {
+    pub(crate) unsafe fn new(node: Ref<Node>, process: Ref<Process>, cookie: usize) -> Self {
         Self {
             node,
             process,
@@ -102,7 +102,7 @@ impl NodeDeath {
     /// once.
     ///
     /// Returns whether it needs to be queued.
-    pub(crate) fn set_cleared(self: &Arc<Self>, abort: bool) -> bool {
+    pub(crate) fn set_cleared(self: &Ref<Self>, abort: bool) -> bool {
         let (needs_removal, needs_queueing) = {
             // Update state and determine if we need to queue a work item. We only need to do it
             // when the node is not dead or if the user already completed the death notification.
@@ -127,7 +127,7 @@ impl NodeDeath {
     /// Sets the 'notification done' flag to `true`.
     ///
     /// Returns whether it needs to be queued.
-    pub(crate) fn set_notification_done(self: Arc<Self>, thread: &Thread) {
+    pub(crate) fn set_notification_done(self: Ref<Self>, thread: &Thread) {
         let needs_queueing = {
             let mut inner = self.inner.lock();
             inner.notification_done = true;
@@ -140,7 +140,7 @@ impl NodeDeath {
     }
 
     /// Sets the 'dead' flag to `true` and queues work item if needed.
-    pub(crate) fn set_dead(self: Arc<Self>) {
+    pub(crate) fn set_dead(self: Ref<Self>) {
         let needs_queueing = {
             let mut inner = self.inner.lock();
             if inner.cleared {
@@ -168,7 +168,7 @@ impl GetLinks for NodeDeath {
 }
 
 impl DeliverToRead for NodeDeath {
-    fn do_work(self: Arc<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
+    fn do_work(self: Ref<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         let done = {
             let inner = self.inner.lock();
             if inner.aborted {
@@ -245,13 +245,13 @@ impl Node {
     pub(crate) fn next_death(
         &self,
         guard: &mut Guard<'_, Mutex<ProcessInner>>,
-    ) -> Option<Arc<NodeDeath>> {
+    ) -> Option<Ref<NodeDeath>> {
         self.inner.access_mut(guard).death_list.pop_front()
     }
 
     pub(crate) fn add_death(
         &self,
-        death: Arc<NodeDeath>,
+        death: Ref<NodeDeath>,
         guard: &mut Guard<'_, Mutex<ProcessInner>>,
     ) {
         self.inner.access_mut(guard).death_list.push_back(death);
@@ -296,7 +296,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn update_refcount(self: &Arc<Self>, inc: bool, strong: bool) {
+    pub(crate) fn update_refcount(self: &Ref<Self>, inc: bool, strong: bool) {
         self.owner
             .inner
             .lock()
@@ -344,7 +344,7 @@ impl Node {
 }
 
 impl DeliverToRead for Node {
-    fn do_work(self: Arc<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
+    fn do_work(self: Ref<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         let mut owner_inner = self.owner.inner.lock();
         let inner = self.inner.access_mut(&mut owner_inner);
         let strong = inner.strong.count > 0;
@@ -396,13 +396,13 @@ impl DeliverToRead for Node {
 }
 
 pub struct NodeRef {
-    pub(crate) node: Arc<Node>,
+    pub(crate) node: Ref<Node>,
     strong_count: usize,
     weak_count: usize,
 }
 
 impl NodeRef {
-    pub(crate) fn new(node: Arc<Node>, strong_count: usize, weak_count: usize) -> Self {
+    pub(crate) fn new(node: Ref<Node>, strong_count: usize, weak_count: usize) -> Self {
         Self {
             node,
             strong_count,

--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -45,11 +45,11 @@ trait DeliverToRead {
     /// Performs work. Returns true if remaining work items in the queue should be processed
     /// immediately, or false if it should return to caller before processing additional work
     /// items.
-    fn do_work(self: Arc<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool>;
+    fn do_work(self: Ref<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool>;
 
     /// Cancels the given work item. This is called instead of [`DeliverToRead::do_work`] when work
     /// won't be delivered.
-    fn cancel(self: Arc<Self>) {}
+    fn cancel(self: Ref<Self>) {}
 
     /// Returns the linked list links for the work item.
     fn get_links(&self) -> &Links<dyn DeliverToRead>;
@@ -66,7 +66,7 @@ impl GetLinks for DeliverToReadListAdapter {
 }
 
 impl GetLinksWrapped for DeliverToReadListAdapter {
-    type Wrapped = Arc<dyn DeliverToRead>;
+    type Wrapped = Ref<dyn DeliverToRead>;
 }
 
 struct DeliverCode {
@@ -84,7 +84,7 @@ impl DeliverCode {
 }
 
 impl DeliverToRead for DeliverCode {
-    fn do_work(self: Arc<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
+    fn do_work(self: Ref<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         writer.write(&self.code)?;
         Ok(true)
     }

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -76,18 +76,18 @@ struct InnerThread {
     /// Work item used to deliver error codes to the thread that started a transaction. When set to
     /// `Some(x)`, it will hold the only reference to the object so that it can update the error
     /// code to be delivered before queuing it.
-    reply_work: Option<Arc<ThreadError>>,
+    reply_work: Option<Ref<ThreadError>>,
 
     /// Work item used to deliver error codes to the current thread. When set to `Some(x)`, it will
     /// hold the only reference to the object so that it can update the error code to be delivered
     /// before queuing.
-    return_work: Option<Arc<ThreadError>>,
+    return_work: Option<Ref<ThreadError>>,
 
     /// Determines whether the work list below should be processed. When set to false, `work_list`
     /// is treated as if it were empty.
     process_work_list: bool,
     work_list: List<DeliverToReadListAdapter>,
-    current_transaction: Option<Arc<Transaction>>,
+    current_transaction: Option<Ref<Transaction>>,
 }
 
 impl InnerThread {
@@ -103,7 +103,7 @@ impl InnerThread {
         }
     }
 
-    fn set_reply_work(&mut self, reply_work: Arc<ThreadError>) {
+    fn set_reply_work(&mut self, reply_work: Ref<ThreadError>) {
         self.reply_work = Some(reply_work);
     }
 
@@ -112,7 +112,7 @@ impl InnerThread {
         self.push_existing_work(work, code);
     }
 
-    fn set_return_work(&mut self, return_work: Arc<ThreadError>) {
+    fn set_return_work(&mut self, return_work: Ref<ThreadError>) {
         self.return_work = Some(return_work);
     }
 
@@ -121,7 +121,7 @@ impl InnerThread {
         self.push_existing_work(work, code);
     }
 
-    fn push_existing_work(&mut self, owork: Option<Arc<ThreadError>>, code: u32) {
+    fn push_existing_work(&mut self, owork: Option<Ref<ThreadError>>, code: u32) {
         // TODO: Write some warning when the following fails. It should not happen, and
         // if it does, there is likely something wrong.
         if let Some(work) = owork {
@@ -134,7 +134,7 @@ impl InnerThread {
         }
     }
 
-    fn pop_work(&mut self) -> Option<Arc<dyn DeliverToRead>> {
+    fn pop_work(&mut self) -> Option<Ref<dyn DeliverToRead>> {
         if !self.process_work_list {
             return None;
         }
@@ -146,11 +146,11 @@ impl InnerThread {
         ret
     }
 
-    fn push_work_deferred(&mut self, work: Arc<dyn DeliverToRead>) {
+    fn push_work_deferred(&mut self, work: Ref<dyn DeliverToRead>) {
         self.work_list.push_back(work);
     }
 
-    fn push_work(&mut self, work: Arc<dyn DeliverToRead>) {
+    fn push_work(&mut self, work: Ref<dyn DeliverToRead>) {
         self.push_work_deferred(work);
         self.process_work_list = true;
     }
@@ -162,7 +162,7 @@ impl InnerThread {
     /// Fetches the transaction the thread can reply to. If the thread has a pending transaction
     /// (that it could respond to) but it has also issued a transaction, it must first wait for the
     /// previously-issued transaction to complete.
-    fn pop_transaction_to_reply(&mut self, thread: &Thread) -> Result<Arc<Transaction>> {
+    fn pop_transaction_to_reply(&mut self, thread: &Thread) -> Result<Ref<Transaction>> {
         let transaction = self.current_transaction.take().ok_or(Error::EINVAL)?;
 
         if core::ptr::eq(thread, transaction.from.as_ref()) {
@@ -175,11 +175,11 @@ impl InnerThread {
         Ok(transaction)
     }
 
-    fn pop_transaction_replied(&mut self, transaction: &Arc<Transaction>) -> bool {
+    fn pop_transaction_replied(&mut self, transaction: &Ref<Transaction>) -> bool {
         match self.current_transaction.take() {
             None => false,
             Some(old) => {
-                if !Arc::ptr_eq(transaction, &old) {
+                if !Ref::ptr_eq(transaction, &old) {
                     self.current_transaction = Some(old);
                     return false;
                 }
@@ -238,42 +238,44 @@ pub(crate) struct Thread {
 }
 
 impl Thread {
-    pub(crate) fn new(id: i32, process: Ref<Process>) -> Result<Arc<Self>> {
-        let return_work = Arc::try_new(ThreadError::new(InnerThread::set_return_work))?;
-        let reply_work = Arc::try_new(ThreadError::new(InnerThread::set_reply_work))?;
-        let mut arc = Arc::try_new(Self {
-            id,
-            process,
-            // SAFETY: `inner` is initialised in the call to `spinlock_init` below.
-            inner: unsafe { SpinLock::new(InnerThread::new()) },
-            // SAFETY: `work_condvar` is initalised in the call to `condvar_init` below.
-            work_condvar: unsafe { CondVar::new() },
-            links: Links::new(),
-        })?;
-        let thread = Arc::get_mut(&mut arc).unwrap();
-        // SAFETY: `inner` is pinned behind the `Arc` reference.
-        let inner = unsafe { Pin::new_unchecked(&mut thread.inner) };
-        kernel::spinlock_init!(inner, "Thread::inner");
+    pub(crate) fn new(id: i32, process: Ref<Process>) -> Result<Ref<Self>> {
+        let return_work = Ref::try_new(ThreadError::new(InnerThread::set_return_work))?;
+        let reply_work = Ref::try_new(ThreadError::new(InnerThread::set_reply_work))?;
+        Ref::try_new_and_init(
+            Self {
+                id,
+                process,
+                // SAFETY: `inner` is initialised in the call to `spinlock_init` below.
+                inner: unsafe { SpinLock::new(InnerThread::new()) },
+                // SAFETY: `work_condvar` is initalised in the call to `condvar_init` below.
+                work_condvar: unsafe { CondVar::new() },
+                links: Links::new(),
+            },
+            |mut thread| {
+                // SAFETY: `inner` is pinned when `thread` is.
+                let inner = unsafe { thread.as_mut().map_unchecked_mut(|t| &mut t.inner) };
+                kernel::spinlock_init!(inner, "Thread::inner");
 
-        // SAFETY: `work_condvar` is pinned behind the `Arc` reference.
-        let condvar = unsafe { Pin::new_unchecked(&mut thread.work_condvar) };
-        kernel::condvar_init!(condvar, "Thread::work_condvar");
-        {
-            let mut inner = arc.inner.lock();
-            inner.set_reply_work(reply_work);
-            inner.set_return_work(return_work);
-        }
-        Ok(arc)
+                // SAFETY: `work_condvar` is pinned when `thread` is.
+                let condvar = unsafe { thread.as_mut().map_unchecked_mut(|t| &mut t.work_condvar) };
+                kernel::condvar_init!(condvar, "Thread::work_condvar");
+                {
+                    let mut inner = thread.inner.lock();
+                    inner.set_reply_work(reply_work);
+                    inner.set_return_work(return_work);
+                }
+            },
+        )
     }
 
-    pub(crate) fn set_current_transaction(&self, transaction: Arc<Transaction>) {
+    pub(crate) fn set_current_transaction(&self, transaction: Ref<Transaction>) {
         self.inner.lock().current_transaction = Some(transaction);
     }
 
     /// Attempts to fetch a work item from the thread-local queue. The behaviour if the queue is
     /// empty depends on `wait`: if it is true, the function waits for some work to be queued (or a
     /// signal); otherwise it returns indicating that none is available.
-    fn get_work_local(self: &Arc<Self>, wait: bool) -> Result<Arc<dyn DeliverToRead>> {
+    fn get_work_local(self: &Ref<Self>, wait: bool) -> Result<Ref<dyn DeliverToRead>> {
         // Try once if the caller does not want to wait.
         if !wait {
             return self.inner.lock().pop_work().ok_or(Error::EAGAIN);
@@ -301,7 +303,7 @@ impl Thread {
     ///
     /// This must only be called when the thread is not participating in a transaction chain. If it
     /// is, the local version (`get_work_local`) should be used instead.
-    fn get_work(self: &Arc<Self>, wait: bool) -> Result<Arc<dyn DeliverToRead>> {
+    fn get_work(self: &Ref<Self>, wait: bool) -> Result<Ref<dyn DeliverToRead>> {
         // Try to get work from the thread's work queue, using only a local lock.
         {
             let mut inner = self.inner.lock();
@@ -346,7 +348,7 @@ impl Thread {
         }
     }
 
-    pub(crate) fn push_work(&self, work: Arc<dyn DeliverToRead>) -> BinderResult {
+    pub(crate) fn push_work(&self, work: Ref<dyn DeliverToRead>) -> BinderResult {
         {
             let mut inner = self.inner.lock();
             if inner.is_dead {
@@ -360,7 +362,7 @@ impl Thread {
 
     /// Attempts to push to given work item to the thread if it's a looper thread (i.e., if it's
     /// part of a thread pool) and is alive. Otherwise, push the work item to the process instead.
-    pub(crate) fn push_work_if_looper(&self, work: Arc<dyn DeliverToRead>) -> BinderResult {
+    pub(crate) fn push_work_if_looper(&self, work: Ref<dyn DeliverToRead>) -> BinderResult {
         let mut inner = self.inner.lock();
         if inner.is_looper() && !inner.is_dead {
             inner.push_work(work);
@@ -371,7 +373,7 @@ impl Thread {
         }
     }
 
-    pub(crate) fn push_work_deferred(&self, work: Arc<dyn DeliverToRead>) {
+    pub(crate) fn push_work_deferred(&self, work: Ref<dyn DeliverToRead>) {
         self.inner.lock().push_work_deferred(work);
     }
 
@@ -494,7 +496,7 @@ impl Thread {
         Ok(alloc)
     }
 
-    fn unwind_transaction_stack(self: &Arc<Self>) {
+    fn unwind_transaction_stack(self: &Ref<Self>) {
         let mut thread = self.clone();
         while let Ok(transaction) = {
             let mut inner = thread.inner.lock();
@@ -511,8 +513,8 @@ impl Thread {
 
     pub(crate) fn deliver_reply(
         &self,
-        reply: Either<Arc<Transaction>, u32>,
-        transaction: &Arc<Transaction>,
+        reply: Either<Ref<Transaction>, u32>,
+        transaction: &Ref<Transaction>,
     ) {
         if self.deliver_single_reply(reply, transaction) {
             transaction.from.unwind_transaction_stack();
@@ -526,8 +528,8 @@ impl Thread {
     /// transaction stack by completing transactions for threads that are dead.
     fn deliver_single_reply(
         &self,
-        reply: Either<Arc<Transaction>, u32>,
-        transaction: &Arc<Transaction>,
+        reply: Either<Ref<Transaction>, u32>,
+        transaction: &Ref<Transaction>,
     ) -> bool {
         {
             let mut inner = self.inner.lock();
@@ -551,24 +553,24 @@ impl Thread {
     }
 
     /// Determines if the given transaction is the current transaction for this thread.
-    fn is_current_transaction(&self, transaction: &Arc<Transaction>) -> bool {
+    fn is_current_transaction(&self, transaction: &Ref<Transaction>) -> bool {
         let inner = self.inner.lock();
         match &inner.current_transaction {
             None => false,
-            Some(current) => Arc::ptr_eq(current, transaction),
+            Some(current) => Ref::ptr_eq(current, transaction),
         }
     }
 
-    fn transaction<T>(self: &Arc<Self>, tr: &BinderTransactionData, inner: T)
+    fn transaction<T>(self: &Ref<Self>, tr: &BinderTransactionData, inner: T)
     where
-        T: FnOnce(&Arc<Self>, &BinderTransactionData) -> BinderResult,
+        T: FnOnce(&Ref<Self>, &BinderTransactionData) -> BinderResult,
     {
         if let Err(err) = inner(self, tr) {
             self.inner.lock().push_return_work(err.reply);
         }
     }
 
-    fn reply_inner(self: &Arc<Self>, tr: &BinderTransactionData) -> BinderResult {
+    fn reply_inner(self: &Ref<Self>, tr: &BinderTransactionData) -> BinderResult {
         let orig = self.inner.lock().pop_transaction_to_reply(self)?;
         if !orig.from.is_current_transaction(&orig) {
             return Err(BinderError::new_failed());
@@ -576,7 +578,7 @@ impl Thread {
 
         // We need to complete the transaction even if we cannot complete building the reply.
         (|| -> BinderResult<_> {
-            let completion = Arc::try_new(DeliverCode::new(BR_TRANSACTION_COMPLETE))?;
+            let completion = Ref::try_new(DeliverCode::new(BR_TRANSACTION_COMPLETE))?;
             let process = orig.from.process.clone();
             let allow_fds = orig.flags & TF_ACCEPT_FDS != 0;
             let reply = Transaction::new_reply(self, process, tr, allow_fds)?;
@@ -597,7 +599,7 @@ impl Thread {
     /// Determines the current top of the transaction stack. It fails if the top is in another
     /// thread (i.e., this thread belongs to a stack but it has called another thread). The top is
     /// [`None`] if the thread is not currently participating in a transaction stack.
-    fn top_of_transaction_stack(&self) -> Result<Option<Arc<Transaction>>> {
+    fn top_of_transaction_stack(&self) -> Result<Option<Ref<Transaction>>> {
         let inner = self.inner.lock();
         Ok(if let Some(cur) = &inner.current_transaction {
             if core::ptr::eq(self, cur.from.as_ref()) {
@@ -609,11 +611,11 @@ impl Thread {
         })
     }
 
-    fn oneway_transaction_inner(self: &Arc<Self>, tr: &BinderTransactionData) -> BinderResult {
+    fn oneway_transaction_inner(self: &Ref<Self>, tr: &BinderTransactionData) -> BinderResult {
         let handle = unsafe { tr.target.handle };
         let node_ref = self.process.get_transaction_node(handle)?;
         security::binder_transaction(&self.process.task, &node_ref.node.owner.task)?;
-        let completion = Arc::try_new(DeliverCode::new(BR_TRANSACTION_COMPLETE))?;
+        let completion = Ref::try_new(DeliverCode::new(BR_TRANSACTION_COMPLETE))?;
         let transaction = Transaction::new(node_ref, None, self, tr)?;
         self.inner.lock().push_work(completion);
         // TODO: Remove the completion on error?
@@ -621,14 +623,14 @@ impl Thread {
         Ok(())
     }
 
-    fn transaction_inner(self: &Arc<Self>, tr: &BinderTransactionData) -> BinderResult {
+    fn transaction_inner(self: &Ref<Self>, tr: &BinderTransactionData) -> BinderResult {
         let handle = unsafe { tr.target.handle };
         let node_ref = self.process.get_transaction_node(handle)?;
         security::binder_transaction(&self.process.task, &node_ref.node.owner.task)?;
         // TODO: We need to ensure that there isn't a pending transaction in the work queue. How
         // could this happen?
         let top = self.top_of_transaction_stack()?;
-        let completion = Arc::try_new(DeliverCode::new(BR_TRANSACTION_COMPLETE))?;
+        let completion = Ref::try_new(DeliverCode::new(BR_TRANSACTION_COMPLETE))?;
         let transaction = Transaction::new(node_ref, top, self, tr)?;
 
         // Check that the transaction stack hasn't changed while the lock was released, then update
@@ -649,7 +651,7 @@ impl Thread {
         Ok(())
     }
 
-    fn write(self: &Arc<Self>, req: &mut BinderWriteRead) -> Result {
+    fn write(self: &Ref<Self>, req: &mut BinderWriteRead) -> Result {
         let write_start = req.write_buffer.wrapping_add(req.write_consumed);
         let write_len = req.write_size - req.write_consumed;
         let mut reader = unsafe { UserSlicePtr::new(write_start as _, write_len as _).reader() };
@@ -694,7 +696,7 @@ impl Thread {
         Ok(())
     }
 
-    fn read(self: &Arc<Self>, req: &mut BinderWriteRead, wait: bool) -> Result {
+    fn read(self: &Ref<Self>, req: &mut BinderWriteRead, wait: bool) -> Result {
         let read_start = req.read_buffer.wrapping_add(req.read_consumed);
         let read_len = req.read_size - req.read_consumed;
         let mut writer = unsafe { UserSlicePtr::new(read_start as _, read_len as _) }.writer();
@@ -748,7 +750,7 @@ impl Thread {
         Ok(())
     }
 
-    pub(crate) fn write_read(self: &Arc<Self>, data: UserSlicePtr, wait: bool) -> Result {
+    pub(crate) fn write_read(self: &Ref<Self>, data: UserSlicePtr, wait: bool) -> Result {
         let (mut reader, mut writer) = data.reader_writer();
         let mut req = reader.read::<BinderWriteRead>()?;
 
@@ -800,7 +802,7 @@ impl Thread {
         self.inner.lock().push_return_work(code)
     }
 
-    pub(crate) fn release(self: &Arc<Thread>) {
+    pub(crate) fn release(self: &Ref<Self>) {
         // Mark the thread as dead.
         self.inner.lock().is_dead = true;
 
@@ -831,12 +833,12 @@ impl GetLinks for Thread {
 
 struct ThreadError {
     error_code: AtomicU32,
-    return_fn: fn(&mut InnerThread, Arc<ThreadError>),
+    return_fn: fn(&mut InnerThread, Ref<ThreadError>),
     links: Links<dyn DeliverToRead>,
 }
 
 impl ThreadError {
-    fn new(return_fn: fn(&mut InnerThread, Arc<ThreadError>)) -> Self {
+    fn new(return_fn: fn(&mut InnerThread, Ref<ThreadError>)) -> Self {
         Self {
             error_code: AtomicU32::new(BR_OK),
             return_fn,
@@ -846,7 +848,7 @@ impl ThreadError {
 }
 
 impl DeliverToRead for ThreadError {
-    fn do_work(self: Arc<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
+    fn do_work(self: Ref<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         // See `ThreadInner::push_existing_work` for the reason why `error_code` is up to date even
         // though we use relaxed semantics.
         let code = self.error_code.load(Ordering::Relaxed);


### PR DESCRIPTION
This allows `Arc` to be removed from the `kernel` and `alloc` crates.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>