### PR TITLE
rust: make `Lock` trait unsafe.

### DIFF
--- a/rust/kernel/sync/guard.rs
+++ b/rust/kernel/sync/guard.rs
@@ -64,7 +64,12 @@ impl<'a, L: Lock + ?Sized> Guard<'a, L> {
 ///
 /// [`Guard`] is written such that any mutual exclusion primitive that can implement this trait can
 /// also benefit from having an automatic way to unlock itself.
-pub trait Lock {
+///
+/// # Safety
+///
+/// Implementers of this trait must ensure that only one thread/CPU may access the protected data
+/// once the lock is held, that is, between calls to `lock_noguard` and `unlock`.
+pub unsafe trait Lock {
     /// The type of the data protected by the lock.
     type Inner: ?Sized;
 

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -77,7 +77,8 @@ impl<T: ?Sized> NeedsLockClass for Mutex<T> {
     }
 }
 
-impl<T: ?Sized> Lock for Mutex<T> {
+// SAFETY: The underlying kernel `struct mutex` object ensures mutual exclusion.
+unsafe impl<T: ?Sized> Lock for Mutex<T> {
     type Inner = T;
     type GuardContext = ();
 

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -80,7 +80,8 @@ impl<T: ?Sized> NeedsLockClass for SpinLock<T> {
     }
 }
 
-impl<T: ?Sized> Lock for SpinLock<T> {
+// SAFETY: The underlying kernel `spinlock_t` object ensures mutual exclusion.
+unsafe impl<T: ?Sized> Lock for SpinLock<T> {
     type Inner = T;
     type GuardContext = ();
 


### PR DESCRIPTION
Without this, one could implement a lock that doesn't really provide
mutual exclusion, which could result in UB. For example, a no-op `Lock`
implementation could provide guards from two different threads
concurrently, which could be used by `LockedBy` to generate two mutable
references to the same underlying object.

Marking `Lock` unsafe has no implication on driver code because all
implementations are expected to come from the `kernel` crate anyway.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>