### PR TITLE
rust: add functions to pin `UniqueRef` and convert it to `Ref`.

### DIFF
--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -304,6 +304,21 @@ impl<T: ?Sized> From<UniqueRef<T>> for Ref<T> {
     }
 }
 
+impl<T: ?Sized> From<UniqueRef<T>> for Pin<UniqueRef<T>> {
+    fn from(obj: UniqueRef<T>) -> Self {
+        // SAFETY: It is not possible to move/replace `T` inside a `Pin<UniqueRef<T>>` (unless `T`
+        // is `Unpin`), so it is ok to convert it to `Pin<UniqueRef<T>>`.
+        unsafe { Pin::new_unchecked(obj) }
+    }
+}
+
+impl<T: ?Sized> From<Pin<UniqueRef<T>>> for Ref<T> {
+    fn from(item: Pin<UniqueRef<T>>) -> Self {
+        // SAFETY: The type invariants of `Ref` guarantee that the data is pinned.
+        unsafe { Pin::into_inner_unchecked(item).inner }
+    }
+}
+
 /// A borrowed [`Ref`] with manually-managed lifetime.
 ///
 /// # Invariants


### PR DESCRIPTION
This allows us to initialise without the need for closures (which has
simpler syntax) by using the following sequence:
1. Create a `UniqueRef`
2. Initialise all fields that don't need pinning
3. Convert `UniqueRef` to `Pin<UniqueRef>`
4. Initialise all fields that require pinning
5. Convert `Pin<UniqueRef>` to `Ref`

The next patch converts all users of `Ref::try_new_and_init` and
`RefUnique::pin_init_and_share` to use parts of the sequence above.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>