### PR TITLE
Use generic associated types (GATs) to implement `PointerWrapper`.

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -5,7 +5,13 @@
 //! TODO: This module is a work in progress.
 
 #![no_std]
-#![feature(global_asm, try_reserve, allocator_api, concat_idents)]
+#![feature(
+    global_asm,
+    try_reserve,
+    allocator_api,
+    concat_idents,
+    generic_associated_types
+)]
 
 use kernel::{
     io_buffer::IoBufferWriter,

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -395,9 +395,13 @@ impl Thread {
                     let ptr = unsafe { obj.__bindgen_anon_1.binder } as _;
                     let cookie = obj.cookie as _;
                     let flags = obj.flags as _;
-                    let node = self
-                        .process
-                        .get_node(ptr, cookie, flags, strong, Some(self))?;
+                    let node = self.process.as_ref_borrow().get_node(
+                        ptr,
+                        cookie,
+                        flags,
+                        strong,
+                        Some(self),
+                    )?;
                     security::binder_transfer_binder(&self.process.task, &view.alloc.process.task)?;
                     Ok(node)
                 })?;

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -21,6 +21,7 @@
     const_panic,
     const_unreachable_unchecked,
     doc_cfg,
+    generic_associated_types,
     ptr_metadata,
     receiver_trait,
     coerce_unsized,

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -11,7 +11,7 @@ use kernel::{
     file_operations::{FileOpener, FileOperations},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
-    sync::{CondVar, Mutex, Ref, UniqueRef},
+    sync::{CondVar, Mutex, Ref, RefBorrow, UniqueRef},
 };
 
 module! {
@@ -68,7 +68,7 @@ impl FileOperations for Token {
     kernel::declare_file_operations!(read, write);
 
     fn read(
-        shared: &Ref<SharedState>,
+        shared: RefBorrow<'_, SharedState>,
         _: &File,
         data: &mut impl IoBufferWriter,
         offset: u64,
@@ -101,7 +101,7 @@ impl FileOperations for Token {
     }
 
     fn write(
-        shared: &Ref<SharedState>,
+        shared: RefBorrow<'_, SharedState>,
         _: &File,
         data: &mut impl IoBufferReader,
         _offset: u64,

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -14,7 +14,7 @@
 //! unblocking up to 3 blocked readers.
 
 #![no_std]
-#![feature(allocator_api, global_asm)]
+#![feature(allocator_api, global_asm, generic_associated_types)]
 
 use core::sync::atomic::{AtomicU64, Ordering};
 use kernel::{
@@ -150,7 +150,7 @@ const IOCTL_GET_READ_COUNT: u32 = 0x80086301;
 const IOCTL_SET_READ_COUNT: u32 = 0x40086301;
 
 impl IoctlHandler for FileState {
-    type Target = Self;
+    type Target<'a> = &'a Self;
 
     fn read(this: &Self, _: &File, cmd: u32, writer: &mut UserSlicePtrWriter) -> Result<i32> {
         match cmd {

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -326,7 +326,7 @@ quiet_cmd_rustc_o_rs = $(RUSTC_OR_CLIPPY_QUIET) $(quiet_modtag) $@
       cmd_rustc_o_rs = \
 	RUST_MODFILE=$(modfile) \
 	$(RUSTC_OR_CLIPPY) $(rust_flags) $(rust_cross_flags) \
-		-Zallow-features=allocator_api,bench_black_box,concat_idents,global_asm,try_reserve \
+		-Zallow-features=allocator_api,bench_black_box,concat_idents,global_asm,try_reserve,generic_associated_types \
 		--extern alloc --extern kernel \
 		--crate-type rlib --out-dir $(obj) -L $(objtree)/rust/ \
 		--crate-name $(patsubst %.o,%,$(notdir $@)) $<; \


### PR DESCRIPTION
The feature, although still unstable, is no longer incomplete. It
allows us to use a lifetime in the `Borrow` assocciated type, which
allows us to simplify some of the code around borrowing the wrapped
value and also allows us to wrap raw pointers and integers without
violating `Deref` recommendations.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>