### PR TITLE
rust: add CStr & ThisModule to prelude

### DIFF
--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -26,3 +26,5 @@ pub use super::module_misc_device;
 pub use super::static_assert;
 
 pub use super::{Error, KernelModule, Result};
+
+pub use super::{str::CStr, ThisModule};

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -6,7 +6,7 @@
 #![feature(allocator_api, global_asm)]
 
 use kernel::prelude::*;
-use kernel::{chrdev, file_operations::FileOperations, str::CStr, ThisModule};
+use kernel::{chrdev, file_operations::FileOperations};
 
 module! {
     type: RustChrdev,

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -5,7 +5,7 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use kernel::{prelude::*, str::CStr, ThisModule};
+use kernel::prelude::*;
 
 module! {
     type: RustMinimal,

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -11,9 +11,7 @@ use kernel::{
     file_operations::{FileOpener, FileOperations},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
-    str::CStr,
     sync::{CondVar, Mutex, Ref},
-    ThisModule,
 };
 
 module! {

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -5,7 +5,7 @@
 #![no_std]
 #![feature(allocator_api, global_asm)]
 
-use kernel::{prelude::*, str::CStr, ThisModule};
+use kernel::prelude::*;
 
 module! {
     type: RustModuleParameters,

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -25,10 +25,8 @@ use kernel::{
     miscdev::Registration,
     mutex_init,
     prelude::*,
-    str::CStr,
     sync::{CondVar, Mutex, Ref},
     user_ptr::{UserSlicePtrReader, UserSlicePtrWriter},
-    ThisModule,
 };
 
 module! {

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -6,7 +6,7 @@
 #![feature(allocator_api, global_asm)]
 #![feature(bench_black_box)]
 
-use kernel::{prelude::*, str::CStr, ThisModule};
+use kernel::prelude::*;
 
 module! {
     type: RustStackProbing,

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -8,9 +8,7 @@
 use kernel::prelude::*;
 use kernel::{
     condvar_init, mutex_init, spinlock_init,
-    str::CStr,
     sync::{CondVar, Mutex, SpinLock},
-    ThisModule,
 };
 
 module! {


### PR DESCRIPTION
Now that the trait signature of KernelModule has changed, we can add
the necessary deps to the prelude considering they'll be needed in each
non-specialized module init

Signed-off-by: Milan <milan@mdaverde.com>