### PR TITLE
Add Samsung Exynos true random number generator driver

### DIFF
--- a/drivers/char/hw_random/Kconfig
+++ b/drivers/char/hw_random/Kconfig
@@ -479,6 +479,19 @@ config HW_RANDOM_EXYNOS
 
 	  If unsure, say Y.
 
+config HW_RANDOM_EXYNOS_RUST
+	tristate "Rust version of Samsung Exynos True Random Number Generator support"
+	depends on HAS_RUST && ARCH_EXYNOS
+	default HW_RANDOM
+	help
+	  This driver provides support for the True Random Number
+	  Generator available in Exynos SoCs.
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called exynos_trng_rust.
+
+	  If unsure, say Y.
+
 config HW_RANDOM_OPTEE
 	tristate "OP-TEE based Random Number Generator support"
 	depends on OPTEE

--- a/drivers/char/hw_random/Makefile
+++ b/drivers/char/hw_random/Makefile
@@ -15,6 +15,7 @@ obj-$(CONFIG_HW_RANDOM_N2RNG) += n2-rng.o
 n2-rng-y := n2-drv.o n2-asm.o
 obj-$(CONFIG_HW_RANDOM_VIA) += via-rng.o
 obj-$(CONFIG_HW_RANDOM_EXYNOS) += exynos-trng.o
+obj-$(CONFIG_HW_RANDOM_EXYNOS_RUST) += exynos_trng_rust.o
 obj-$(CONFIG_HW_RANDOM_IXP4XX) += ixp4xx-rng.o
 obj-$(CONFIG_HW_RANDOM_OMAP) += omap-rng.o
 obj-$(CONFIG_HW_RANDOM_OMAP3_ROM) += omap3-rom-rng.o

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -52,15 +52,15 @@ struct RngDriver;
 impl PlatformDriver for RngDriver {
     type DrvData = Pin<Box<miscdev::Registration<()>>>;
 
-    fn probe(device_id: i32) -> Result<Self::DrvData> {
-        pr_info!("probing discovered hwrng with id {}\n", device_id);
+    fn probe(pdev: &mut PlatformDevice) -> Result<Self::DrvData> {
+        pr_info!("probing discovered pdev with name {}\n", pdev.name());
         let drv_data =
             miscdev::Registration::new_pinned::<RngDevice>(c_str!("rust_hwrng"), None, ())?;
         Ok(drv_data)
     }
 
-    fn remove(device_id: i32, _drv_data: Self::DrvData) -> Result {
-        pr_info!("removing hwrng with id {}\n", device_id);
+    fn remove(pdev: &mut PlatformDevice, _drv_data: Self::DrvData) -> Result {
+        pr_info!("removing pdev with name {}\n", pdev.name());
         Ok(())
     }
 }

--- a/drivers/char/hw_random/exynos_trng_rust.rs
+++ b/drivers/char/hw_random/exynos_trng_rust.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! RNG driver for Exynos TRNGs
+//!
+//! Author: Maciej Falkowski <m.falkowski@samsung.com>
+//!
+//! Copyright 2021 (c) Samsung Electronics Software, Inc.
+//!
+//! Based on the Exynos TRNG driver drivers/char/hw_random/exynos-rng by
+//! Łukasz Stelmach <l.stelmach@samsung.com>
+
+#![no_std]
+#![feature(allocator_api, global_asm)]
+
+use core::{cmp::min, convert::TryInto, str};
+
+use kernel::{
+    c_str,
+    clk::{self, Clk},
+    declare_hwrng_operations,
+    device::RawDevice,
+    hw_random::{self, HwrngOperations},
+    io_mem::{self, IoMem},
+    of::ConstOfMatchTable,
+    platdev::{self, PlatformDevice, PlatformDriver},
+    prelude::*,
+};
+
+module! {
+    type: ExynosTrngDriverModule,
+    name: b"exynos_trng_rust",
+    author: b"Maciej Falkowski <m.falkowski@samsung.com>",
+    description: b"RNG driver for Exynos TRNGs",
+    license: b"GPL v2",
+}
+
+const EXYNOS_TRNG_CLKDIV: usize = 0x0;
+
+const EXYNOS_TRNG_CTRL: usize = 0x20;
+const EXYNOS_TRNG_CTRL_RNGEN: u32 = 0x1 << 31; // BIT(31)
+
+const EXYNOS_REG_SIZE: usize = 0x100;
+const EXYNOS_TRNG_POST_CTRL: usize = 0x30;
+const _EXYNOS_TRNG_ONLINE_CTRL: usize = 0x40;
+const _EXYNOS_TRNG_ONLINE_STAT: usize = 0x44;
+const _EXYNOS_TRNG_ONLINE_MAXCHI2: usize = 0x48;
+const EXYNOS_TRNG_FIFO_CTRL: usize = 0x50;
+const EXYNOS_TRNG_FIFO_0: usize = 0x80;
+const _EXYNOS_TRNG_FIFO_1: usize = 0x84;
+const _EXYNOS_TRNG_FIFO_2: usize = 0x88;
+const _EXYNOS_TRNG_FIFO_3: usize = 0x8c;
+const _EXYNOS_TRNG_FIFO_4: usize = 0x90;
+const _EXYNOS_TRNG_FIFO_5: usize = 0x94;
+const _EXYNOS_TRNG_FIFO_6: usize = 0x98;
+const _EXYNOS_TRNG_FIFO_7: usize = 0x9c;
+const EXYNOS_TRNG_FIFO_LEN: u32 = 8;
+const EXYNOS_TRNG_CLOCK_RATE: u32 = 500000;
+
+struct ExynosTrngDevice {
+    clk: Clk,
+    mem: IoMem<EXYNOS_REG_SIZE>,
+}
+
+impl HwrngOperations for ExynosTrngDevice {
+    declare_hwrng_operations!(init);
+
+    type Data = Box<ExynosTrngDevice>;
+
+    fn init(trng: &Self) -> Result {
+        let sss_rate = trng.clk.get_rate();
+
+        // For most TRNG circuits the clock frequency of under 500 kHz
+        // is safe.
+        let mut val = sss_rate / (EXYNOS_TRNG_CLOCK_RATE * 2);
+        if val > 0x7fff {
+            // dev_err(trng->dev, "clock divider too large: %d", val);
+            pr_info!("rust_hwrng_init(): clock divider too large: {}\n", val);
+            return Err(Error::ERANGE);
+        }
+
+        val <<= 1;
+        trng.mem.writel_relaxed(val, EXYNOS_TRNG_CLKDIV);
+
+        // Enable the generator.
+        val = EXYNOS_TRNG_CTRL_RNGEN;
+        trng.mem.writel_relaxed(val, EXYNOS_TRNG_CTRL);
+
+        // Disable post-processing. /dev/hwrng is supposed to deliver
+        // unprocessed data.
+        trng.mem.writel_relaxed(0, EXYNOS_TRNG_POST_CTRL);
+
+        Ok(())
+    }
+
+    fn read(trng: &Self, data: &mut [i8], _wait: bool) -> Result<i32> {
+        let max: u32 = min(data.len().try_into()?, EXYNOS_TRNG_FIFO_LEN * 4);
+
+        trng.mem.writel_relaxed(max * 8, EXYNOS_TRNG_FIFO_CTRL);
+
+        let _ =
+            trng.mem
+                .readl_poll_timeout(EXYNOS_TRNG_FIFO_CTRL, |val| *val == 0, 200, 1000000)?;
+
+        io_mem::try_memcpy_fromio(&trng.mem, data, EXYNOS_TRNG_FIFO_0, max.try_into()?)?;
+
+        Ok(max as i32)
+    }
+}
+
+struct ExynosTrngDriver;
+
+impl PlatformDriver for ExynosTrngDriver {
+    type DrvData = Pin<Box<hw_random::Registration<ExynosTrngDevice>>>;
+
+    fn probe(pdev: &mut PlatformDevice) -> Result<Self::DrvData> {
+        let mut clk = clk::devm_clk_get(pdev, c_str!("secss"))?;
+        clk.prepare_enable()?;
+
+        let mem = IoMem::<EXYNOS_REG_SIZE>::try_platform_ioremap_resource(pdev, 0)?;
+
+        let exynos_trng = Box::try_new(ExynosTrngDevice { clk, mem })?;
+
+        let drv_data = hw_random::Registration::new_pinned(pdev.name(), 0, exynos_trng)?;
+
+        Ok(drv_data)
+    }
+
+    fn remove(_pdev: &mut PlatformDevice, _drv_data: Self::DrvData) -> Result {
+        Ok(())
+    }
+}
+
+struct ExynosTrngDriverModule {
+    _pdev: Pin<Box<platdev::Registration>>,
+}
+
+impl KernelModule for ExynosTrngDriverModule {
+    fn init(name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
+        const OF_MATCH_TBL: ConstOfMatchTable<1> =
+            ConstOfMatchTable::new_const([c_str!("samsung,exynos5250-trng")]);
+
+        let pdev = platdev::Registration::new_pinned::<ExynosTrngDriver>(
+            name,
+            Some(&OF_MATCH_TBL),
+            module,
+        )?;
+
+        Ok(ExynosTrngDriverModule { _pdev: pdev })
+    }
+}

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -2,6 +2,7 @@
 
 #include <linux/bug.h>
 #include <linux/build_bug.h>
+#include <linux/clk.h>
 #include <linux/uaccess.h>
 #include <linux/sched/signal.h>
 #include <linux/gfp.h>
@@ -21,6 +22,12 @@ __noreturn void rust_helper_BUG(void)
 {
 	BUG();
 }
+
+int rust_helper_clk_prepare_enable(struct clk *clk)
+{
+	return clk_prepare_enable(clk);
+}
+EXPORT_SYMBOL_GPL(rust_helper_clk_prepare_enable);
 
 unsigned long rust_helper_copy_from_user(void *to, const void __user *from, unsigned long n)
 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -176,6 +176,12 @@ void rust_helper_writeq_relaxed(u64 value, volatile void __iomem *addr)
 }
 EXPORT_SYMBOL_GPL(rust_helper_writeq_relaxed);
 #endif
+
+void rust_helper_memcpy_fromio(void *to, const volatile void __iomem *from, long count)
+{
+	memcpy_fromio(to, from, count);
+}
+
 void rust_helper___spin_lock_init(spinlock_t *lock, const char *name,
 				  struct lock_class_key *key)
 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -3,6 +3,9 @@
 #include <linux/bug.h>
 #include <linux/build_bug.h>
 #include <linux/clk.h>
+#include <linux/delay.h>
+#include <linux/ktime.h>
+#include <linux/kernel.h>
 #include <linux/uaccess.h>
 #include <linux/sched/signal.h>
 #include <linux/gfp.h>
@@ -21,6 +24,26 @@
 __noreturn void rust_helper_BUG(void)
 {
 	BUG();
+}
+
+void rust_helper_usleep_range(unsigned long min, unsigned long max)
+{
+	usleep_range(min, max);
+}
+
+void rust_helper_might_sleep(void)
+{
+	might_sleep();
+}
+
+int rust_helper_ktime_compare(const ktime_t cmp1, const ktime_t cmp2)
+{
+	return ktime_compare(cmp1, cmp2);
+}
+
+ktime_t rust_helper_ktime_add_us(const ktime_t kt, const u64 usec)
+{
+	return ktime_add_us(kt, usec);
 }
 
 int rust_helper_clk_prepare_enable(struct clk *clk)

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -102,6 +102,57 @@ void rust_helper_writeq(u64 value, volatile void __iomem *addr)
 EXPORT_SYMBOL_GPL(rust_helper_writeq);
 #endif
 
+u8 rust_helper_readb_relaxed(const volatile void __iomem *addr)
+{
+	return readb_relaxed(addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_readb_relaxed);
+
+u16 rust_helper_readw_relaxed(const volatile void __iomem *addr)
+{
+	return readw_relaxed(addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_readw_relaxed);
+
+u32 rust_helper_readl_relaxed(const volatile void __iomem *addr)
+{
+	return readl_relaxed(addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_readl_relaxed);
+
+#ifdef CONFIG_64BIT
+u64 rust_helper_readq_relaxed(const volatile void __iomem *addr)
+{
+	return readq_relaxed(addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_readq_relaxed);
+#endif
+
+void rust_helper_writeb_relaxed(u8 value, volatile void __iomem *addr)
+{
+        writeb_relaxed(value, addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_writeb_relaxed);
+
+void rust_helper_writew_relaxed(u16 value, volatile void __iomem *addr)
+{
+        writew_relaxed(value, addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_writew_relaxed);
+
+void rust_helper_writel_relaxed(u32 value, volatile void __iomem *addr)
+{
+        writel_relaxed(value, addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_writel_relaxed);
+
+#ifdef CONFIG_64BIT
+void rust_helper_writeq_relaxed(u64 value, volatile void __iomem *addr)
+{
+        writeq_relaxed(value, addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_writeq_relaxed);
+#endif
 void rust_helper___spin_lock_init(spinlock_t *lock, const char *name,
 				  struct lock_class_key *key)
 {

--- a/rust/kernel/bindings_helper.h
+++ b/rust/kernel/bindings_helper.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 
 #include <linux/cdev.h>
+#include <linux/clk.h>
 #include <linux/errname.h>
 #include <linux/fs.h>
 #include <linux/hw_random.h>

--- a/rust/kernel/bindings_helper.h
+++ b/rust/kernel/bindings_helper.h
@@ -3,6 +3,7 @@
 #include <linux/cdev.h>
 #include <linux/errname.h>
 #include <linux/fs.h>
+#include <linux/hw_random.h>
 #include <linux/module.h>
 #include <linux/random.h>
 #include <linux/slab.h>

--- a/rust/kernel/clk.rs
+++ b/rust/kernel/clk.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Clock subsystem
+//!
+//! C header: [`include/linux/clk.h`](../../../../include/linux/clk.h)
+
+use crate::{
+    bindings, device,
+    error::{from_kernel_err_ptr, Error, Result},
+    str::CStr,
+};
+
+/// Represents `struct clk *`
+///
+/// # Invariants
+///
+/// The pointer is valid.
+pub struct Clk(*mut bindings::clk);
+
+impl Clk {
+    /// Returns value of rate field of `struct clk`.
+    pub fn get_rate(&self) -> u32 {
+        // SAFETY: the pointer is valid by the type invariant.
+        unsafe { bindings::clk_get_rate((*self).0) }
+    }
+
+    /// Do not use in atomic context.
+    pub fn prepare_enable(&mut self) -> Result {
+        // SAFETY: the pointer is valid by the type invariant.
+        let ret = unsafe { bindings::clk_prepare_enable((*self).0) };
+        if ret < 0 {
+            return Err(Error::from_kernel_errno(ret));
+        }
+
+        Ok(())
+    }
+}
+
+/// Lookup and obtain a managed reference to a clock producer.
+///
+/// * `dev` - device for clock "consumer".
+/// * `id` - clock consumer ID.
+pub fn devm_clk_get(dev: &impl device::RawDevice, id: &'static CStr) -> Result<Clk> {
+    // SAFETY:
+    //   - dev is valid by the safety contract.
+    //   - id is valid by the type invariant.
+    let clk_ptr =
+        unsafe { from_kernel_err_ptr(bindings::devm_clk_get(dev.raw_device(), id.as_char_ptr())) }?;
+
+    Ok(Clk(clk_ptr))
+}

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -488,17 +488,12 @@ pub(crate) use from_kernel_result;
 /// # use kernel::from_kernel_err_ptr;
 /// # use kernel::c_types;
 /// # use kernel::bindings;
-/// fn devm_platform_ioremap_resource(
+/// pub fn devm_platform_ioremap_resource(
 ///     pdev: &mut PlatformDevice,
 ///     index: u32,
 /// ) -> Result<*mut c_types::c_void> {
-///     // SAFETY: FFI call.
-///     unsafe {
-///         from_kernel_err_ptr(bindings::devm_platform_ioremap_resource(
-///             pdev.to_ptr(),
-///             index,
-///         ))
-///     }
+///     // SAFETY: `pdev` is valid by the type invariant.
+///     unsafe { from_kernel_err_ptr(bindings::devm_platform_ioremap_resource(pdev.0, index)) }
 /// }
 /// ```
 // TODO: remove `dead_code` marker once an in-kernel client is available.

--- a/rust/kernel/hw_random.rs
+++ b/rust/kernel/hw_random.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Hardware Random Number Generator
+//!
+//! C header: [`include/linux/hw_random.h`](../../../../include/linux/hw_random.h)
+
+use alloc::{boxed::Box, slice::from_raw_parts_mut};
+
+use crate::{
+    bindings, c_types, from_kernel_result, str::CStr, types::PointerWrapper, Error, Result,
+};
+
+use core::{cell::UnsafeCell, marker::PhantomData, ops::Deref, pin::Pin};
+
+/// This trait is implemented in order to provide callbacks to `struct hwrng`.
+pub trait HwrngOperations: Sized + 'static {
+    /// The methods to use to populate [`struct hwrng`].
+    const TO_USE: ToUse;
+
+    /// The pointer type that will be used to hold user-defined data type.
+    type Data: PointerWrapper = Box<Self>;
+
+    /// Initialization callback, can be left undefined.
+    fn init(_data: <Self::Data as PointerWrapper>::Borrowed<'_>) -> Result {
+        Err(Error::EINVAL)
+    }
+
+    /// Cleanup callback, can be left undefined.
+    fn cleanup(_data: <Self::Data as PointerWrapper>::Borrowed<'_>) {}
+
+    /// Read data into the provided buffer.
+    /// Drivers can fill up to max bytes of data into the buffer.
+    /// The buffer is aligned for any type and max is a multiple of 4 and >= 32 bytes.
+    fn read(
+        data: <Self::Data as PointerWrapper>::Borrowed<'_>,
+        buffer: &mut [i8],
+        wait: bool,
+    ) -> Result<i32>;
+}
+
+/// Registration structure for Hardware Random Number Generator driver.
+pub struct Registration<T: HwrngOperations> {
+    hwrng: UnsafeCell<bindings::hwrng>,
+    _p: PhantomData<T>,
+}
+
+impl<'a, T: HwrngOperations> Registration<T> {
+    fn init_hwrng(
+        hwrng: &mut bindings::hwrng,
+        name: &'a CStr,
+        quality: u16,
+        data: *const core::ffi::c_void,
+    ) {
+        hwrng.name = name.as_char_ptr();
+
+        hwrng.init = if T::TO_USE.init {
+            Some(init_callback::<T>)
+        } else {
+            None
+        };
+        hwrng.cleanup = if T::TO_USE.cleanup {
+            Some(cleanup_callback::<T>)
+        } else {
+            None
+        };
+        hwrng.data_present = None;
+        hwrng.data_read = None;
+        hwrng.read = Some(read_callback::<T>);
+
+        hwrng.priv_ = data as _;
+        hwrng.quality = quality;
+
+        // SAFETY: All fields are properly initialized as
+        // remaining fields `list`, `ref` and `cleanup_done` are already
+        // zeroed by `bindings::hwrng::default()` call.
+    }
+
+    /// Registers a hwrng device within the rest of the kernel.
+    ///
+    /// It must be pinned because the memory block that represents the registration.
+    fn register(&self) -> Result {
+        // SAFETY: register function requires initialized `bindings::hwrng`
+        // It is called in `Registration<T>::new_pinned` after initialization of the structure
+        // that quarantees safety.
+        let ret = unsafe { bindings::hwrng_register(&mut *self.hwrng.get()) };
+
+        if ret < 0 {
+            return Err(Error::from_kernel_errno(ret));
+        }
+        Ok(())
+    }
+
+    /// Returns a registered and pinned, heap-allocated representation of the registration.
+    pub fn new_pinned(name: &'a CStr, quality: u16, data: T::Data) -> Result<Pin<Box<Self>>> {
+        let data_pointer = <T::Data as PointerWrapper>::into_pointer(data);
+
+        let registeration = Self {
+            hwrng: UnsafeCell::new(bindings::hwrng::default()),
+            _p: PhantomData::default(),
+        };
+
+        // SAFETY: registeration contains allocated and set to zero `bindings::hwrng` structure.
+        Self::init_hwrng(
+            unsafe { &mut *registeration.hwrng.get() },
+            name,
+            quality,
+            data_pointer,
+        );
+
+        let pinned = Pin::from(Box::try_new(registeration)?);
+
+        pinned.as_ref().register()?;
+
+        Ok(pinned)
+    }
+}
+
+/// Represents which callbacks of [`struct hwrng`] should be populated with pointers.
+pub struct ToUse {
+    /// The `init` field of [`struct hwrng`].
+    pub init: bool,
+
+    /// The `cleanup` field of [`struct hwrng`].
+    pub cleanup: bool,
+}
+
+/// A constant version where all values are to set to `false`, that is, all supported fields will
+/// be set to null pointers.
+pub const USE_NONE: ToUse = ToUse {
+    init: false,
+    cleanup: false,
+};
+
+/// Defines the [`HwrngOperations::TO_USE`] field based on a list of fields to be populated.
+#[macro_export]
+macro_rules! declare_hwrng_operations {
+    () => {
+        const TO_USE: $crate::hw_random::ToUse = $crate::hw_random::USE_NONE;
+    };
+    ($($i:ident),+) => {
+        const TO_USE: kernel::hw_random::ToUse =
+            $crate::hw_random::ToUse {
+                $($i: true),+ ,
+                ..$crate::hw_random::USE_NONE
+            };
+    };
+}
+
+unsafe extern "C" fn init_callback<T: HwrngOperations>(
+    rng: *mut bindings::hwrng,
+) -> c_types::c_int {
+    from_kernel_result! {
+        // SAFETY: `priv` private data field was initialized during creation of
+        // the `bindings::hwrng` in `Self::init_hwrng` function. This callback
+        // is only called once `new_pinned` suceeded previously which guarantees safety.
+        let data = unsafe { T::Data::borrow((*rng).priv_ as *const core::ffi::c_void) };
+        T::init(data)?;
+        Ok(0)
+    }
+}
+
+unsafe extern "C" fn cleanup_callback<T: HwrngOperations>(rng: *mut bindings::hwrng) {
+    // SAFETY: `priv` private data field was initialized during creation of
+    // the `bindings::hwrng` in `Self::init_hwrng` function. This callback
+    // is only called once `new_pinned` suceeded previously which guarantees safety.
+    let data = unsafe { T::Data::borrow((*rng).priv_ as *const core::ffi::c_void) };
+    T::cleanup(data);
+}
+
+unsafe extern "C" fn read_callback<T: HwrngOperations>(
+    rng: *mut bindings::hwrng,
+    data: *mut c_types::c_void,
+    max: usize,
+    wait: bindings::bool_,
+) -> c_types::c_int {
+    from_kernel_result! {
+        // SAFETY: `priv` private data field was initialized during creation of
+        // the `bindings::hwrng` in `Self::init_hwrng` function. This callback
+        // is only called once `new_pinned` suceeded previously which guarantees safety.
+        let drv_data = unsafe { T::Data::borrow((*rng).priv_ as *const core::ffi::c_void) };
+
+        // SAFETY: Slice is created from `data` and `max` arguments that are C api buffer
+        // and its size in bytes which are safe for this conversion.
+        let buffer = unsafe { from_raw_parts_mut(data as *mut c_types::c_char, max) };
+        let ret = T::read(drv_data, buffer, wait)?;
+        Ok(ret)
+    }
+}
+
+// SAFETY: `Registration` does not expose any of its state across threads
+unsafe impl<T: HwrngOperations> Sync for Registration<T> {}
+
+impl<T: HwrngOperations> Drop for Registration<T> {
+    /// Removes the registration from the kernel if it has completed successfully before.
+    fn drop(&mut self) {
+        // SAFETY: The instance of Registration<T> is returned from `new_pinned`
+        // function after being initialized and registered.
+        unsafe { bindings::hwrng_unregister(&mut *self.hwrng.get()) };
+    }
+}

--- a/rust/kernel/hw_random.rs
+++ b/rust/kernel/hw_random.rs
@@ -7,10 +7,10 @@
 use alloc::{boxed::Box, slice::from_raw_parts_mut};
 
 use crate::{
-    bindings, c_types, from_kernel_result, str::CStr, types::PointerWrapper, Error, Result,
+    bindings, c_types, error::from_kernel_result, str::CStr, types::PointerWrapper, Error, Result,
 };
 
-use core::{cell::UnsafeCell, marker::PhantomData, ops::Deref, pin::Pin};
+use core::{cell::UnsafeCell, marker::PhantomData, pin::Pin};
 
 /// This trait is implemented in order to provide callbacks to `struct hwrng`.
 pub trait HwrngOperations: Sized + 'static {

--- a/rust/kernel/io_mem.rs
+++ b/rust/kernel/io_mem.rs
@@ -187,6 +187,16 @@ impl<const SIZE: usize> IoMem<SIZE> {
         u64
     );
 
+    define_read!(readb_relaxed, try_readb_relaxed, u8);
+    define_read!(readw_relaxed, try_readw_relaxed, u16);
+    define_read!(readl_relaxed, try_readl_relaxed, u32);
+    define_read!(
+        #[cfg(CONFIG_64BIT)]
+        readq_relaxed,
+        try_readq_relaxed,
+        u64
+    );
+
     define_write!(writeb, try_writeb, u8);
     define_write!(writew, try_writew, u16);
     define_write!(writel, try_writel, u32);
@@ -194,6 +204,16 @@ impl<const SIZE: usize> IoMem<SIZE> {
         #[cfg(CONFIG_64BIT)]
         writeq,
         try_writeq,
+        u64
+    );
+
+    define_write!(writeb_relaxed, try_writeb_relaxed, u8);
+    define_write!(writew_relaxed, try_writew_relaxed, u16);
+    define_write!(writel_relaxed, try_writel_relaxed, u32);
+    define_write!(
+        #[cfg(CONFIG_64BIT)]
+        writeq_relaxed,
+        try_writeq_relaxed,
         u64
     );
 }

--- a/rust/kernel/io_mem.rs
+++ b/rust/kernel/io_mem.rs
@@ -6,7 +6,11 @@
 
 #![allow(dead_code)]
 
-use crate::{bindings, Error, Result};
+use crate::{
+    bindings
+    platdev::{self, PlatformDevice},
+    Error, Result,
+};
 use core::convert::TryInto;
 
 /// Represents a memory resource.
@@ -162,6 +166,14 @@ impl<const SIZE: usize> IoMem<SIZE> {
             // also 8-byte aligned because we checked it above.
             Ok(Self { ptr: addr as usize })
         }
+    }
+
+    // TODO: Handle Drop properly
+    pub fn try_platform_ioremap_resource(pdev: &mut PlatformDevice, index: u32) -> Result<Self> {
+        let raw_ptr = platdev::devm_platform_ioremap_resource(pdev, index)?;
+        Ok(Self {
+            ptr: raw_ptr as usize,
+        })
     }
 
     const fn offset_ok<T>(offset: usize) -> bool {

--- a/rust/kernel/iopoll.rs
+++ b/rust/kernel/iopoll.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Helper routines for polling IO addresses.
+//!
+//! C header: [`include/linux/iopoll.h`](../../../../include/linux/iopoll.h)
+
+use core::mem::MaybeUninit;
+
+use crate::{
+    bindings, c_types,
+    error::{Error, Result},
+    might_sleep_if,
+};
+
+/// Periodically poll an address until a condition is met or a timeout occurs.
+///
+/// # Safety
+///
+/// `addr` must be non-null pointer valid io address.
+pub unsafe fn read_poll_timeout<T, F: Fn(&T) -> bool>(
+    op: unsafe extern "C" fn(*const c_types::c_void) -> T,
+    cond: F,
+    sleep_us: u32,
+    timeout_us: u64,
+    sleep_before_read: bool,
+    addr: *const c_types::c_void,
+) -> Result<T> {
+    // SAFETY: FFI call.
+    let timeout = unsafe { bindings::ktime_add_us(bindings::ktime_get(), timeout_us) };
+    might_sleep_if!(sleep_us != 0);
+
+    if sleep_before_read && sleep_us != 0 {
+        // SAFETY: FFI call.
+        unsafe { bindings::usleep_range((sleep_us >> 2) + 1, sleep_us) };
+    }
+
+    let mut val = MaybeUninit::<T>::uninit();
+
+    loop {
+        unsafe { val.as_mut_ptr().write(op(addr)) };
+        if cond(unsafe { &*val.as_mut_ptr() }) {
+            break;
+        }
+
+        // SAFETY: FFI call.
+        if timeout_us != 0 && unsafe { bindings::ktime_compare(bindings::ktime_get(), timeout) } > 0
+        {
+            unsafe { val.as_mut_ptr().write(op(addr)) };
+            break;
+        }
+
+        if sleep_us != 0 {
+            // SAFETY: FFI call.
+            unsafe { bindings::usleep_range((sleep_us >> 2) + 1, sleep_us) };
+        }
+    }
+
+    if cond(unsafe { &*val.as_mut_ptr() }) {
+        // SAFETY: variable is properly initialized as there is at least one write to it at loop.
+        Ok(unsafe { val.assume_init() })
+    } else {
+        Err(Error::ETIMEDOUT)
+    }
+}
+
+/// # Safety
+///
+/// `addr` must be non-null pointer valid io address.
+pub unsafe fn readx_poll_timeout<T, F: Fn(&T) -> bool>(
+    op: unsafe extern "C" fn(*const c_types::c_void) -> T,
+    cond: F,
+    sleep_us: u32,
+    timeout_us: u64,
+    addr: *const c_types::c_void,
+) -> Result<T> {
+    // SAFETY: `addr` is valid by the safety contract.
+    unsafe { read_poll_timeout(op, cond, sleep_us, timeout_us, false, addr) }
+}

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -55,6 +55,7 @@ pub mod file;
 pub mod file_operations;
 pub mod gpio;
 pub mod hw_random;
+pub mod iopoll;
 pub mod irq;
 pub mod miscdev;
 pub mod pages;
@@ -175,6 +176,17 @@ impl<'a> Drop for KParamGuard<'a> {
         // guarantees that the lock is held.
         unsafe { bindings::kernel_param_unlock(self.this_module.0) }
     }
+}
+
+#[macro_export]
+macro_rules! might_sleep_if {
+    ($cond:expr) => {
+        if $cond {
+            unsafe {
+                bindings::might_sleep();
+            }
+        }
+    };
 }
 
 /// Calculates the offset of a field from the beginning of the struct it belongs to.

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -47,6 +47,7 @@ pub mod amba;
 pub mod buffer;
 pub mod c_types;
 pub mod chrdev;
+pub mod clk;
 pub mod device;
 pub mod driver;
 mod error;

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -53,6 +53,7 @@ mod error;
 pub mod file;
 pub mod file_operations;
 pub mod gpio;
+pub mod hw_random;
 pub mod irq;
 pub mod miscdev;
 pub mod pages;

--- a/rust/kernel/platdev.rs
+++ b/rust/kernel/platdev.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     bindings, c_types, device,
-    error::{from_kernel_result, Error, Result},
+    error::{from_kernel_err_ptr, from_kernel_result, Error, Result},
     of::OfMatchTable,
     str::CStr,
     types::PointerWrapper,
@@ -30,6 +30,15 @@ unsafe impl device::RawDevice for PlatformDevice {
         // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
         unsafe { &mut (*self.0).dev }
     }
+}
+
+/// Ioremaps resources of a platform device.
+pub fn devm_platform_ioremap_resource(
+    pdev: &mut PlatformDevice,
+    index: u32,
+) -> Result<*mut c_types::c_void> {
+    // SAFETY: `pdev` is valid by the type invariant.
+    unsafe { from_kernel_err_ptr(bindings::devm_platform_ioremap_resource(pdev.0, index)) }
 }
 
 /// A registration of a platform device.


### PR DESCRIPTION
Hello,

As a part of the introduction of our kernel team to the RustForLinux project, <br> I created a driver that is a port of [Samsung Exynos true random number generator](https://github.com/torvalds/linux/blob/master/drivers/char/hw_random/exynos-trng.c) that now I would like to present.

This is mainly a request for an initial code review. There are some patches that are not yet prepared and require some design decisions. The power management of the driver is for now skipped as it was not needed to get the driver working.

The driver is tested on the ODROID-XU3 board (Exynos 5422).

---

- [ ] rust: drivers: char: hw_random: add Exynos HWRNG driver
- [ ] https://github.com/Rust-for-Linux/linux/pull/701
- [ ] [rust: ktime: add ktime_get, ktime_add_us, ktime_compare bindings](https://github.com/Rust-for-Linux/linux/pull/701)
- [ ] [rust: delay: add usleep_range function](https://github.com/Rust-for-Linux/linux/pull/701)
- [ ] https://github.com/Rust-for-Linux/linux/pull/700
- [ ] https://github.com/Rust-for-Linux/linux/pull/682
- [x] https://github.com/Rust-for-Linux/linux/pull/681
- [x] https://github.com/Rust-for-Linux/linux/pull/621
- [x] https://github.com/Rust-for-Linux/linux/pull/593
- [x] https://github.com/Rust-for-Linux/linux/pull/592