### PR TITLE
rust: add `SeqLock`.

### DIFF
--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -5,7 +5,7 @@ use kernel::{
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, Links, List},
     prelude::*,
-    sync::{Guard, LockedBy, Mutex, Ref, SpinLock},
+    sync::{GuardMut, LockedBy, Mutex, Ref, SpinLock},
     user_ptr::UserSlicePtrWriter,
 };
 
@@ -244,7 +244,7 @@ impl Node {
 
     pub(crate) fn next_death(
         &self,
-        guard: &mut Guard<'_, Mutex<ProcessInner>>,
+        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
     ) -> Option<Ref<NodeDeath>> {
         self.inner.access_mut(guard).death_list.pop_front()
     }
@@ -252,7 +252,7 @@ impl Node {
     pub(crate) fn add_death(
         &self,
         death: Ref<NodeDeath>,
-        guard: &mut Guard<'_, Mutex<ProcessInner>>,
+        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
     ) {
         self.inner.access_mut(guard).death_list.push_back(death);
     }
@@ -306,7 +306,7 @@ impl Node {
     pub(crate) fn populate_counts(
         &self,
         out: &mut BinderNodeInfoForRef,
-        guard: &Guard<'_, Mutex<ProcessInner>>,
+        guard: &GuardMut<'_, Mutex<ProcessInner>>,
     ) {
         let inner = self.inner.access(guard);
         out.strong_count = inner.strong.count as _;
@@ -316,7 +316,7 @@ impl Node {
     pub(crate) fn populate_debug_info(
         &self,
         out: &mut BinderNodeDebugInfo,
-        guard: &Guard<'_, Mutex<ProcessInner>>,
+        guard: &GuardMut<'_, Mutex<ProcessInner>>,
     ) {
         out.ptr = self.ptr as _;
         out.cookie = self.cookie as _;
@@ -329,7 +329,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn force_has_count(&self, guard: &mut Guard<'_, Mutex<ProcessInner>>) {
+    pub(crate) fn force_has_count(&self, guard: &mut GuardMut<'_, Mutex<ProcessInner>>) {
         let inner = self.inner.access_mut(guard);
         inner.strong.has_count = true;
         inner.weak.has_count = true;

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -10,7 +10,7 @@ use kernel::{
     pages::Pages,
     prelude::*,
     rbtree::RBTree,
-    sync::{Guard, Mutex, Ref, UniqueRef},
+    sync::{GuardMut, Mutex, Ref, UniqueRef},
     task::Task,
     user_ptr::{UserSlicePtr, UserSlicePtrReader},
 };
@@ -925,7 +925,7 @@ impl<'a> Registration<'a> {
     fn new(
         process: &'a Process,
         thread: &'a Ref<Thread>,
-        guard: &mut Guard<'_, Mutex<ProcessInner>>,
+        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
     ) -> Self {
         guard.ready_threads.push_back(thread.clone());
         Self { process, thread }

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -278,6 +278,37 @@ void *rust_helper_dev_get_drvdata(struct device *dev)
 }
 EXPORT_SYMBOL_GPL(rust_helper_dev_get_drvdata);
 
+void rust_helper___seqcount_init(seqcount_t *s, const char *name,
+                               struct lock_class_key *key)
+{
+        __seqcount_init(s, name, key);
+}
+EXPORT_SYMBOL_GPL(rust_helper___seqcount_init);
+
+unsigned rust_helper_read_seqcount_begin(seqcount_t *s)
+{
+        return read_seqcount_begin(s);
+}
+EXPORT_SYMBOL_GPL(rust_helper_read_seqcount_begin);
+
+int rust_helper_read_seqcount_retry(seqcount_t *s, unsigned start)
+{
+        return read_seqcount_retry(s, start);
+}
+EXPORT_SYMBOL_GPL(rust_helper_read_seqcount_retry);
+
+void rust_helper_write_seqcount_begin(seqcount_t *s)
+{
+        do_write_seqcount_begin(s);
+}
+EXPORT_SYMBOL_GPL(rust_helper_write_seqcount_begin);
+
+void rust_helper_write_seqcount_end(seqcount_t *s)
+{
+        do_write_seqcount_end(s);
+}
+EXPORT_SYMBOL_GPL(rust_helper_write_seqcount_end);
+
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust
  * expects a usize like slice (array) indices. usize is defined to be

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -41,52 +41,52 @@ EXPORT_SYMBOL_GPL(rust_helper_ioremap);
 
 u8 rust_helper_readb(const volatile void __iomem *addr)
 {
-        return readb(addr);
+	return readb(addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_readb);
 
 u16 rust_helper_readw(const volatile void __iomem *addr)
 {
-        return readw(addr);
+	return readw(addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_readw);
 
 u32 rust_helper_readl(const volatile void __iomem *addr)
 {
-        return readl(addr);
+	return readl(addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_readl);
 
 #ifdef CONFIG_64BIT
 u64 rust_helper_readq(const volatile void __iomem *addr)
 {
-        return readq(addr);
+	return readq(addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_readq);
 #endif
 
 void rust_helper_writeb(u8 value, volatile void __iomem *addr)
 {
-        writeb(value, addr);
+	writeb(value, addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_writeb);
 
 void rust_helper_writew(u16 value, volatile void __iomem *addr)
 {
-        writew(value, addr);
+	writew(value, addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_writew);
 
 void rust_helper_writel(u32 value, volatile void __iomem *addr)
 {
-        writel(value, addr);
+	writel(value, addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_writel);
 
 #ifdef CONFIG_64BIT
 void rust_helper_writeq(u64 value, volatile void __iomem *addr)
 {
-        writeq(value, addr);
+	writeq(value, addr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_writeq);
 #endif
@@ -279,33 +279,33 @@ void *rust_helper_dev_get_drvdata(struct device *dev)
 EXPORT_SYMBOL_GPL(rust_helper_dev_get_drvdata);
 
 void rust_helper___seqcount_init(seqcount_t *s, const char *name,
-                               struct lock_class_key *key)
+				 struct lock_class_key *key)
 {
-        __seqcount_init(s, name, key);
+	__seqcount_init(s, name, key);
 }
 EXPORT_SYMBOL_GPL(rust_helper___seqcount_init);
 
 unsigned rust_helper_read_seqcount_begin(seqcount_t *s)
 {
-        return read_seqcount_begin(s);
+	return read_seqcount_begin(s);
 }
 EXPORT_SYMBOL_GPL(rust_helper_read_seqcount_begin);
 
 int rust_helper_read_seqcount_retry(seqcount_t *s, unsigned start)
 {
-        return read_seqcount_retry(s, start);
+	return read_seqcount_retry(s, start);
 }
 EXPORT_SYMBOL_GPL(rust_helper_read_seqcount_retry);
 
 void rust_helper_write_seqcount_begin(seqcount_t *s)
 {
-        do_write_seqcount_begin(s);
+	do_write_seqcount_begin(s);
 }
 EXPORT_SYMBOL_GPL(rust_helper_write_seqcount_begin);
 
 void rust_helper_write_seqcount_end(seqcount_t *s)
 {
-        do_write_seqcount_end(s);
+	do_write_seqcount_end(s);
 }
 EXPORT_SYMBOL_GPL(rust_helper_write_seqcount_end);
 

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -5,7 +5,7 @@
 //! This module allows Rust code to use the kernel's [`struct wait_queue_head`] as a condition
 //! variable.
 
-use super::{Guard, Lock, NeedsLockClass};
+use super::{GuardMut, Lock, NeedsLockClass};
 use crate::{bindings, str::CStr, task::Task};
 use core::{cell::UnsafeCell, marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
 
@@ -60,7 +60,7 @@ impl CondVar {
     ///
     /// Returns whether there is a signal pending.
     #[must_use = "wait returns if a signal is pending, so the caller must check the return value"]
-    pub fn wait<L: Lock>(&self, guard: &mut Guard<'_, L>) -> bool {
+    pub fn wait<L: Lock>(&self, guard: &mut GuardMut<'_, L>) -> bool {
         let lock = guard.lock;
         let mut wait = MaybeUninit::<bindings::wait_queue_entry>::uninit();
 

--- a/rust/kernel/sync/guard.rs
+++ b/rust/kernel/sync/guard.rs
@@ -6,13 +6,16 @@
 //! the ([`Lock`]) trait. It also contains the definition of the trait, which can be leveraged by
 //! other constructs to work on generic locking primitives.
 
+use super::NeedsLockClass;
+use crate::{bindings, str::CStr};
+use core::pin::Pin;
+
 /// Allows mutual exclusion primitives that implement the [`Lock`] trait to automatically unlock
 /// when a guard goes out of scope. It also provides a safe and convenient way to access the data
 /// protected by the lock.
 #[must_use = "the lock unlocks immediately when the guard is unused"]
 pub struct GuardMut<'a, L: Lock + ?Sized> {
-    pub(crate) lock: &'a L,
-    pub(crate) context: L::GuardContext,
+    pub(crate) guard: Guard<'a, L>,
 }
 
 // SAFETY: `GuardMut` is sync when the data protected by the lock is also sync. This is more
@@ -30,27 +33,69 @@ impl<L: Lock + ?Sized> core::ops::Deref for GuardMut<'_, L> {
     type Target = L::Inner;
 
     fn deref(&self) -> &Self::Target {
-        // SAFETY: The caller owns the lock, so it is safe to deref the protected data.
-        unsafe { &*self.lock.locked_data().get() }
+        self.guard.deref()
     }
 }
 
 impl<L: Lock + ?Sized> core::ops::DerefMut for GuardMut<'_, L> {
     fn deref_mut(&mut self) -> &mut L::Inner {
         // SAFETY: The caller owns the lock, so it is safe to deref the protected data.
-        unsafe { &mut *self.lock.locked_data().get() }
+        unsafe { &mut *self.guard.lock.locked_data().get() }
     }
 }
 
-impl<L: Lock + ?Sized> Drop for GuardMut<'_, L> {
+impl<'a, L: Lock + ?Sized> GuardMut<'a, L> {
+    /// Constructs a new lock guard.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that it owns the lock.
+    pub(crate) unsafe fn new(lock: &'a L, context: L::GuardContext) -> Self {
+        // SAFETY: The safety requirements for this function satisfy the `Guard::new` ones.
+        Self {
+            guard: unsafe { Guard::new(lock, context) },
+        }
+    }
+}
+
+/// Allows mutual exclusion primitives that implement the [`Lock`] trait to automatically unlock
+/// when a guard goes out of scope. It also provides a safe and convenient way to immutably access
+/// the data protected by the lock.
+#[must_use = "the lock unlocks immediately when the guard is unused"]
+pub struct Guard<'a, L: Lock + ?Sized> {
+    pub(crate) lock: &'a L,
+    pub(crate) context: L::GuardContext,
+}
+
+// SAFETY: `Guard` is sync when the data protected by the lock is also sync. This is more
+// conservative than the default compiler implementation; more details can be found on
+// https://github.com/rust-lang/rust/issues/41622 -- it refers to `MutexGuard` from the standard
+// library.
+unsafe impl<L> Sync for Guard<'_, L>
+where
+    L: Lock + ?Sized,
+    L::Inner: Sync,
+{
+}
+
+impl<L: Lock + ?Sized> core::ops::Deref for Guard<'_, L> {
+    type Target = L::Inner;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The caller owns the lock, so it is safe to deref the protected data.
+        unsafe { &*self.lock.locked_data().get() }
+    }
+}
+
+impl<L: Lock + ?Sized> Drop for Guard<'_, L> {
     fn drop(&mut self) {
         // SAFETY: The caller owns the lock, so it is safe to unlock it.
         unsafe { self.lock.unlock(&mut self.context) };
     }
 }
 
-impl<'a, L: Lock + ?Sized> GuardMut<'a, L> {
-    /// Constructs a new lock guard.
+impl<'a, L: Lock + ?Sized> Guard<'a, L> {
+    /// Constructs a new immutable lock guard.
     ///
     /// # Safety
     ///
@@ -62,8 +107,8 @@ impl<'a, L: Lock + ?Sized> GuardMut<'a, L> {
 
 /// A generic mutual exclusion primitive.
 ///
-/// [`GuardMut`] is written such that any mutual exclusion primitive that can implement this trait
-/// can also benefit from having an automatic way to unlock itself.
+/// [`Guard`] and [`GuardMut`] are written such that any mutual exclusion primitive that can
+/// implement this trait can also benefit from having an automatic way to unlock itself.
 ///
 /// # Safety
 ///
@@ -88,4 +133,38 @@ pub unsafe trait Lock {
 
     /// Returns the data protected by the lock.
     fn locked_data(&self) -> &core::cell::UnsafeCell<Self::Inner>;
+}
+
+/// A generic mutual exclusion primitive that can be instantiated generically.
+pub trait CreatableLock: Lock {
+    /// Constructs a new instance of the lock.
+    ///
+    /// # Safety
+    ///
+    /// The caller must call [`CreatableLock::init_lock`] before using the lock.
+    unsafe fn new_lock(data: Self::Inner) -> Self;
+
+    /// Initialises the lock type instance so that it can be safely used.
+    ///
+    /// # Safety
+    ///
+    /// `key` must point to a valid memory location that will remain valid until the lock is
+    /// dropped.
+    unsafe fn init_lock(
+        self: Pin<&mut Self>,
+        name: &'static CStr,
+        key: *mut bindings::lock_class_key,
+    );
+}
+
+impl<L: CreatableLock> NeedsLockClass for L {
+    unsafe fn init(
+        self: Pin<&mut Self>,
+        name: &'static CStr,
+        key: *mut bindings::lock_class_key,
+        _: *mut bindings::lock_class_key,
+    ) {
+        // SAFETY: The safety requirements of this function satisfy those of `init_lock`.
+        unsafe { self.init_lock(name, key) };
+    }
 }

--- a/rust/kernel/sync/locked_by.rs
+++ b/rust/kernel/sync/locked_by.rs
@@ -2,7 +2,7 @@
 
 //! A wrapper for data protected by a lock that does not wrap it.
 
-use super::{Guard, Lock};
+use super::{GuardMut, Lock};
 use core::{cell::UnsafeCell, ops::Deref, ptr};
 
 /// Allows access to some data to be serialised by a lock that does not wrap it.
@@ -77,8 +77,8 @@ impl<T, L: Lock + ?Sized> LockedBy<T, L> {
 
 impl<T: ?Sized, L: Lock + ?Sized> LockedBy<T, L> {
     /// Returns a reference to the protected data when the caller provides evidence (via a
-    /// [`Guard`]) that the owner is locked.
-    pub fn access<'a>(&'a self, guard: &'a Guard<'_, L>) -> &'a T {
+    /// [`GuardMut`]) that the owner is locked.
+    pub fn access<'a>(&'a self, guard: &'a GuardMut<'_, L>) -> &'a T {
         if !ptr::eq(guard.deref(), self.owner) {
             panic!("guard does not match owner");
         }
@@ -88,8 +88,8 @@ impl<T: ?Sized, L: Lock + ?Sized> LockedBy<T, L> {
     }
 
     /// Returns a mutable reference to the protected data when the caller provides evidence (via a
-    /// mutable [`Guard`]) that the owner is locked mutably.
-    pub fn access_mut<'a>(&'a self, guard: &'a mut Guard<'_, L>) -> &'a mut T {
+    /// mutable [`GuardMut`]) that the owner is locked mutably.
+    pub fn access_mut<'a>(&'a self, guard: &'a mut GuardMut<'_, L>) -> &'a mut T {
         if !ptr::eq(guard.deref().deref(), self.owner) {
             panic!("guard does not match owner");
         }

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -33,7 +33,7 @@ mod spinlock;
 
 pub use arc::{Ref, RefBorrow, UniqueRef};
 pub use condvar::CondVar;
-pub use guard::{Guard, Lock};
+pub use guard::{GuardMut, Lock};
 pub use locked_by::LockedBy;
 pub use mutex::Mutex;
 pub use spinlock::SpinLock;

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -4,7 +4,7 @@
 //!
 //! This module allows Rust code to use the kernel's [`struct mutex`].
 
-use super::{Guard, Lock, NeedsLockClass};
+use super::{GuardMut, Lock, NeedsLockClass};
 use crate::bindings;
 use crate::str::CStr;
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
@@ -64,10 +64,10 @@ impl<T> Mutex<T> {
 impl<T: ?Sized> Mutex<T> {
     /// Locks the mutex and gives the caller access to the data protected by it. Only one thread at
     /// a time is allowed to access the protected data.
-    pub fn lock(&self) -> Guard<'_, Self> {
+    pub fn lock(&self) -> GuardMut<'_, Self> {
         self.lock_noguard();
         // SAFETY: The mutex was just acquired.
-        unsafe { Guard::new(self, ()) }
+        unsafe { GuardMut::new(self, ()) }
     }
 }
 

--- a/rust/kernel/sync/seqlock.rs
+++ b/rust/kernel/sync/seqlock.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! A kernel sequential lock (seqlock).
+//!
+//! This module allows Rust code to use the sequential locks based on the kernel's `seqcount_t` and
+//! any locks implementing the [`CreatableLock`] trait.
+//!
+//! See <https://www.kernel.org/doc/Documentation/locking/seqlock.rst>.
+
+use super::{CreatableLock, Guard, Lock, NeedsLockClass};
+use crate::{bindings, str::CStr};
+use core::{cell::UnsafeCell, marker::PhantomPinned, ops::Deref, pin::Pin};
+
+/// Exposes sequential locks backed by the kernel's `seqcount_t`.
+///
+/// The write-side critical section is protected by a lock implementing the `CreatableLock` trait.
+///
+/// # Examples
+///
+///```
+/// # use kernel::prelude::*;
+/// use kernel::sync::{SeqLock, SpinLock};
+/// use core::sync::atomic::{AtomicU32, Ordering};
+///
+/// struct Example {
+///     a: AtomicU32,
+///     b: AtomicU32,
+/// }
+///
+/// fn get_sum(v: &SeqLock<SpinLock<Example>>) -> u32 {
+///     // Use `access` to access the fields of `Example`.
+///     v.access(|e| e.a.load(Ordering::Relaxed) + e.b.load(Ordering::Relaxed))
+/// }
+///
+/// fn get_sum_with_guard(v: &SeqLock<SpinLock<Example>>) -> u32 {
+///     // Use `read` and `need_retry` in a loop to access the fields of `Example`.
+///     loop {
+///         let guard = v.read();
+///         let sum = guard.a.load(Ordering::Relaxed) + guard.b.load(Ordering::Relaxed);
+///         if !guard.need_retry() {
+///             break sum;
+///         }
+///     }
+/// }
+///
+/// fn inc_each(v: &SeqLock<SpinLock<Example>>) {
+///     // Use a write-side guard to access the fields of `Example`.
+///     let guard = v.write();
+///     let a = guard.a.load(Ordering::Relaxed);
+///     guard.a.store(a + 1, Ordering::Relaxed);
+///     let b = guard.b.load(Ordering::Relaxed);
+///     guard.b.store(b + 1, Ordering::Relaxed);
+/// }
+/// ```
+pub struct SeqLock<L: CreatableLock + ?Sized> {
+    _p: PhantomPinned,
+    count: UnsafeCell<bindings::seqcount>,
+    write_lock: L,
+}
+
+// SAFETY: `SeqLock` can be transferred across thread boundaries iff the data it protects and the
+// underlying lock can.
+unsafe impl<L: CreatableLock + Send> Send for SeqLock<L> where L::Inner: Send {}
+
+// SAFETY: `SeqLock` allows concurrent access to the data it protects by both readers and writers,
+// so it requires that the data it protects be `Sync`, as well as the underlying lock.
+unsafe impl<L: CreatableLock + Sync> Sync for SeqLock<L> where L::Inner: Sync {}
+
+impl<L: CreatableLock> SeqLock<L> {
+    /// Constructs a new instance of [`SeqLock`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must call [`SeqLock::init`] before using the seqlock.
+    pub unsafe fn new(data: L::Inner) -> Self
+    where
+        L::Inner: Sized,
+    {
+        Self {
+            _p: PhantomPinned,
+            count: UnsafeCell::new(bindings::seqcount::default()),
+            // SAFETY: `L::init_lock` is called from `SeqLock::init`, which is required to be
+            // called by the function's safety requirements.
+            write_lock: unsafe { L::new_lock(data) },
+        }
+    }
+}
+
+impl<L: CreatableLock + ?Sized> SeqLock<L> {
+    /// Accesses the protected data in read mode.
+    ///
+    /// Readers and writers are allowed to run concurrently, so callers must check if they need to
+    /// refetch the values before they are used (e.g., because a writer changed them concurrently,
+    /// rendering them potentially inconsistent). The check is performed via calls to
+    /// [`SeqLockReadGuard::need_retry`].
+    pub fn read(&self) -> SeqLockReadGuard<'_, L> {
+        SeqLockReadGuard {
+            lock: self,
+            // SAFETY: `count` contains valid memory.
+            start_count: unsafe { bindings::read_seqcount_begin(self.count.get()) },
+        }
+    }
+
+    /// Accesses the protected data in read mode.
+    ///
+    /// The provided closure is called repeatedly if it may have accessed inconsistent data (e.g.,
+    /// because a concurrent writer modified it). This is a wrapper around [`SeqLock::read`] and
+    /// [`SeqLockReadGuard::need_retry`] in a loop.
+    pub fn access<F: Fn(&L::Inner) -> R, R>(&self, cb: F) -> R {
+        loop {
+            let guard = self.read();
+            let ret = cb(&guard);
+            if !guard.need_retry() {
+                return ret;
+            }
+        }
+    }
+
+    /// Locks the underlying lock and returns a guard that allows access to the protected data.
+    ///
+    /// The guard is not mutable though because readers are still allowed to concurrently access
+    /// the data. The protected data structure needs to provide interior mutability itself (e.g.,
+    /// via atomic types) for the individual fields that can be mutated.
+    pub fn write(&self) -> Guard<'_, Self> {
+        let ctx = self.lock_noguard();
+        // SAFETY: The seqlock was just acquired.
+        unsafe { Guard::new(self, ctx) }
+    }
+}
+
+impl<L: CreatableLock + ?Sized> NeedsLockClass for SeqLock<L> {
+    unsafe fn init(
+        mut self: Pin<&mut Self>,
+        name: &'static CStr,
+        key1: *mut bindings::lock_class_key,
+        key2: *mut bindings::lock_class_key,
+    ) {
+        // SAFETY: `write_lock` is pinned when `self` is.
+        let pinned = unsafe { self.as_mut().map_unchecked_mut(|s| &mut s.write_lock) };
+        // SAFETY: `key1` is valid by the safety requirements of this function.
+        unsafe { pinned.init_lock(name, key1) };
+        // SAFETY: `key2` is valid by the safety requirements of this function.
+        unsafe { bindings::__seqcount_init(self.count.get(), name.as_char_ptr(), key2) };
+    }
+}
+
+// SAFETY: The underlying lock ensures mutual exclusion.
+unsafe impl<L: CreatableLock + ?Sized> Lock for SeqLock<L> {
+    type Inner = L::Inner;
+    type GuardContext = L::GuardContext;
+
+    fn lock_noguard(&self) -> L::GuardContext {
+        let ctx = self.write_lock.lock_noguard();
+        // SAFETY: `count` contains valid memory.
+        unsafe { bindings::write_seqcount_begin(self.count.get()) };
+        ctx
+    }
+
+    unsafe fn unlock(&self, ctx: &mut L::GuardContext) {
+        // SAFETY: The safety requirements of the function ensure that lock is owned by the caller.
+        unsafe { bindings::write_seqcount_end(self.count.get()) };
+        // SAFETY: The safety requirements of the function ensure that lock is owned by the caller.
+        unsafe { self.write_lock.unlock(ctx) };
+    }
+
+    fn locked_data(&self) -> &UnsafeCell<L::Inner> {
+        self.write_lock.locked_data()
+    }
+}
+
+/// Allows read-side access to data protected by a sequential lock.
+pub struct SeqLockReadGuard<'a, L: CreatableLock + ?Sized> {
+    lock: &'a SeqLock<L>,
+    start_count: u32,
+}
+
+impl<L: CreatableLock + ?Sized> SeqLockReadGuard<'_, L> {
+    /// Determine if the callers needs to retry reading values.
+    ///
+    /// It returns `true` when a concurrent writer ran between the guard being created and
+    /// [`Self::need_retry`] being called.
+    pub fn need_retry(&self) -> bool {
+        // SAFETY: `count` is valid because the guard guarantees that the lock remains alive.
+        unsafe { bindings::read_seqcount_retry(self.lock.count.get(), self.start_count) != 0 }
+    }
+}
+
+impl<L: CreatableLock + ?Sized> Deref for SeqLockReadGuard<'_, L> {
+    type Target = L::Inner;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: We only ever allow shared access to the protected data.
+        unsafe { &*self.lock.locked_data().get() }
+    }
+}

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -6,7 +6,7 @@
 //!
 //! See <https://www.kernel.org/doc/Documentation/locking/spinlocks.txt>.
 
-use super::{Guard, Lock, NeedsLockClass};
+use super::{GuardMut, Lock, NeedsLockClass};
 use crate::bindings;
 use crate::str::CStr;
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
@@ -67,10 +67,10 @@ impl<T> SpinLock<T> {
 impl<T: ?Sized> SpinLock<T> {
     /// Locks the spinlock and gives the caller access to the data protected by it. Only one thread
     /// at a time is allowed to access the protected data.
-    pub fn lock(&self) -> Guard<'_, Self> {
+    pub fn lock(&self) -> GuardMut<'_, Self> {
         self.lock_noguard();
         // SAFETY: The spinlock was just acquired.
-        unsafe { Guard::new(self, ()) }
+        unsafe { GuardMut::new(self, ()) }
     }
 }
 


### PR DESCRIPTION
This is based on the discussion in:
https://lore.kernel.org/rust-for-linux/YWccYPLUOH7t9JtB@google.com/

It has one modification where the `SeqLock` embeds a lock to serialise
the write-side critical section implicitly.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>