### PR TITLE
Clean warnings

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -66,12 +66,12 @@ rustdoc-macros: $(srctree)/rust/macros/lib.rs FORCE
 rustdoc-compiler_builtins: $(srctree)/rust/compiler_builtins.rs rustdoc-core FORCE
 	$(call if_changed,rustdoc)
 
-# We need to allow `broken_intra_doc_links` because some
+# We need to allow `rustdoc::broken_intra_doc_links` because some
 # `no_global_oom_handling` functions refer to non-`no_global_oom_handling`
 # functions. Ideally `rustdoc` would have a way to distinguish broken links
 # due to things that are "configured out" vs. entirely non-existing ones.
 rustdoc-alloc: private rustc_target_flags = $(alloc-cfgs) \
-    -Abroken_intra_doc_links
+    -Arustdoc::broken_intra_doc_links
 rustdoc-alloc: $(srctree)/rust/alloc/lib.rs rustdoc-core \
     rustdoc-compiler_builtins FORCE
 	$(call if_changed,rustdoc)

--- a/rust/kernel/io_mem.rs
+++ b/rust/kernel/io_mem.rs
@@ -4,6 +4,8 @@
 //!
 //! C header: [`include/asm-generic/io.h`](../../../../include/asm-generic/io.h)
 
+#![allow(dead_code)]
+
 use crate::{bindings, Error, Result};
 use core::convert::TryInto;
 

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -89,6 +89,8 @@ pub use build_error::build_error;
 pub use crate::error::{Error, Result};
 pub use crate::types::{Mode, ScopeGuard};
 
+use core::marker::PhantomData;
+
 /// Page size defined in terms of the `PAGE_SHIFT` macro from C.
 ///
 /// [`PAGE_SHIFT`]: ../../../include/asm-generic/page.h
@@ -139,7 +141,11 @@ impl ThisModule {
             bindings::kernel_param_lock(self.0)
         }
 
-        KParamGuard { this_module: self }
+        KParamGuard {
+            #[cfg(CONFIG_SYSFS)]
+            this_module: self,
+            phantom: PhantomData,
+        }
     }
 }
 
@@ -147,7 +153,9 @@ impl ThisModule {
 ///
 /// Lock will be released when this struct is dropped.
 pub struct KParamGuard<'a> {
+    #[cfg(CONFIG_SYSFS)]
     this_module: &'a ThisModule,
+    phantom: PhantomData<&'a ()>,
 }
 
 #[cfg(CONFIG_SYSFS)]

--- a/rust/kernel/power.rs
+++ b/rust/kernel/power.rs
@@ -4,6 +4,8 @@
 //!
 //! C header: [`include/linux/pm.h`](../../../../include/linux/pm.h)
 
+#![allow(dead_code)]
+
 use crate::{bindings, c_types, from_kernel_result, sync::Ref, types::PointerWrapper, Result};
 use core::{marker::PhantomData, ops::Deref};
 


### PR DESCRIPTION
This cleans existing warnings to later enable `CONFIG_WERROR`.