### PR TITLE
Kconfig: document `CONFIG_WERROR` applies to Rust too

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -151,7 +151,8 @@ config WERROR
 	default COMPILE_TEST
 	help
 	  A kernel build should not cause any compiler warnings, and this
-	  enables the '-Werror' flag to enforce that rule by default.
+	  enables the '-Werror' (for C) and '-Dwarnings' (for Rust) flags
+	  to enforce that rule by default.
 
 	  However, if you have a new (or very old) compiler with odd and
 	  unusual warnings, or you have some architecture with problems,


### PR DESCRIPTION
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>