### PR TITLE
rust: add `bit` function.

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -91,7 +91,7 @@ pub mod user_ptr;
 pub use build_error::build_error;
 
 pub use crate::error::{to_result, Error, Result};
-pub use crate::types::{bits_iter, Mode, Opaque, ScopeGuard};
+pub use crate::types::{bit, bits_iter, Mode, Opaque, ScopeGuard};
 
 use core::marker::PhantomData;
 


### PR DESCRIPTION
It behaves similarly to C's `BIT` macro. It is used to seamlessly
convert C code that uses this macro, for example the PL061 driver.

Some of this was discussed in Zulip. We couldn't find a simpler solution
that offered the same ergonomics.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>