### PR TITLE
rust: add `bits_iter`.

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -86,7 +86,7 @@ pub mod user_ptr;
 pub use build_error::build_error;
 
 pub use crate::error::{Error, Result};
-pub use crate::types::{Mode, Opaque, ScopeGuard};
+pub use crate::types::{bits_iter, Mode, Opaque, ScopeGuard};
 
 use core::marker::PhantomData;
 


### PR DESCRIPTION
This allows callers to efficiently iterate over the bits set in a given
integer.

It is implemented generically, so it works even in custom integer types
as long as they provide all the functions we need.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>