### PR TITLE
Add some missing `// SAFETY` comments

### DIFF
--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -170,7 +170,9 @@ impl<T: FileOperations> Registration<T> {
         this.registered = true;
         this.open_data.write(open_data);
 
-        // SAFETY: FFI call.
+        // SAFETY: the `fops`, `name` and `minor` fields of `this.mdev` have
+        // been properly initialized above (the other fields are zeroed and will be
+        // initialized by `misc_register`).
         let ret = unsafe { bindings::misc_register(&mut this.mdev) };
         if ret < 0 {
             // INVARIANT: `registered` is set back to `false` and the `open_data` is destructued.

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -147,7 +147,7 @@ impl<T: FileOperations> Registration<T> {
         open_data: T::OpenData,
         opts: &Options<'_>,
     ) -> Result {
-        // SAFETY: We must ensure that we never move out of `this`.
+        // SAFETY: we don't move out of `this`.
         let this = unsafe { self.get_unchecked_mut() };
         if this.registered {
             // Already registered.
@@ -170,6 +170,7 @@ impl<T: FileOperations> Registration<T> {
         this.registered = true;
         this.open_data.write(open_data);
 
+        // SAFETY: FFI call.
         let ret = unsafe { bindings::misc_register(&mut this.mdev) };
         if ret < 0 {
             // INVARIANT: `registered` is set back to `false` and the `open_data` is destructued.

--- a/rust/kernel/pages.rs
+++ b/rust/kernel/pages.rs
@@ -127,7 +127,7 @@ impl<const ORDER: u32> Pages<ORDER> {
         // so `offset` can't overflow an `isize`.
         let dest = unsafe { (mapping.ptr as *mut u8).add(offset) };
         // SAFETY: `src` is guaranteed by the caller to be valid for reads, and `dest` is
-        //valid for writes from the type invariants. Because we're copying `u8`s
+        // valid for writes from the type invariants. Because we're copying `u8`s
         // which have an alignment of 1, `src` and `dest` are always properly aligned.
         unsafe { ptr::copy(src, dest, len) };
         Ok(())

--- a/rust/kernel/pages.rs
+++ b/rust/kernel/pages.rs
@@ -95,7 +95,7 @@ impl<const ORDER: u32> Pages<ORDER> {
         let mapping = self.kmap(0).ok_or(Error::EINVAL)?;
         // SAFETY: we just checked that `offset + len <= PAGE_SIZE`, so `mapping.ptr` and
         // `mapping.ptr + offset` are in the same allocated object, the page we're
-        // reading from, with no overflow. Also, `offset <= PAGE_LEN < isize::MAX`
+        // reading from, with no overflow. Also, `offset <= PAGE_SIZE < isize::MAX`
         // so `offset` can't overflow an `isize`.
         let src = unsafe { (mapping.ptr as *mut u8).add(offset) };
         // SAFETY: `src` is valid for reads from the type invariants, and `dest` is
@@ -123,7 +123,7 @@ impl<const ORDER: u32> Pages<ORDER> {
         let mapping = self.kmap(0).ok_or(Error::EINVAL)?;
         // SAFETY: we just checked that `offset + len <= PAGE_SIZE`, so `mapping.ptr` and
         // `mapping.ptr + offset` are in the same allocated object, the page we're
-        // reading from, with no overflow. Also, `offset <= PAGE_LEN < isize::MAX`
+        // reading from, with no overflow. Also, `offset <= PAGE_SIZE < isize::MAX`
         // so `offset` can't overflow an `isize`.
         let dest = unsafe { (mapping.ptr as *mut u8).add(offset) };
         // SAFETY: `src` is guaranteed by the caller to be valid for reads, and `dest` is

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -33,7 +33,7 @@ unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_vo
             // `buf` goes past `end`.
             let len_to_copy = cmp::min(buf_new, self.end).saturating_sub(self.buf);
 
-            // SAFETY: In any case, `buf` is non-null and properly aligned.
+            // SAFETY: The caller guarantees `buf` is non-null and properly aligned.
             // If `len_to_copy` is non-zero, then we know `buf` has not past
             // `end` yet and so is valid.
             unsafe {
@@ -53,6 +53,7 @@ unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_vo
         buf: buf as _,
         end: end as _,
     };
+    // SAFETY: the caller must guarantee that `ptr` is valid.
     let _ = w.write_fmt(unsafe { *(ptr as *const fmt::Arguments<'_>) });
     w.buf as _
 }
@@ -132,6 +133,7 @@ pub unsafe fn call_printk(
     args: fmt::Arguments<'_>,
 ) {
     // `_printk` does not seem to fail in any path.
+    // SAFETY: FFI call.
     unsafe {
         bindings::_printk(
             format_string.as_ptr() as _,

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -138,9 +138,7 @@ pub unsafe fn call_printk(
     args: fmt::Arguments<'_>,
 ) {
     // `_printk` does not seem to fail in any path.
-    // SAFETY: references are guaranteed to be valid for reads.
-    // The caller guarantees that `format_string` is a valid format
-    // specifier and that `module_name` is null-terminated.
+    // SAFETY: this is safe by the safety contract.
     unsafe {
         bindings::_printk(
             format_string.as_ptr() as _,

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -12,7 +12,12 @@ use core::fmt;
 use crate::bindings;
 use crate::c_types::{c_char, c_void};
 
-// Called from `vsprintf` with format specifier `%pA`.
+/// Called from `vsprintf` with format specifier `%pA`.
+///
+/// # Safety
+///
+/// The region between `buf` and `end` must be valid for writes.
+/// `ptr` must point to a valid instance of `fmt::Arguments`.
 #[no_mangle]
 unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_void) -> *mut c_char {
     use fmt::Write;

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -133,7 +133,9 @@ pub unsafe fn call_printk(
     args: fmt::Arguments<'_>,
 ) {
     // `_printk` does not seem to fail in any path.
-    // SAFETY: FFI call.
+    // SAFETY: references are guaranteed to be valid for reads.
+    // The caller guarantees that `format_string` is a valid format
+    // specifier and that `module_name` is null-terminated.
     unsafe {
         bindings::_printk(
             format_string.as_ptr() as _,


### PR DESCRIPTION
Helps with #351.

Signed-off-by: Léo Lanteri Thauvin <leseulartichaut@gmail.com>