### PR TITLE
rust: alloc: implement `try_format!` macro

### DIFF
--- a/rust/alloc/fmt.rs
+++ b/rust/alloc/fmt.rs
@@ -548,7 +548,7 @@ pub use core::fmt::{LowerExp, UpperExp};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{LowerHex, Pointer, UpperHex};
 
-#[cfg(not(no_global_oom_handling))]
+use crate::collections::TryReserveError;
 use crate::string;
 
 /// The `format` function takes an [`Arguments`] struct and returns the resulting
@@ -584,4 +584,51 @@ pub fn format(args: Arguments<'_>) -> string::String {
     let mut output = string::String::with_capacity(capacity);
     output.write_fmt(args).expect("a formatting trait implementation returned an error");
     output
+}
+
+/// The `try_format` function takes an [`Arguments`] struct and returns the
+/// resulting formatted string if all memory allocations during formatting
+/// were succesful.
+///
+/// The [`Arguments`] instance can be created with the [`format_args!`] macro.
+///
+/// # Errors
+///
+/// If the capacity of overflows, or the allocator reports a failure, then an error
+/// is returned.
+///
+/// # Panics
+///
+/// Panics if a formatting trait implementation returns an error.
+/// This indicates an incorrect implementation
+/// since `fmt::Write for String` never returns an error itself.
+/// Never panics on memory allocation failure.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use std::fmt;
+///
+/// let s = fmt::try_format(format_args!("Hello, {}!", "world")).unwrap();
+/// assert_eq!(s, "Hello, world!");
+/// ```
+///
+/// Please note that using [`try_format!`] might be preferable.
+/// Example:
+///
+/// ```
+/// let s = try_format!("Hello, {}!", "world").unwrap();
+/// assert_eq!(s, "Hello, world!");
+/// ```
+///
+/// [`format_args!`]: core::format_args
+/// [`try_format!`]: crate::try_format
+#[stable(feature = "kernel", since = "1.0.0")]
+pub fn try_format(args: Arguments<'_>) -> core::result::Result<string::String, TryReserveError> {
+    let capacity = args.estimated_capacity();
+    let mut writer = string::StringWriter::try_with_capacity(capacity)?;
+    writer.write_fmt(args).expect("a formatting trait implementation returned an error");
+    writer.into_string()
 }

--- a/rust/alloc/macros.rs
+++ b/rust/alloc/macros.rs
@@ -117,6 +117,41 @@ macro_rules! format {
     }}
 }
 
+/// Tries to create a `String` using interpolation of runtime expressions.
+///
+/// The `try_format!` is an equivalent of [`format!`] macro, that will never
+/// panic on memory allocation failure. See [`format!`] for functionality details.
+///
+/// [`format!`]: crate::format
+///
+/// # Errors
+///
+/// If the capacity overflows, or the allocator reports a failure, then an error
+/// is returned.
+///
+/// # Panics
+///
+/// `try_format!` panics if a formatting trait implementation returns an error.
+/// This indicates an incorrect implementation
+/// since `fmt::Write for String` never returns an error itself.
+/// Never panics on memory allocation failure.
+///
+/// # Examples
+///
+/// ```
+/// try_format!("test").unwrap();
+/// try_format!("hello {}", "world!").unwrap();
+/// try_format!("x = {}, y = {y}", 10, y = 30).unwrap();
+/// ```
+#[macro_export]
+#[stable(feature = "kernel", since = "1.0.0")]
+macro_rules! try_format {
+    ($($arg:tt)*) => {{
+        let res = $crate::fmt::try_format($crate::__export::format_args!($($arg)*));
+        res
+    }}
+}
+
 /// Force AST node to an expression to improve diagnostics in pattern position.
 #[doc(hidden)]
 #[macro_export]

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -5,6 +5,7 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
+use alloc::try_format;
 use kernel::prelude::*;
 
 module! {
@@ -25,7 +26,7 @@ impl KernelModule for RustMinimal {
         pr_info!("Am I built-in? {}\n", !cfg!(MODULE));
 
         Ok(RustMinimal {
-            message: "on the heap!".try_to_owned()?,
+            message: try_format!("on the {}!", "heap")?,
         })
     }
 }


### PR DESCRIPTION
Implement `try_format!` macro - an equivalent of `format!` that will never panic on memory allocation failure. It returns an error instead.

The `try_format!` macro uses a `StringWriter` helper internally that implements `Write` trait for a `String` in a way that never panics during memory allocation.

The usage of `try_format!` is demonstrated in the `rust_minimal` sample module.

Based on https://github.com/Rust-for-Linux/linux/pull/476.