### PR TITLE
rust: Remove is-builtin from target configs

### DIFF
--- a/arch/arm/rust/target.json
+++ b/arch/arm/rust/target.json
@@ -9,7 +9,6 @@
   "function-sections": false,
   "has-elf-tls": true,
   "has-rpath": true,
-  "is-builtin": true,
   "linker-is-gnu": true,
   "llvm-target": "arm-unknown-linux-gnueabi",
   "max-atomic-width": 64,

--- a/arch/arm64/rust/target.json
+++ b/arch/arm64/rust/target.json
@@ -7,7 +7,6 @@
   "env": "gnu",
   "features": "+strict-align,+neon,+fp-armv8",
   "function-sections": false,
-  "is-builtin": true,
   "linker-flavor": "gcc",
   "linker-is-gnu": true,
   "llvm-target": "aarch64-unknown-none",

--- a/arch/powerpc/rust/target.json
+++ b/arch/powerpc/rust/target.json
@@ -6,7 +6,6 @@
   "env": "gnu",
   "features": "-altivec,-vsx,-hard-float",
   "function-sections": false,
-  "is-builtin": true,
   "linker-flavor": "gcc",
   "linker-is-gnu": true,
   "llvm-target": "powerpc64le-elf",

--- a/arch/riscv/rust/rv32ima.json
+++ b/arch/riscv/rust/rv32ima.json
@@ -9,7 +9,6 @@
   "env": "gnu",
   "features": "+m,+a",
   "function-sections": false,
-  "is-builtin": true,
   "linker-flavor": "gcc",
   "linker-is-gnu": true,
   "llvm-target": "riscv32",

--- a/arch/riscv/rust/rv32imac.json
+++ b/arch/riscv/rust/rv32imac.json
@@ -9,7 +9,6 @@
   "env": "gnu",
   "features": "+m,+a,+c",
   "function-sections": false,
-  "is-builtin": true,
   "linker-flavor": "gcc",
   "linker-is-gnu": true,
   "llvm-target": "riscv32",

--- a/arch/riscv/rust/rv64ima.json
+++ b/arch/riscv/rust/rv64ima.json
@@ -9,7 +9,6 @@
   "env": "gnu",
   "features": "+m,+a",
   "function-sections": false,
-  "is-builtin": true,
   "linker-flavor": "gcc",
   "linker-is-gnu": true,
   "llvm-target": "riscv64",

--- a/arch/riscv/rust/rv64imac.json
+++ b/arch/riscv/rust/rv64imac.json
@@ -9,7 +9,6 @@
   "env": "gnu",
   "features": "+m,+a,+c",
   "function-sections": false,
-  "is-builtin": true,
   "linker-flavor": "gcc",
   "linker-is-gnu": true,
   "llvm-target": "riscv64",

--- a/arch/x86/rust/target.json
+++ b/arch/x86/rust/target.json
@@ -9,7 +9,6 @@
   "env": "gnu",
   "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
   "function-sections": false,
-  "is-builtin": true,
   "linker-flavor": "gcc",
   "linker-is-gnu": true,
   "llvm-target": "x86_64-elf",


### PR DESCRIPTION
The in-tree targets are technically not builtin targets. Furthermore,
rustc will start erroring out if JSON configs contain `is-builtin: true`
in the future. See
https://github.com/rust-lang/rust/commit/f4701cd65cf6b3f .

Signed-off-by: Daniel Xu <dxu@dxuuu.xyz>