### PR TITLE
Filter out bindgen flags not supported by libclang

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -199,6 +199,7 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-mabi=lp64 -mstack-protector-guard% -fconserve-stack -falign-jumps=% \
 	-falign-loops=% \
 	-fno-ipa-cp-clone -fno-ipa-sra -fno-partial-inlining \
+	-fplugin-arg-arm_ssp_per_task_plugin-% \
 	-fno-reorder-blocks -fno-allow-store-data-races -fasan-shadow-offset=% \
 	-Wno-packed-not-aligned -Wno-format-truncation -Wno-format-overflow \
 	-Wno-stringop-truncation -Wno-unused-but-set-variable \

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -197,7 +197,8 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-mskip-rax-setup -mgeneral-regs-only -msign-return-address=% \
 	-mindirect-branch=thunk-extern -mindirect-branch-register -mrecord-mcount \
 	-mabi=lp64 -mstack-protector-guard% -fconserve-stack -falign-jumps=% \
-	-falign-loops=% -fno-ipa-cp-clone -fno-partial-inlining \
+	-falign-loops=% \
+	-fno-ipa-cp-clone -fno-ipa-sra -fno-partial-inlining \
 	-fno-reorder-blocks -fno-allow-store-data-races -fasan-shadow-offset=% \
 	-Wno-packed-not-aligned -Wno-format-truncation -Wno-format-overflow \
 	-Wno-stringop-truncation -Wno-unused-but-set-variable \

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -197,7 +197,7 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-mskip-rax-setup -mgeneral-regs-only -msign-return-address=% \
 	-mindirect-branch=thunk-extern -mindirect-branch-register -mrecord-mcount \
 	-mabi=lp64 -mstack-protector-guard% -fconserve-stack -falign-jumps=% \
-	-falign-loops=% \
+	-falign-loops=% -femit-struct-debug-baseonly \
 	-fno-ipa-cp-clone -fno-ipa-sra -fno-partial-inlining \
 	-fplugin-arg-arm_ssp_per_task_plugin-% \
 	-fno-reorder-blocks -fno-allow-store-data-races -fasan-shadow-offset=% \


### PR DESCRIPTION
These changes make it possible to build defconfig + the rust-related CONFIG_* variables on all architectures (arm, arm64, powerpc, riscv, x86_64). I tested the following:

- CONFIG_RUST=y
- CONFIG_SAMPLES=y
- CONFIG_SAMPLES_RUST=y
- CONFIG_SAMPLE_RUST_MINIMAL=m
- CONFIG_SAMPLE_RUST_PRINT=m
- CONFIG_SAMPLE_RUST_MODULE_PARAMETERS=m
- CONFIG_SAMPLE_RUST_SYNC=m
- CONFIG_SAMPLE_RUST_CHRDEV=m
- CONFIG_SAMPLE_RUST_MISCDEV=m
- CONFIG_SAMPLE_RUST_STACK_PROBING=m
- CONFIG_SAMPLE_RUST_SEMAPHORE=m
- CONFIG_SAMPLE_RUST_SEMAPHORE_C=m
- CONFIG_SAMPLE_RUST_RANDOM=m
- CONFIG_RUST_OVERFLOW_CHECKS=y
- CONFIG_RUST_OPT_LEVEL_SIMILAR_AS_CHOSEN_FOR_C=y
- CONFIG_RUST_BUILD_ASSERT_DENY=y

I tested this on tuxsuite:

```
$ tuxsuite plan --git-repo https://github.com/terceiro/linux.git --git-ref rust-defconfig-arm-arm64  ../plans/rust.yaml 
Running Linux Kernel plan 'Rust builds': 'Build and test Linux with Rust on several architectures'
Plan https://tuxapi.tuxsuite.com/v1/groups/tuxsuite/projects/antonio/plans/1wYDSpC24Vz3hN7d52b1hzzOhly

uid: 1wYDSpC24Vz3hN7d52b1hzzOhly
⚙️  Provisioning:  x86_64 (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDStSYQiJmN3G2pJVGcTjw9dl/
⚙️  Provisioning:  arm64 (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSwzNcVfzFW7xjGtin9DpTdX/
⚙️  Provisioning:  arm (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSxKfYxRVIrdIrZOmexDVzTb/
⚙️  Provisioning:  powerpc (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSzF5KyWIKwKFqaTpPgp7Aql/
⚙️  Provisioning:  riscv (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDT5QYF82ufTCgF7r4PrZHlm8/
🚀 Running: adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") arm64 (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSwzNcVfzFW7xjGtin9DpTdX/
🚀 Running: adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") arm (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSxKfYxRVIrdIrZOmexDVzTb/
🚀 Running: adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") powerpc (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSzF5KyWIKwKFqaTpPgp7Aql/
🚀 Running: adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") riscv (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDT5QYF82ufTCgF7r4PrZHlm8/
🚀 Running: adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") x86_64 (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDStSYQiJmN3G2pJVGcTjw9dl/
👾 Pass (11 warnings): adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") riscv (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDT5QYF82ufTCgF7r4PrZHlm8/
👾 Pass (9 warnings): adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") x86_64 (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDStSYQiJmN3G2pJVGcTjw9dl/
🎉 Pass: adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") powerpc (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSzF5KyWIKwKFqaTpPgp7Aql/
👾 Pass (10 warnings): adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") arm64 (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSwzNcVfzFW7xjGtin9DpTdX/
👾 Pass (10 warnings): adcd13ae5e0a ("rust: filter out -femit-struct-debug-baseonly from bindgen flags") arm (defconfig+16) with rust @ https://builds.tuxbuild.com/1wYDSxKfYxRVIrdIrZOmexDVzTb/

Summary: https://tuxapi.tuxsuite.com/v1/groups/tuxsuite/projects/antonio/plans/1wYDSpC24Vz3hN7d52b1hzzOhly
1wYDSzF5KyWIKwKFqaTpPgp7Aql 🎉 Pass powerpc@rust
1wYDSxKfYxRVIrdIrZOmexDVzTb 👾 Pass (10 warnings) arm@rust
1wYDSwzNcVfzFW7xjGtin9DpTdX 👾 Pass (10 warnings) arm64@rust
1wYDT5QYF82ufTCgF7r4PrZHlm8 👾 Pass (11 warnings) riscv@rust
1wYDStSYQiJmN3G2pJVGcTjw9dl 👾 Pass (9 warnings) x86_64@rust
```

`../plans/rust.yaml` is this (the "test" part in the description is still missing):

```yaml
version: 1
name: Rust builds
description: Build and test Linux with Rust on several architectures
jobs:
- name: rust
  builds:
  - target_arch: x86_64
    toolchain: rust
    kconfig: &kconfig
      - defconfig
      - CONFIG_RUST=y
      - CONFIG_SAMPLES=y
      - CONFIG_SAMPLES_RUST=y
      - CONFIG_SAMPLE_RUST_MINIMAL=m
      - CONFIG_SAMPLE_RUST_PRINT=m
      - CONFIG_SAMPLE_RUST_MODULE_PARAMETERS=m
      - CONFIG_SAMPLE_RUST_SYNC=m
      - CONFIG_SAMPLE_RUST_CHRDEV=m
      - CONFIG_SAMPLE_RUST_MISCDEV=m
      - CONFIG_SAMPLE_RUST_STACK_PROBING=m
      - CONFIG_SAMPLE_RUST_SEMAPHORE=m
      - CONFIG_SAMPLE_RUST_SEMAPHORE_C=m
      - CONFIG_SAMPLE_RUST_RANDOM=m
      - CONFIG_RUST_OVERFLOW_CHECKS=y
      - CONFIG_RUST_OPT_LEVEL_SIMILAR_AS_CHOSEN_FOR_C=y
      - CONFIG_RUST_BUILD_ASSERT_DENY=y
  - target_arch: arm64
    toolchain: rust
    kconfig: *kconfig
  - target_arch: arm
    toolchain: rust
    kconfig: *kconfig
  - target_arch: powerpc
    toolchain: rust
    kconfig: *kconfig
  - target_arch: riscv
    toolchain: rust
    kconfig: *kconfig
```