### PR TITLE
Update `rustfmt` and rust-analyzer to edition 2021

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2018"
+edition = "2021"
 newline_style = "Unix"
 
 # Unstable options that help catching some mistakes in formatting and that we may want to enable

--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -32,7 +32,7 @@ def generate_crates(srctree, objtree, sysroot_src):
             "is_proc_macro": is_proc_macro,
             "deps": [{"crate": crates_indexes[dep], "name": dep} for dep in deps],
             "cfg": cfg,
-            "edition": "2018",
+            "edition": "2021",
             "env": {
                 "RUST_MODFILE": "This is only for rust-analyzer"
             }


### PR DESCRIPTION
`core` and `alloc` are technically 2018, but we are compiling them as 2021 anyway.