### PR TITLE
Use Result type alias with a default error type

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -224,7 +224,7 @@ impl From<TryReserveError> for Error {
 /// Note that even if a function does not return anything when it succeeds,
 /// it should still be modeled as returning a `Result` rather than
 /// just an [`Error`].
-pub type Result<T = ()> = core::result::Result<T, Error>;
+pub type Result<T = (), E = Error> = core::result::Result<T, E>;
 
 impl From<AllocError> for Error {
     fn from(_: AllocError) -> Error {


### PR DESCRIPTION
`Result` type aliases with a fixed error types are problematic when they shadow the `core`'s `Result` type. The shadowing can cause confusing generic type errors.

Setting the `Error` type as a default argument relaxes the alias from behaving like a custom incompatible  `Result` type to being just *the* usual `Result` type with a default, and it doesn't cause problems when the alias shadows prelude's `Result`.
