### PR TITLE
rust: report file and line number that caused a panic.

### DIFF
--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -133,14 +133,3 @@ define_panicking_intrinsics!("`u64` division/modulo should not be used", {
     __aeabi_uldivmod,
     __mulodi4,
 });
-
-extern "C" {
-    fn rust_helper_BUG() -> !;
-}
-
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
-    unsafe {
-        rust_helper_BUG();
-    }
-}

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -226,3 +226,14 @@ macro_rules! container_of {
         ptr.wrapping_offset(-offset) as *const $type
     }}
 }
+
+#[cfg(not(any(testlib, test)))]
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+    extern "C" {
+        fn rust_helper_BUG() -> !;
+    }
+    pr_emerg!("{}\n", info);
+    // SAFETY: FFI call.
+    unsafe { rust_helper_BUG() };
+}


### PR DESCRIPTION
At the moment we get a mangled call stack. This prints a message that
allows us to pinpoint the source of the panic.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>