### PR TITLE
Introduce `Opaque` type and use it in `sync` module.

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -86,7 +86,7 @@ pub mod user_ptr;
 pub use build_error::build_error;
 
 pub use crate::error::{Error, Result};
-pub use crate::types::{Mode, ScopeGuard};
+pub use crate::types::{Mode, Opaque, ScopeGuard};
 
 use core::marker::PhantomData;
 

--- a/rust/kernel/sync/seqlock.rs
+++ b/rust/kernel/sync/seqlock.rs
@@ -8,7 +8,7 @@
 //! See <https://www.kernel.org/doc/Documentation/locking/seqlock.rst>.
 
 use super::{CreatableLock, Guard, Lock, NeedsLockClass};
-use crate::{bindings, str::CStr};
+use crate::{bindings, str::CStr, Opaque};
 use core::{cell::UnsafeCell, marker::PhantomPinned, ops::Deref, pin::Pin};
 
 /// Exposes sequential locks backed by the kernel's `seqcount_t`.
@@ -54,7 +54,7 @@ use core::{cell::UnsafeCell, marker::PhantomPinned, ops::Deref, pin::Pin};
 /// ```
 pub struct SeqLock<L: CreatableLock + ?Sized> {
     _p: PhantomPinned,
-    count: UnsafeCell<bindings::seqcount>,
+    count: Opaque<bindings::seqcount>,
     write_lock: L,
 }
 
@@ -78,7 +78,7 @@ impl<L: CreatableLock> SeqLock<L> {
     {
         Self {
             _p: PhantomPinned,
-            count: UnsafeCell::new(bindings::seqcount::default()),
+            count: Opaque::uninit(),
             // SAFETY: `L::init_lock` is called from `SeqLock::init`, which is required to be
             // called by the function's safety requirements.
             write_lock: unsafe { L::new_lock(data) },

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -7,8 +7,7 @@
 //! See <https://www.kernel.org/doc/Documentation/locking/spinlocks.txt>.
 
 use super::{CreatableLock, GuardMut, Lock};
-use crate::bindings;
-use crate::str::CStr;
+use crate::{bindings, str::CStr, Opaque};
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
 
 /// Safely initialises a [`SpinLock`] with the given name, generating a new lock class.
@@ -33,7 +32,7 @@ macro_rules! spinlock_init {
 ///
 /// [`spinlock_t`]: ../../../include/linux/spinlock.h
 pub struct SpinLock<T: ?Sized> {
-    spin_lock: UnsafeCell<bindings::spinlock>,
+    spin_lock: Opaque<bindings::spinlock>,
 
     /// Spinlocks are architecture-defined. So we conservatively require them to be pinned in case
     /// some architecture uses self-references now or in the future.
@@ -57,7 +56,7 @@ impl<T> SpinLock<T> {
     /// The caller must call [`SpinLock::init_lock`] before using the spinlock.
     pub unsafe fn new(t: T) -> Self {
         Self {
-            spin_lock: UnsafeCell::new(bindings::spinlock::default()),
+            spin_lock: Opaque::uninit(),
             data: UnsafeCell::new(t),
             _pin: PhantomPinned,
         }


### PR DESCRIPTION
It has the advantage that the objects don't have to be zero-initialised
before calling their init functions (e.g., `mutex_init` for mutexes).
This makes the code performance closer to C.

This uses `UnsafeCell::raw_get`, which was stabilised in 1.56.0.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>