### PR TITLE
rust: rename `Guard` to `GuardMut`.

### DIFF
--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -5,7 +5,7 @@ use kernel::{
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, Links, List},
     prelude::*,
-    sync::{Guard, LockedBy, Mutex, Ref, SpinLock},
+    sync::{GuardMut, LockedBy, Mutex, Ref, SpinLock},
     user_ptr::UserSlicePtrWriter,
 };
 
@@ -244,7 +244,7 @@ impl Node {
 
     pub(crate) fn next_death(
         &self,
-        guard: &mut Guard<'_, Mutex<ProcessInner>>,
+        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
     ) -> Option<Ref<NodeDeath>> {
         self.inner.access_mut(guard).death_list.pop_front()
     }
@@ -252,7 +252,7 @@ impl Node {
     pub(crate) fn add_death(
         &self,
         death: Ref<NodeDeath>,
-        guard: &mut Guard<'_, Mutex<ProcessInner>>,
+        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
     ) {
         self.inner.access_mut(guard).death_list.push_back(death);
     }
@@ -306,7 +306,7 @@ impl Node {
     pub(crate) fn populate_counts(
         &self,
         out: &mut BinderNodeInfoForRef,
-        guard: &Guard<'_, Mutex<ProcessInner>>,
+        guard: &GuardMut<'_, Mutex<ProcessInner>>,
     ) {
         let inner = self.inner.access(guard);
         out.strong_count = inner.strong.count as _;
@@ -316,7 +316,7 @@ impl Node {
     pub(crate) fn populate_debug_info(
         &self,
         out: &mut BinderNodeDebugInfo,
-        guard: &Guard<'_, Mutex<ProcessInner>>,
+        guard: &GuardMut<'_, Mutex<ProcessInner>>,
     ) {
         out.ptr = self.ptr as _;
         out.cookie = self.cookie as _;
@@ -329,7 +329,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn force_has_count(&self, guard: &mut Guard<'_, Mutex<ProcessInner>>) {
+    pub(crate) fn force_has_count(&self, guard: &mut GuardMut<'_, Mutex<ProcessInner>>) {
         let inner = self.inner.access_mut(guard);
         inner.strong.has_count = true;
         inner.weak.has_count = true;

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -10,7 +10,7 @@ use kernel::{
     pages::Pages,
     prelude::*,
     rbtree::RBTree,
-    sync::{Guard, Mutex, Ref, UniqueRef},
+    sync::{GuardMut, Mutex, Ref, UniqueRef},
     task::Task,
     user_ptr::{UserSlicePtr, UserSlicePtrReader},
 };
@@ -925,7 +925,7 @@ impl<'a> Registration<'a> {
     fn new(
         process: &'a Process,
         thread: &'a Ref<Thread>,
-        guard: &mut Guard<'_, Mutex<ProcessInner>>,
+        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
     ) -> Self {
         guard.ready_threads.push_back(thread.clone());
         Self { process, thread }

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -5,7 +5,7 @@
 //! This module allows Rust code to use the kernel's [`struct wait_queue_head`] as a condition
 //! variable.
 
-use super::{Guard, Lock, NeedsLockClass};
+use super::{GuardMut, Lock, NeedsLockClass};
 use crate::{bindings, str::CStr, task::Task};
 use core::{cell::UnsafeCell, marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
 
@@ -60,7 +60,7 @@ impl CondVar {
     ///
     /// Returns whether there is a signal pending.
     #[must_use = "wait returns if a signal is pending, so the caller must check the return value"]
-    pub fn wait<L: Lock>(&self, guard: &mut Guard<'_, L>) -> bool {
+    pub fn wait<L: Lock>(&self, guard: &mut GuardMut<'_, L>) -> bool {
         let lock = guard.lock;
         let mut wait = MaybeUninit::<bindings::wait_queue_entry>::uninit();
 

--- a/rust/kernel/sync/locked_by.rs
+++ b/rust/kernel/sync/locked_by.rs
@@ -2,7 +2,7 @@
 
 //! A wrapper for data protected by a lock that does not wrap it.
 
-use super::{Guard, Lock};
+use super::{GuardMut, Lock};
 use core::{cell::UnsafeCell, ops::Deref, ptr};
 
 /// Allows access to some data to be serialised by a lock that does not wrap it.
@@ -77,8 +77,8 @@ impl<T, L: Lock + ?Sized> LockedBy<T, L> {
 
 impl<T: ?Sized, L: Lock + ?Sized> LockedBy<T, L> {
     /// Returns a reference to the protected data when the caller provides evidence (via a
-    /// [`Guard`]) that the owner is locked.
-    pub fn access<'a>(&'a self, guard: &'a Guard<'_, L>) -> &'a T {
+    /// [`GuardMut`]) that the owner is locked.
+    pub fn access<'a>(&'a self, guard: &'a GuardMut<'_, L>) -> &'a T {
         if !ptr::eq(guard.deref(), self.owner) {
             panic!("guard does not match owner");
         }
@@ -88,8 +88,8 @@ impl<T: ?Sized, L: Lock + ?Sized> LockedBy<T, L> {
     }
 
     /// Returns a mutable reference to the protected data when the caller provides evidence (via a
-    /// mutable [`Guard`]) that the owner is locked mutably.
-    pub fn access_mut<'a>(&'a self, guard: &'a mut Guard<'_, L>) -> &'a mut T {
+    /// mutable [`GuardMut`]) that the owner is locked mutably.
+    pub fn access_mut<'a>(&'a self, guard: &'a mut GuardMut<'_, L>) -> &'a mut T {
         if !ptr::eq(guard.deref().deref(), self.owner) {
             panic!("guard does not match owner");
         }

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -33,7 +33,7 @@ mod spinlock;
 
 pub use arc::{Ref, RefBorrow, UniqueRef};
 pub use condvar::CondVar;
-pub use guard::{Guard, Lock};
+pub use guard::{GuardMut, Lock};
 pub use locked_by::LockedBy;
 pub use mutex::Mutex;
 pub use spinlock::SpinLock;

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -4,7 +4,7 @@
 //!
 //! This module allows Rust code to use the kernel's [`struct mutex`].
 
-use super::{Guard, Lock, NeedsLockClass};
+use super::{GuardMut, Lock, NeedsLockClass};
 use crate::bindings;
 use crate::str::CStr;
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
@@ -64,10 +64,10 @@ impl<T> Mutex<T> {
 impl<T: ?Sized> Mutex<T> {
     /// Locks the mutex and gives the caller access to the data protected by it. Only one thread at
     /// a time is allowed to access the protected data.
-    pub fn lock(&self) -> Guard<'_, Self> {
+    pub fn lock(&self) -> GuardMut<'_, Self> {
         self.lock_noguard();
         // SAFETY: The mutex was just acquired.
-        unsafe { Guard::new(self, ()) }
+        unsafe { GuardMut::new(self, ()) }
     }
 }
 

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -6,7 +6,7 @@
 //!
 //! See <https://www.kernel.org/doc/Documentation/locking/spinlocks.txt>.
 
-use super::{Guard, Lock, NeedsLockClass};
+use super::{GuardMut, Lock, NeedsLockClass};
 use crate::bindings;
 use crate::str::CStr;
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
@@ -67,10 +67,10 @@ impl<T> SpinLock<T> {
 impl<T: ?Sized> SpinLock<T> {
     /// Locks the spinlock and gives the caller access to the data protected by it. Only one thread
     /// at a time is allowed to access the protected data.
-    pub fn lock(&self) -> Guard<'_, Self> {
+    pub fn lock(&self) -> GuardMut<'_, Self> {
         self.lock_noguard();
         // SAFETY: The spinlock was just acquired.
-        unsafe { Guard::new(self, ()) }
+        unsafe { GuardMut::new(self, ()) }
     }
 }
 


### PR DESCRIPTION
This is in preparation for the introduction of `Guard`, which won't
implement `DerefMut`. It will be used in sequence locks where the
protected data cannot be directly modified because it can be accessed
concurrently by readers.

This is a pure refactor with no functional changes intended.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>