### PR TITLE
Makefile: rust: Make debuginfo independent on whether llvm-as is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -937,11 +937,12 @@ endif
 
 ifndef CONFIG_AS_IS_LLVM
 KBUILD_AFLAGS	+= -Wa,-gdwarf-2
+endif
+
 ifdef CONFIG_DEBUG_INFO_REDUCED
 DEBUG_RUSTFLAGS += -Cdebuginfo=1
 else
 DEBUG_RUSTFLAGS += -Cdebuginfo=2
-endif
 endif
 
 ifndef CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT


### PR DESCRIPTION
Otherwise debuginfo won't be generated even if DEBUG_INFO=y when make
using "LLVM=1".

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>