### PR TITLE
rust: use `impl` syntactic sugar to simplify read/write.

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -35,7 +35,7 @@ impl FileOpener<()> for RngDevice {
 impl FileOperations for RngDevice {
     kernel::declare_file_operations!(read);
 
-    fn read<T: IoBufferWriter>(_: &Self, _: &File, data: &mut T, offset: u64) -> Result<usize> {
+    fn read(_: &Self, _: &File, data: &mut impl IoBufferWriter, offset: u64) -> Result<usize> {
         // Succeed if the caller doesn't provide a buffer or if not at the start.
         if data.is_empty() || offset != 0 {
             return Ok(0);

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -622,10 +622,10 @@ pub trait FileOperations: Send + Sync + Sized {
     /// Reads data from this file to the caller's buffer.
     ///
     /// Corresponds to the `read` and `read_iter` function pointers in `struct file_operations`.
-    fn read<T: IoBufferWriter>(
+    fn read(
         _this: &<<Self::Wrapper as PointerWrapper>::Borrowed as Deref>::Target,
         _file: &File,
-        _data: &mut T,
+        _data: &mut impl IoBufferWriter,
         _offset: u64,
     ) -> Result<usize> {
         Err(Error::EINVAL)
@@ -634,10 +634,10 @@ pub trait FileOperations: Send + Sync + Sized {
     /// Writes data from the caller's buffer to this file.
     ///
     /// Corresponds to the `write` and `write_iter` function pointers in `struct file_operations`.
-    fn write<T: IoBufferReader>(
+    fn write(
         _this: &<<Self::Wrapper as PointerWrapper>::Borrowed as Deref>::Target,
         _file: &File,
-        _data: &mut T,
+        _data: &mut impl IoBufferReader,
         _offset: u64,
     ) -> Result<usize> {
         Err(Error::EINVAL)

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -68,10 +68,10 @@ impl FileOperations for Token {
 
     kernel::declare_file_operations!(read, write);
 
-    fn read<T: IoBufferWriter>(
+    fn read(
         shared: &Ref<SharedState>,
         _: &File,
-        data: &mut T,
+        data: &mut impl IoBufferWriter,
         offset: u64,
     ) -> Result<usize> {
         // Succeed if the caller doesn't provide a buffer or if not at the start.
@@ -101,10 +101,10 @@ impl FileOperations for Token {
         Ok(1)
     }
 
-    fn write<T: IoBufferReader>(
+    fn write(
         shared: &Ref<SharedState>,
         _: &File,
-        data: &mut T,
+        data: &mut impl IoBufferReader,
         _offset: u64,
     ) -> Result<usize> {
         {

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -21,7 +21,7 @@ struct RandomFile;
 impl FileOperations for RandomFile {
     kernel::declare_file_operations!(read, write, read_iter, write_iter);
 
-    fn read<T: IoBufferWriter>(_this: &Self, file: &File, buf: &mut T, _: u64) -> Result<usize> {
+    fn read(_this: &Self, file: &File, buf: &mut impl IoBufferWriter, _: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
 
@@ -39,7 +39,7 @@ impl FileOperations for RandomFile {
         Ok(total_len)
     }
 
-    fn write<T: IoBufferReader>(_this: &Self, _file: &File, buf: &mut T, _: u64) -> Result<usize> {
+    fn write(_this: &Self, _file: &File, buf: &mut impl IoBufferReader, _: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
         while !buf.is_empty() {

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -77,7 +77,7 @@ impl FileOpener<Ref<Semaphore>> for FileState {
 impl FileOperations for FileState {
     declare_file_operations!(read, write, ioctl);
 
-    fn read<T: IoBufferWriter>(this: &Self, _: &File, data: &mut T, offset: u64) -> Result<usize> {
+    fn read(this: &Self, _: &File, data: &mut impl IoBufferWriter, offset: u64) -> Result<usize> {
         if data.is_empty() || offset > 0 {
             return Ok(0);
         }
@@ -87,7 +87,7 @@ impl FileOperations for FileState {
         Ok(1)
     }
 
-    fn write<T: IoBufferReader>(this: &Self, _: &File, data: &mut T, _offs: u64) -> Result<usize> {
+    fn write(this: &Self, _: &File, data: &mut impl IoBufferReader, _offs: u64) -> Result<usize> {
         {
             let mut inner = this.shared.inner.lock();
             inner.count = inner.count.saturating_add(data.len());


### PR DESCRIPTION
This removes the need to explicitly declare a generic parameter.
Although it is just syntactic sugar, it looks less intimidating to
readers not familiar with Rust.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>