### PR TITLE
Makefile: remove `TENTATIVE_CLANG_FLAGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -630,7 +630,9 @@ endif
 # and from include/config/auto.conf.cmd to detect the compiler upgrade.
 CC_VERSION_TEXT = $(subst $(pound),,$(shell LC_ALL=C $(CC) --version 2>/dev/null | head -n 1))
 
+ifneq ($(findstring clang,$(CC_VERSION_TEXT)),)
 include $(srctree)/scripts/Makefile.clang
+endif
 
 # Include this also for config targets because some architectures need
 # cc-cross-prefix to determine CROSS_COMPILE.

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -199,9 +199,7 @@ else
 #
 # For the moment, here we are tweaking the flags on the fly. Some config
 # options may not work (e.g. `GCC_PLUGIN_RANDSTRUCT` if we end up using one
-# of those structs). We might want to redo how Clang flags are kept track of
-# in the general `Makefile` even for GCC builds, similar to what we did with
-# `TENTATIVE_CLANG_FLAGS`.
+# of those structs).
 bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-mskip-rax-setup -mgeneral-regs-only -msign-return-address=% \
 	-mindirect-branch=thunk-extern -mindirect-branch-register -mrecord-mcount \
@@ -220,7 +218,15 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 bindgen_skip_c_flags += -mtraceback=no -mno-pointers-to-nested-functions \
 	-mno-string -mno-strict-align
 
-bindgen_extra_c_flags = $(TENTATIVE_CLANG_FLAGS) -Wno-address-of-packed-member
+# Derived from `scripts/Makefile.clang`
+BINDGEN_TARGET_arm	:= arm-linux-gnueabi
+BINDGEN_TARGET_arm64	:= aarch64-linux-gnu
+BINDGEN_TARGET_powerpc	:= powerpc64le-linux-gnu
+BINDGEN_TARGET_riscv	:= riscv64-linux-gnu
+BINDGEN_TARGET_x86	:= x86_64-linux-gnu
+BINDGEN_TARGET		:= $(BINDGEN_TARGET_$(SRCARCH))
+
+bindgen_extra_c_flags = --target=$(BINDGEN_TARGET) -Wno-address-of-packed-member
 bindgen_c_flags = $(filter-out $(bindgen_skip_c_flags), $(c_flags)) \
 	$(bindgen_extra_c_flags)
 endif

--- a/scripts/Makefile.clang
+++ b/scripts/Makefile.clang
@@ -12,37 +12,29 @@ CLANG_TARGET_FLAGS_s390		:= s390x-linux-gnu
 CLANG_TARGET_FLAGS_x86		:= x86_64-linux-gnu
 CLANG_TARGET_FLAGS		:= $(CLANG_TARGET_FLAGS_$(SRCARCH))
 
-TENTATIVE_CLANG_FLAGS :=
-
 ifeq ($(CROSS_COMPILE),)
 ifeq ($(CLANG_TARGET_FLAGS),)
 $(error Specify CROSS_COMPILE or add '--target=' option to scripts/Makefile.clang)
 else
-TENTATIVE_CLANG_FLAGS	+= --target=$(CLANG_TARGET_FLAGS)
+CLANG_FLAGS	+= --target=$(CLANG_TARGET_FLAGS)
 endif # CLANG_TARGET_FLAGS
 else
-TENTATIVE_CLANG_FLAGS	+= --target=$(notdir $(CROSS_COMPILE:%-=%))
+CLANG_FLAGS	+= --target=$(notdir $(CROSS_COMPILE:%-=%))
 endif # CROSS_COMPILE
 
 ifeq ($(LLVM_IAS),0)
-TENTATIVE_CLANG_FLAGS	+= -fno-integrated-as
+CLANG_FLAGS	+= -fno-integrated-as
 GCC_TOOLCHAIN_DIR := $(dir $(shell which $(CROSS_COMPILE)elfedit))
-TENTATIVE_CLANG_FLAGS	+= --prefix=$(GCC_TOOLCHAIN_DIR)$(notdir $(CROSS_COMPILE))
+CLANG_FLAGS	+= --prefix=$(GCC_TOOLCHAIN_DIR)$(notdir $(CROSS_COMPILE))
 else
-TENTATIVE_CLANG_FLAGS	+= -fintegrated-as
+CLANG_FLAGS	+= -fintegrated-as
 endif
 # By default, clang only warns when it encounters an unknown warning flag or
 # certain optimization flags it knows it has not implemented.
 # Make it behave more like gcc by erroring when these flags are encountered
 # so they can be implemented or wrapped in cc-option.
-TENTATIVE_CLANG_FLAGS	+= -Werror=unknown-warning-option
-TENTATIVE_CLANG_FLAGS	+= -Werror=ignored-optimization-argument
-
-export TENTATIVE_CLANG_FLAGS
-
-ifneq ($(findstring clang,$(CC_VERSION_TEXT)),)
-CLANG_FLAGS	+= $(TENTATIVE_CLANG_FLAGS)
+CLANG_FLAGS	+= -Werror=unknown-warning-option
+CLANG_FLAGS	+= -Werror=ignored-optimization-argument
 KBUILD_CFLAGS	+= $(CLANG_FLAGS)
 KBUILD_AFLAGS	+= $(CLANG_FLAGS)
 export CLANG_FLAGS
-endif


### PR DESCRIPTION
We only really care about the target. And even if we did need
something more, it would be better to control it explicitly.

On top of that, there is now an `$(error ...)` that we would
need to avoid otherwise.

I will talk with the Clang team to see if they would be happy
moving the arch table outside so that we can reuse it.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>