### PR TITLE
rust: remove `Arc` from the `kernel` crate.

### DIFF
--- a/rust/kernel/linked_list.rs
+++ b/rust/kernel/linked_list.rs
@@ -4,7 +4,7 @@
 //!
 //! TODO: This module is a work in progress.
 
-use alloc::{boxed::Box, sync::Arc};
+use alloc::boxed::Box;
 use core::ptr::NonNull;
 
 pub use crate::raw_list::{Cursor, GetLinks, Links};
@@ -34,20 +34,6 @@ impl<T: ?Sized> Wrapper<T> for Box<T> {
 
     unsafe fn from_pointer(ptr: NonNull<T>) -> Self {
         unsafe { Box::from_raw(ptr.as_ptr()) }
-    }
-
-    fn as_ref(&self) -> &T {
-        AsRef::as_ref(self)
-    }
-}
-
-impl<T: ?Sized> Wrapper<T> for Arc<T> {
-    fn into_pointer(self) -> NonNull<T> {
-        NonNull::new(Arc::into_raw(self) as _).unwrap()
-    }
-
-    unsafe fn from_pointer(ptr: NonNull<T>) -> Self {
-        unsafe { Arc::from_raw(ptr.as_ptr()) }
     }
 
     fn as_ref(&self) -> &T {
@@ -98,20 +84,6 @@ where
 }
 
 impl<T: GetLinks + ?Sized> GetLinks for Box<T> {
-    type EntryType = T::EntryType;
-    fn get_links(data: &Self::EntryType) -> &Links<Self::EntryType> {
-        <T as GetLinks>::get_links(data)
-    }
-}
-
-impl<T: ?Sized> GetLinksWrapped for Arc<T>
-where
-    Arc<T>: GetLinks,
-{
-    type Wrapped = Arc<<Arc<T> as GetLinks>::EntryType>;
-}
-
-impl<T: GetLinks + ?Sized> GetLinks for Arc<T> {
     type EntryType = T::EntryType;
     fn get_links(data: &Self::EntryType) -> &Links<Self::EntryType> {
         <T as GetLinks>::get_links(data)

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -13,7 +13,7 @@
 
 pub use core::pin::Pin;
 
-pub use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+pub use alloc::{boxed::Box, string::String, vec::Vec};
 
 pub use macros::{module, module_misc_device};
 

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -8,7 +8,7 @@ use crate::{
     bindings, c_types,
     sync::{Ref, RefBorrow},
 };
-use alloc::{boxed::Box, sync::Arc};
+use alloc::boxed::Box;
 use core::{ops::Deref, pin::Pin, ptr::NonNull};
 
 /// Permissions.
@@ -97,27 +97,6 @@ impl<T> PointerWrapper for Ref<T> {
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
         // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
         unsafe { Ref::from_usize(ptr as _) }
-    }
-}
-
-impl<T> PointerWrapper for Arc<T> {
-    type Borrowed = UnsafeReference<T>;
-
-    fn into_pointer(self) -> *const c_types::c_void {
-        Arc::into_raw(self) as _
-    }
-
-    unsafe fn borrow(ptr: *const c_types::c_void) -> Self::Borrowed {
-        // SAFETY: The safety requirements for this function ensure that the object is still alive,
-        // so it is safe to dereference the raw pointer.
-        // The safety requirements also ensure that the object remains alive for the lifetime of
-        // the returned value.
-        unsafe { UnsafeReference::new(&*ptr.cast()) }
-    }
-
-    unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
-        // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
-        unsafe { Arc::from_raw(ptr as _) }
     }
 }
 


### PR DESCRIPTION
These references existed to support binder, but are no longer needed.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>