### PR TITLE
Update generate_rust_analyzer.py

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -296,7 +296,7 @@ rustc_host_target = $(shell $(RUSTC) --version --verbose | grep -F 'host: ' | cu
 RUST_LIB_SRC ?= $(rustc_sysroot)/lib/rustlib/src/rust/library
 
 rust-analyzer:
-	$(Q)$(srctree)/scripts/generate_rust_analyzer.py $(srctree) $(objtree) $(RUST_LIB_SRC) $(objtree)/rust/bindings_generated.rs > $(objtree)/rust-project.json
+	$(Q)$(srctree)/scripts/generate_rust_analyzer.py $(srctree) $(objtree) $(RUST_LIB_SRC) > $(objtree)/rust-project.json
 
 $(objtree)/rust/compiler_builtins.o: private rustc_objcopy = -w -W '__*'
 $(objtree)/rust/compiler_builtins.o: $(srctree)/rust/compiler_builtins.rs \

--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -8,7 +8,7 @@ import logging
 import pathlib
 import sys
 
-def generate_crates(srctree, objtree, sysroot_src, bindings_file):
+def generate_crates(srctree, objtree, sysroot_src):
     # Generate the configuration list.
     cfg = []
     with open(objtree / "include" / "generated" / "rustc_cfg") as fd:
@@ -78,7 +78,7 @@ def generate_crates(srctree, objtree, sysroot_src, bindings_file):
         ["core", "alloc", "macros", "build_error"],
         cfg=cfg,
     )
-    crates[-1]["env"]["RUST_BINDINGS_FILE"] = str(bindings_file.resolve(True))
+    crates[-1]["env"]["OBJTREE"] = str(objtree.resolve(True))
     crates[-1]["source"] = {
         "include_dirs": [
             str(srctree / "rust" / "kernel"),
@@ -115,7 +115,6 @@ def main():
     parser.add_argument("srctree", type=pathlib.Path)
     parser.add_argument("objtree", type=pathlib.Path)
     parser.add_argument("sysroot_src", type=pathlib.Path)
-    parser.add_argument("bindings_file", type=pathlib.Path)
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -124,7 +123,7 @@ def main():
     )
 
     rust_project = {
-        "crates": generate_crates(args.srctree, args.objtree, args.sysroot_src, args.bindings_file),
+        "crates": generate_crates(args.srctree, args.objtree, args.sysroot_src),
         "sysroot_src": str(args.sysroot_src),
     }
 


### PR DESCRIPTION
1. Sets the [newly introduced](https://github.com/rust-analyzer/rust-analyzer/pull/9752) `is_proc_macro` field in the generated rust-project.json. rust-analyzer now properly resolves the [`use use proc_macro::TokenStream` import](https://github.com/Rust-for-Linux/linux/blob/b00d4c3e7e867a59d6afca3ecb03eaf692ef9742/rust/macros/lib.rs#L8). I've also taken the liberty to slightly refactor the script a bit to reduce duplication.
2. Update the script to account for #359.