### PR TITLE
rust: remove instances of `Pin<Ref<T>>`.

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -260,8 +260,8 @@ unsafe impl Send for Process {}
 unsafe impl Sync for Process {}
 
 impl Process {
-    fn new(ctx: Ref<Context>) -> Result<Pin<Ref<Self>>> {
-        Ok(Ref::pinned(Ref::try_new_and_init(
+    fn new(ctx: Ref<Context>) -> Result<Ref<Self>> {
+        Ref::try_new_and_init(
             Self {
                 ctx,
                 task: Task::current().group_leader().clone(),
@@ -278,7 +278,7 @@ impl Process {
                 let pinned = unsafe { process.as_mut().map_unchecked_mut(|p| &mut p.node_refs) };
                 kernel::mutex_init!(pinned, "Process::node_refs");
             },
-        )?))
+        )
     }
 
     /// Attemps to fetch a work item from the process queue.
@@ -797,7 +797,7 @@ impl FileOpener<Ref<Context>> for Process {
 }
 
 impl FileOperations for Process {
-    type Wrapper = Pin<Ref<Self>>;
+    type Wrapper = Ref<Self>;
 
     kernel::declare_file_operations!(ioctl, compat_ioctl, mmap, poll);
 

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -159,12 +159,6 @@ impl<T: ?Sized> Ref<T> {
         ptr::eq(a.ptr.as_ptr(), b.ptr.as_ptr())
     }
 
-    /// Returns a pinned version of a given `Ref` instance.
-    pub fn pinned(obj: Self) -> Pin<Self> {
-        // SAFETY: The type invariants guarantee that the value is pinned.
-        unsafe { Pin::new_unchecked(obj) }
-    }
-
     /// Deconstructs a [`Ref`] object into a raw pointer.
     ///
     /// It can be reconstructed once via [`Ref::from_raw`].


### PR DESCRIPTION
Since `Ref<T>` is already pinned, there is no need to wrap it in `Pin`.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>