### PR TITLE
rust: improve `KernelModule` initialisation.

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -8,11 +8,11 @@
 #![feature(global_asm, try_reserve, allocator_api, concat_idents)]
 
 use kernel::{
-    c_str,
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, GetLinksWrapped, Links},
     miscdev::Registration,
     prelude::*,
+    str::CStr,
     sync::Ref,
     user_ptr::UserSlicePtrWriter,
 };
@@ -106,9 +106,9 @@ struct BinderModule {
 }
 
 impl KernelModule for BinderModule {
-    fn init() -> Result<Self> {
+    fn init(name: &'static CStr, _module: &'static kernel::ThisModule) -> Result<Self> {
         let ctx = Context::new()?;
-        let reg = Registration::new_pinned::<process::Process>(c_str!("rust_binder"), None, ctx)?;
+        let reg = Registration::new_pinned::<process::Process>(name, None, ctx)?;
         Ok(Self { _reg: reg })
     }
 }

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -13,7 +13,8 @@ use kernel::{
     of::ConstOfMatchTable,
     platdev::PlatformDriver,
     prelude::*,
-    {c_str, platdev},
+    str::CStr,
+    ThisModule, {c_str, platdev},
 };
 
 module! {
@@ -69,15 +70,12 @@ struct RngModule {
 }
 
 impl KernelModule for RngModule {
-    fn init() -> Result<Self> {
+    fn init(name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
         const OF_MATCH_TBL: ConstOfMatchTable<1> =
             ConstOfMatchTable::new_const([c_str!("brcm,bcm2835-rng")]);
 
-        let pdev = platdev::Registration::new_pinned::<RngDriver>(
-            c_str!("bcm2835-rng-rust"),
-            Some(&OF_MATCH_TBL),
-            &THIS_MODULE,
-        )?;
+        let pdev =
+            platdev::Registration::new_pinned::<RngDriver>(name, Some(&OF_MATCH_TBL), module)?;
 
         Ok(RngModule { _pdev: pdev })
     }

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -108,7 +108,7 @@ pub trait KernelModule: Sized + Sync {
     /// should do.
     ///
     /// Equivalent to the `module_init` macro in the C API.
-    fn init() -> Result<Self>;
+    fn init(name: &'static str::CStr, module: &'static ThisModule) -> Result<Self>;
 }
 
 /// Equivalent to `THIS_MODULE` in the C API.

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -15,11 +15,13 @@ pub use core::pin::Pin;
 
 pub use alloc::{boxed::Box, string::String, vec::Vec};
 
-pub use macros::{module, module_misc_device};
+pub use macros::module;
 
 pub use super::build_assert;
 
 pub use super::{dbg, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
+
+pub use super::module_misc_device;
 
 pub use super::static_assert;
 

--- a/rust/macros/lib.rs
+++ b/rust/macros/lib.rs
@@ -92,37 +92,3 @@ use proc_macro::TokenStream;
 pub fn module(ts: TokenStream) -> TokenStream {
     module::module(ts)
 }
-
-/// Declares a kernel module that exposes a single misc device.
-///
-/// The `type` argument should be a type which implements the [`FileOpener`] trait. Also accepts
-/// various forms of kernel metadata.
-///
-/// C header: [`include/linux/moduleparam.h`](../../../include/linux/moduleparam.h)
-///
-/// [`FileOpener`]: ../kernel/file_operations/trait.FileOpener.html
-///
-/// # Examples
-///
-/// ```ignore
-/// use kernel::prelude::*;
-///
-/// module_misc_device! {
-///     type: MyFile,
-///     name: b"my_miscdev_kernel_module",
-///     author: b"Rust for Linux Contributors",
-///     description: b"My very own misc device kernel module!",
-///     license: b"GPL v2",
-/// }
-///
-/// #[derive(Default)]
-/// struct MyFile;
-///
-/// impl kernel::file_operations::FileOperations for MyFile {
-///     kernel::declare_file_operations!();
-/// }
-/// ```
-#[proc_macro]
-pub fn module_misc_device(ts: TokenStream) -> TokenStream {
-    module::module_misc_device(ts)
-}

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -6,7 +6,7 @@
 #![feature(allocator_api, global_asm)]
 
 use kernel::prelude::*;
-use kernel::{c_str, chrdev, file_operations::FileOperations};
+use kernel::{chrdev, file_operations::FileOperations, str::CStr, ThisModule};
 
 module! {
     type: RustChrdev,
@@ -28,11 +28,10 @@ struct RustChrdev {
 }
 
 impl KernelModule for RustChrdev {
-    fn init() -> Result<Self> {
+    fn init(name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust character device sample (init)\n");
 
-        let mut chrdev_reg =
-            chrdev::Registration::new_pinned(c_str!("rust_chrdev"), 0, &THIS_MODULE)?;
+        let mut chrdev_reg = chrdev::Registration::new_pinned(name, 0, module)?;
 
         // Register the same kind of device twice, we're just demonstrating
         // that you can use multiple minors. There are two minors in this case

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -5,7 +5,7 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use kernel::prelude::*;
+use kernel::{prelude::*, str::CStr, ThisModule};
 
 module! {
     type: RustMinimal,
@@ -20,7 +20,7 @@ struct RustMinimal {
 }
 
 impl KernelModule for RustMinimal {
-    fn init() -> Result<Self> {
+    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust minimal sample (init)\n");
         pr_info!("Am I built-in? {}\n", !cfg!(MODULE));
 

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -7,12 +7,13 @@
 
 use kernel::prelude::*;
 use kernel::{
-    c_str,
     file::File,
     file_operations::{FileOpener, FileOperations},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
+    str::CStr,
     sync::{CondVar, Mutex, Ref},
+    ThisModule,
 };
 
 module! {
@@ -132,13 +133,13 @@ struct RustMiscdev {
 }
 
 impl KernelModule for RustMiscdev {
-    fn init() -> Result<Self> {
+    fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust miscellaneous device sample (init)\n");
 
         let state = SharedState::try_new()?;
 
         Ok(RustMiscdev {
-            _dev: miscdev::Registration::new_pinned::<Token>(c_str!("rust_miscdev"), None, state)?,
+            _dev: miscdev::Registration::new_pinned::<Token>(name, None, state)?,
         })
     }
 }

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -5,7 +5,7 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use kernel::prelude::*;
+use kernel::{prelude::*, str::CStr, ThisModule};
 
 module! {
     type: RustModuleParameters,
@@ -45,11 +45,11 @@ module! {
 struct RustModuleParameters;
 
 impl KernelModule for RustModuleParameters {
-    fn init() -> Result<Self> {
+    fn init(_name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust module parameters sample (init)\n");
 
         {
-            let lock = THIS_MODULE.kernel_param_lock();
+            let lock = module.kernel_param_lock();
             pr_info!("Parameters:\n");
             pr_info!("  my_bool:    {}\n", my_bool.read());
             pr_info!("  my_i32:     {}\n", my_i32.read(&lock));

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -5,8 +5,8 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use kernel::pr_cont;
 use kernel::prelude::*;
+use kernel::{pr_cont, str::CStr, ThisModule};
 
 module! {
     type: RustPrint,
@@ -19,7 +19,7 @@ module! {
 struct RustPrint;
 
 impl KernelModule for RustPrint {
-    fn init() -> Result<Self> {
+    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust printing macros sample (init)\n");
 
         pr_emerg!("Emergency message (level 0) without args\n");

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -18,15 +18,17 @@
 
 use core::sync::atomic::{AtomicU64, Ordering};
 use kernel::{
-    c_str, condvar_init, declare_file_operations,
+    condvar_init, declare_file_operations,
     file::File,
     file_operations::{FileOpener, FileOperations, IoctlCommand, IoctlHandler},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev::Registration,
     mutex_init,
     prelude::*,
+    str::CStr,
     sync::{CondVar, Mutex, Ref},
     user_ptr::{UserSlicePtrReader, UserSlicePtrWriter},
+    ThisModule,
 };
 
 module! {
@@ -110,7 +112,7 @@ struct RustSemaphore {
 }
 
 impl KernelModule for RustSemaphore {
-    fn init() -> Result<Self> {
+    fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust semaphore sample (init)\n");
 
         let sema = Ref::try_new_and_init(
@@ -138,7 +140,7 @@ impl KernelModule for RustSemaphore {
         )?;
 
         Ok(Self {
-            _dev: Registration::new_pinned::<FileState>(c_str!("rust_semaphore"), None, sema)?,
+            _dev: Registration::new_pinned::<FileState>(name, None, sema)?,
         })
     }
 }

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -6,7 +6,7 @@
 #![feature(allocator_api, global_asm)]
 #![feature(bench_black_box)]
 
-use kernel::prelude::*;
+use kernel::{prelude::*, str::CStr, ThisModule};
 
 module! {
     type: RustStackProbing,
@@ -19,7 +19,7 @@ module! {
 struct RustStackProbing;
 
 impl KernelModule for RustStackProbing {
-    fn init() -> Result<Self> {
+    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust stack probing sample (init)\n");
 
         // Including this large variable on the stack will trigger

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -8,7 +8,9 @@
 use kernel::prelude::*;
 use kernel::{
     condvar_init, mutex_init, spinlock_init,
+    str::CStr,
     sync::{CondVar, Mutex, SpinLock},
+    ThisModule,
 };
 
 module! {
@@ -22,7 +24,7 @@ module! {
 struct RustSync;
 
 impl KernelModule for RustSync {
-    fn init() -> Result<Self> {
+    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust synchronisation primitives sample (init)\n");
 
         // Test mutexes.


### PR DESCRIPTION
These changes allow the init of modules to be implemented in other
modules (e.g., the main kernel crate, which isn't a separate module).
This, in turn, allows us to define module macros for specific types of
modules without procmacros (albeit with the limitation that `type` must
be the first parameter).

As an example, I redefined `module_misc_device` as a regular macro.

This is in preparation for adding macros for pci, amba, and platform
modules without the need for more procmacros.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>