### PR TITLE
rust: add `PointerWrapper` implementation for `*mut T`.

### DIFF
--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -128,6 +128,22 @@ impl<T: PointerWrapper + Deref> PointerWrapper for Pin<T> {
     }
 }
 
+impl<T> PointerWrapper for *mut T {
+    type Borrowed<'a> = *mut T;
+
+    fn into_pointer(self) -> *const c_types::c_void {
+        self as _
+    }
+
+    unsafe fn borrow<'a>(ptr: *const c_types::c_void) -> Self::Borrowed<'a> {
+        ptr as _
+    }
+
+    unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        ptr as _
+    }
+}
+
 /// Runs a cleanup function/closure when dropped.
 ///
 /// The [`ScopeGuard::dismiss`] function prevents the cleanup function from running.


### PR DESCRIPTION
The implementation is straightforward: converting to `void *` and
borrowing are just pointer casts.

This is used by the GPIO subsystem where some context data is controlled
by the C side, so it is necessarily a raw pointer. (This is hidden from
driver writers though.)

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>