### PR TITLE
Don't hide unsafety in `$ptr` argument of `container_of!`

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -220,7 +220,8 @@ macro_rules! offset_of {
 #[macro_export]
 macro_rules! container_of {
     ($ptr:expr, $type:ty, $($f:tt)*) => {{
+        let ptr = $ptr as *const _ as *const u8;
         let offset = $crate::offset_of!($type, $($f)*);
-        unsafe { ($ptr as *const _ as *const u8).offset(-offset) as *const $type }
+        unsafe { ptr.offset(-offset) as *const $type }
     }}
 }

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -85,10 +85,8 @@ impl<T: Sync> FileOpenAdapter for Registration<T> {
     type Arg = T;
 
     unsafe fn convert(_inode: *mut bindings::inode, file: *mut bindings::file) -> *const Self::Arg {
-        // TODO: `SAFETY` comment required here even if `unsafe` is not present,
-        // because `container_of!` hides it. Ideally we would not allow
-        // `unsafe` code as parameters to macros.
-        let reg = crate::container_of!((*file).private_data, Self, mdev);
+        // SAFETY: the caller must guarantee that `file` is valid.
+        let reg = crate::container_of!(unsafe { (*file).private_data }, Self, mdev);
         unsafe { &(*reg).context }
     }
 }


### PR DESCRIPTION
By evaluating `$ptr` outside of the macro's `unsafe` block, it is up to the caller to wrap any `unsafe` code needed to evaluate the pointer in an `unsafe` block and provide a `SAFETY` explanation.

Helps with #351.

Signed-off-by: Léo Lanteri Thauvin <leseulartichaut@gmail.com>