### PR TITLE
rust: remove feature `maybe_uninit_ref`

### DIFF
--- a/rust/alloc/lib.rs
+++ b/rust/alloc/lib.rs
@@ -111,7 +111,6 @@
 #![feature(iter_zip)]
 #![feature(lang_items)]
 #![feature(layout_for_ptr)]
-#![feature(maybe_uninit_ref)]
 #![feature(negative_impls)]
 #![feature(never_type)]
 #![feature(nll)]


### PR DESCRIPTION
Removes `#![feature(maybe_uninit_ref)]` as it was stabilized in 1.55

See https://github.com/rust-lang/rust/issues/63568

Depends on #497 

Signed-off-by: Matthew Bakhtiari dev@mtbk.me