### PR TITLE
rust: kernel: add missing safety comments

### DIFF
--- a/rust/kernel/pages.rs
+++ b/rust/kernel/pages.rs
@@ -93,6 +93,14 @@ impl<const ORDER: u32> Pages<ORDER> {
         }
 
         let mapping = self.kmap(0).ok_or(Error::EINVAL)?;
+        // SAFETY:
+        // (*mut u8).add(): `dest.add(offset)` is guarenteed to not overflow an
+        // `isize` due to the check above, assuming `PAGE_SIZE` is less than or
+        // equal to `isize::MAX`.
+        // ptr::copy(): The safety contract of this function guarentees that
+        // the `dest` buffer is valid for atleast `len` bytes. The invariant
+        // guarentee of this struct, and the checks guarentees that the
+        // 'mapping.ptr' buffer is valid for atleast `len` bytes.
         unsafe { ptr::copy((mapping.ptr as *mut u8).add(offset), dest, len) };
         Ok(())
     }
@@ -113,6 +121,14 @@ impl<const ORDER: u32> Pages<ORDER> {
         }
 
         let mapping = self.kmap(0).ok_or(Error::EINVAL)?;
+        // SAFETY:
+        // (*mut u8).add(): `dest.add(offset)` is guarenteed to not overflow an
+        // `isize` due to the check above, assuming `PAGE_SIZE` is less than or
+        // equal to `isize::MAX`.
+        // ptr::copy(): The safety contract of this function guarentees that
+        // the `dest` buffer is valid for at least `len` bytes. The invariant
+        // guarentee of this struct, and the checks guarentees that the
+        // 'mapping.ptr' buffer is valid for at least `len` bytes.
         unsafe { ptr::copy(src, (mapping.ptr as *mut u8).add(offset), len) };
         Ok(())
     }

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -12,7 +12,15 @@ use core::fmt;
 use crate::bindings;
 use crate::c_types::{c_char, c_void};
 
-// Called from `vsprintf` with format specifier `%pA`.
+/// Called from `vsprintf` with format specifier `%pA`.
+///
+/// # Safety
+///
+/// The caller must ensure the following guarentees are met.
+///
+/// * `buf` is non-null and is valid until `end`.
+/// * `end` is non-null and is greater than `buf`.
+/// * `ptr` is non-null and points to a valid [`fmt::Arguments`].
 #[no_mangle]
 unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_void) -> *mut c_char {
     use fmt::Write;
@@ -53,6 +61,7 @@ unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_vo
         buf: buf as _,
         end: end as _,
     };
+    // SAFETY: `ptr` is valid by the safety requirements of this function.
     let _ = w.write_fmt(unsafe { *(ptr as *const fmt::Arguments<'_>) });
     w.buf as _
 }

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -132,6 +132,11 @@ impl NeedsLockClass for CondVar {
         key: *mut bindings::lock_class_key,
         _: *mut bindings::lock_class_key,
     ) {
+        // SAFETY:
+        // `wait_list` is a valid uninitialised C `wait_list`.
+        // `name` is a valid NUL-Terminated `CStr`.
+        // `key` The safety requirements of `init` require that it is
+        //  valid and will remain valid for the lifetime for the lock.
         unsafe { bindings::__init_waitqueue_head(self.wait_list.get(), name.as_char_ptr(), key) };
     }
 }

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -82,6 +82,11 @@ impl<T> CreatableLock for Mutex<T> {
         name: &'static CStr,
         key: *mut bindings::lock_class_key,
     ) {
+        // SAFETY:
+        // `mutex` is a valid uninitialised C `mutex`.
+        // `name` is a valid NUL-Terminated `CStr`.
+        // `key` The safety requirements of `init_lock` require that it is
+        //  valid and will remain valid for the lifetime for the lock.
         unsafe { bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key) };
     }
 }

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -141,6 +141,11 @@ impl<T> CreatableLock for SpinLock<T> {
         name: &'static CStr,
         key: *mut bindings::lock_class_key,
     ) {
+        // SAFETY:
+        // `spin_lock` is a valid uninitialised C `spin_lock`.
+        // `name` is a valid `NUL`-Terminated `CStr`.
+        // `key` The safety requirements of `init_lock` require that it is
+        //  valid and will remain valid for the lifetime for the lock.
         unsafe { bindings::__spin_lock_init(self.spin_lock.get(), name.as_char_ptr(), key) };
     }
 }


### PR DESCRIPTION
Contributes to #351

Added `// SAFETY` docs to `fn proc_handler`
`rust/kernel/sysctl.rs:97:1`
`rust/kernel/sysctl.rs:113:5`
`rust/kernel/sysctl.rs:115:9`
`rust/kernel/sysctl.rs:120:5`
`rust/kernel/sysctl.rs:124:5`
`rust/kernel/sysctl.rs:136:5`
`rust/kernel/sysctl.rs:138:5`

Added `// SAFETY` docs to `fn init_lock`
`rust/kernel/sync/mutex.rs:85:9`

Added `// SAFETY` docs to `fn init_lock`
`rust/kernel/sync/spinlock.rs:144:9`

Added `// SAFETY` docs to `fn init`
`rust/kernel/sync/condvar.rs:135:9`

Added `// SAFETY` docs to `fn read`
`rust/kernel/pages.rs:96:9`

Added `// SAFETY` docs to `fn write`
`rust/kernel/pages.rs:125:9`

Added `// SAFETY` docs to `fn rust_fmt_argument`
`rust/kernel/print.rs:17:1`
`rust/kernel/print.rs:62:5`

Added `// SAFETY` docs to `fn set_param`
`rust/kernel/module_param.rs:63:5`
`rust/kernel/module_param.rs:74:13`
`rust/kernel/module_param.rs:80:17`
`rust/kernel/module_param.rs:83:17`

Added `// SAFETY` docs to `fn get_param`
`rust/kernel/module_param.rs:104:9`
`rust/kernel/module_param.rs:108:9`

Added `// SAFETY` docs to `fn free`
`rust/kernel/module_param.rs:124:9`

Signed-off-by: Dee-Jay Logozzo <git@djl.id.au>