### PR TITLE
[RFC] Fix the support of larger symbol name

### DIFF
--- a/scripts/kallsyms.c
+++ b/scripts/kallsyms.c
@@ -27,6 +27,9 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
 
+#define _stringify_1(x)	#x
+#define _stringify(x)	_stringify_1(x)
+
 #define KSYM_NAME_LEN		512
 
 struct sym_entry {
@@ -197,15 +200,15 @@ static void check_symbol_range(const char *sym, unsigned long long addr,
 
 static struct sym_entry *read_symbol(FILE *in)
 {
-	char name[500], type;
+	char name[KSYM_NAME_LEN+1], type;
 	unsigned long long addr;
 	unsigned int len;
 	struct sym_entry *sym;
 	int rc;
 
-	rc = fscanf(in, "%llx %c %499s\n", &addr, &type, name);
+	rc = fscanf(in, "%llx %c %" _stringify(KSYM_NAME_LEN) "s\n", &addr, &type, name);
 	if (rc != 3) {
-		if (rc != EOF && fgets(name, 500, in) == NULL)
+		if (rc != EOF && fgets(name, KSYM_NAME_LEN + 1, in) == NULL)
 			fprintf(stderr, "Read error or end of file.\n");
 		return NULL;
 	}


### PR DESCRIPTION
In the initial support, we enlarge the max length of symbol name to be 511 (by setting `KSYM_NAME_LEN`), however we still use a 500 bytes buffer to read the symbol name in `read_symbol()`, which makes 1) the support for symbol name with length 500~511 is missing and 2) we are unable to tell whether a symbol name is too long .

Fix this by enlarging the buffer size.  A selftest is also added in this PR, if the fix is dropped, the selftest can trigger a warning that shows the problem. Note that the selftest is still a POC, because the longest symbol is always compiled when KALLSYMS is enabled, which we probably don't want it.
