### PR TITLE
rust: kernel: ioctl returns ENOTTY if not implemented

### DIFF
--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -662,7 +662,7 @@ pub trait FileOperations: Send + Sync + Sized {
         _file: &File,
         _cmd: &mut IoctlCommand,
     ) -> Result<i32> {
-        Err(Error::EINVAL)
+        Err(Error::ENOTTY)
     }
 
     /// Performs 32-bit IO control operations on that are specific to the file on 64-bit kernels.
@@ -673,7 +673,7 @@ pub trait FileOperations: Send + Sync + Sized {
         _file: &File,
         _cmd: &mut IoctlCommand,
     ) -> Result<i32> {
-        Err(Error::EINVAL)
+        Err(Error::ENOTTY)
     }
 
     /// Syncs pending changes to this file.


### PR DESCRIPTION
According to fs/ioctl.c, ioctl system call first test the cmd
value with do_vfs_ioctl. If the cmd is not supported command,
it calls vfs_ioctl. Then vfs_ioctl returns ENOTTY if ioctl is
not implemented.

Signed-off-by: Gioh Kim <gurugio@gmail.com>
Reviewed-by: Wei Liu <wei.liu@kernel.org>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>