### PR TITLE
Enable some lints and simplify `CLIPPY=1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,12 +539,13 @@ KBUILD_RUSTFLAGS := --emit=dep-info,obj,metadata --edition=2021 \
 		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
 		     -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
 		     -Dunreachable_pub -Dnon_ascii_idents \
-		     -Drustdoc::missing_crate_level_docs -Wmissing_docs
-KBUILD_CLIPPYFLAGS := -Dclippy::correctness -Dclippy::style -Dclippy::suspicious \
-		      -Dclippy::complexity -Dclippy::perf -Dclippy::float_arithmetic \
-		      -Dclippy::let_unit_value -Dclippy::mut_mut \
-		      -Dclippy::needless_bitwise_bool -Dclippy::needless_continue \
-		      -Wclippy::dbg_macro
+		     -Wmissing_docs \
+		     -Drustdoc::missing_crate_level_docs \
+		     -Dclippy::correctness -Dclippy::style -Dclippy::suspicious \
+		     -Dclippy::complexity -Dclippy::perf -Dclippy::float_arithmetic \
+		     -Dclippy::let_unit_value -Dclippy::mut_mut \
+		     -Dclippy::needless_bitwise_bool -Dclippy::needless_continue \
+		     -Wclippy::dbg_macro
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
 KBUILD_RUSTFLAGS_KERNEL :=
@@ -557,7 +558,7 @@ CLANG_FLAGS :=
 
 ifeq ($(KBUILD_CLIPPY),1)
 	RUSTC_OR_CLIPPY_QUIET := CLIPPY
-	RUSTC_OR_CLIPPY = $(CLIPPY_DRIVER) $(KBUILD_CLIPPYFLAGS)
+	RUSTC_OR_CLIPPY = $(CLIPPY_DRIVER)
 else
 	RUSTC_OR_CLIPPY_QUIET := RUSTC
 	RUSTC_OR_CLIPPY = $(RUSTC)

--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,7 @@ KBUILD_RUSTFLAGS := --emit=dep-info,obj,metadata --edition=2021 \
 		     -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
 		     -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
-		     -Wmissing_docs
+		     -Dunreachable_pub -Wmissing_docs
 KBUILD_CLIPPYFLAGS := -Dclippy::correctness -Dclippy::style \
 		      -Dclippy::complexity -Dclippy::perf -Dclippy::float_arithmetic
 KBUILD_AFLAGS_KERNEL :=

--- a/Makefile
+++ b/Makefile
@@ -538,10 +538,13 @@ KBUILD_RUSTFLAGS := --emit=dep-info,obj,metadata --edition=2021 \
 		     -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
 		     -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
-		     -Dunreachable_pub -Wmissing_docs
-KBUILD_CLIPPYFLAGS := -Dclippy::correctness -Dclippy::style \
+		     -Dunreachable_pub -Dnon_ascii_idents \
+		     -Drustdoc::missing_crate_level_docs -Wmissing_docs
+KBUILD_CLIPPYFLAGS := -Dclippy::correctness -Dclippy::style -Dclippy::suspicious \
 		      -Dclippy::complexity -Dclippy::perf -Dclippy::float_arithmetic \
-		      -Dclippy::let_unit_value
+		      -Dclippy::let_unit_value -Dclippy::mut_mut \
+		      -Dclippy::needless_bitwise_bool -Dclippy::needless_continue \
+		      -Wclippy::dbg_macro
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
 KBUILD_RUSTFLAGS_KERNEL :=

--- a/Makefile
+++ b/Makefile
@@ -540,7 +540,8 @@ KBUILD_RUSTFLAGS := --emit=dep-info,obj,metadata --edition=2021 \
 		     -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
 		     -Dunreachable_pub -Wmissing_docs
 KBUILD_CLIPPYFLAGS := -Dclippy::correctness -Dclippy::style \
-		      -Dclippy::complexity -Dclippy::perf -Dclippy::float_arithmetic
+		      -Dclippy::complexity -Dclippy::perf -Dclippy::float_arithmetic \
+		      -Dclippy::let_unit_value
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
 KBUILD_RUSTFLAGS_KERNEL :=

--- a/drivers/android/allocation.rs
+++ b/drivers/android/allocation.rs
@@ -156,14 +156,14 @@ impl<'a, 'b> AllocationView<'a, 'b> {
         AllocationView { alloc, limit }
     }
 
-    pub fn read<T>(&self, offset: usize) -> Result<T> {
+    pub(crate) fn read<T>(&self, offset: usize) -> Result<T> {
         if offset.checked_add(size_of::<T>()).ok_or(Error::EINVAL)? > self.limit {
             return Err(Error::EINVAL);
         }
         self.alloc.read(offset)
     }
 
-    pub fn write<T>(&self, offset: usize, obj: &T) -> Result {
+    pub(crate) fn write<T>(&self, offset: usize, obj: &T) -> Result {
         if offset.checked_add(size_of::<T>()).ok_or(Error::EINVAL)? > self.limit {
             return Err(Error::EINVAL);
         }

--- a/drivers/android/defs.rs
+++ b/drivers/android/defs.rs
@@ -9,7 +9,7 @@ use kernel::{
 
 macro_rules! pub_no_prefix {
     ($prefix:ident, $($newname:ident),+) => {
-        $(pub const $newname: u32 = concat_idents!($prefix, $newname);)+
+        $(pub(crate) const $newname: u32 = concat_idents!($prefix, $newname);)+
     };
 }
 

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -395,7 +395,7 @@ impl DeliverToRead for Node {
     }
 }
 
-pub struct NodeRef {
+pub(crate) struct NodeRef {
     pub(crate) node: Ref<Node>,
     strong_count: usize,
     weak_count: usize,

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -303,7 +303,7 @@ quiet_cmd_rustc_library = $(if $(skip_clippy),RUSTC,$(RUSTC_OR_CLIPPY_QUIET)) L 
       cmd_rustc_library = \
 	OBJTREE=$(abspath $(objtree)) \
 	$(if $(skip_clippy),$(RUSTC),$(RUSTC_OR_CLIPPY)) \
-		$(rust_flags) $(rust_cross_flags) $(rustc_target_flags) \
+		$(filter-out $(skip_flags),$(rust_flags) $(rust_cross_flags) $(rustc_target_flags)) \
 		--crate-type rlib --out-dir $(objtree)/rust/ -L $(objtree)/rust/ \
 		--crate-name $(patsubst %.o,%,$(notdir $@)) $<; \
 	mv $(objtree)/rust/$(patsubst %.o,%,$(notdir $@)).d $(depfile); \
@@ -324,6 +324,7 @@ $(objtree)/rust/compiler_builtins.o: $(srctree)/rust/compiler_builtins.rs \
 	$(call if_changed_dep,rustc_library)
 
 $(objtree)/rust/alloc.o: private skip_clippy = 1
+$(objtree)/rust/alloc.o: private skip_flags = -Dunreachable_pub
 $(objtree)/rust/alloc.o: private rustc_target_flags = $(alloc-cfgs)
 $(objtree)/rust/alloc.o: $(srctree)/rust/alloc/lib.rs \
     $(objtree)/rust/compiler_builtins.o FORCE
@@ -346,6 +347,7 @@ $(objtree)/rust/kernel.o: $(srctree)/rust/kernel/lib.rs $(objtree)/rust/alloc.o 
 # Targets that need to expand twice
 .SECONDEXPANSION:
 $(objtree)/rust/core.o: private skip_clippy = 1
+$(objtree)/rust/core.o: private skip_flags = -Dunreachable_pub
 $(objtree)/rust/core.o: private rustc_target_flags = $(core-cfgs)
 $(objtree)/rust/core.o: $$(RUST_LIB_SRC)/core/src/lib.rs FORCE
 	$(call if_changed_dep,rustc_library)

--- a/rust/kernel/allocator.rs
+++ b/rust/kernel/allocator.rs
@@ -8,7 +8,7 @@ use core::ptr;
 use crate::bindings;
 use crate::c_types;
 
-pub struct KernelAllocator;
+struct KernelAllocator;
 
 unsafe impl GlobalAlloc for KernelAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -30,18 +30,20 @@ static ALLOCATOR: KernelAllocator = KernelAllocator;
 // `rustc` only generates these for some crate types. Even then, we would need
 // to extract the object file that has them from the archive. For the moment,
 // let's generate them ourselves instead.
+//
+// Note that `#[no_mangle]` implies exported too, nowadays.
 #[no_mangle]
-pub fn __rust_alloc(size: usize, _align: usize) -> *mut u8 {
+fn __rust_alloc(size: usize, _align: usize) -> *mut u8 {
     unsafe { bindings::krealloc(core::ptr::null(), size, bindings::GFP_KERNEL) as *mut u8 }
 }
 
 #[no_mangle]
-pub fn __rust_dealloc(ptr: *mut u8, _size: usize, _align: usize) {
+fn __rust_dealloc(ptr: *mut u8, _size: usize, _align: usize) {
     unsafe { bindings::kfree(ptr as *const c_types::c_void) };
 }
 
 #[no_mangle]
-pub fn __rust_realloc(ptr: *mut u8, _old_size: usize, _align: usize, new_size: usize) -> *mut u8 {
+fn __rust_realloc(ptr: *mut u8, _old_size: usize, _align: usize, new_size: usize) -> *mut u8 {
     unsafe {
         bindings::krealloc(
             ptr as *const c_types::c_void,
@@ -52,7 +54,7 @@ pub fn __rust_realloc(ptr: *mut u8, _old_size: usize, _align: usize, new_size: u
 }
 
 #[no_mangle]
-pub fn __rust_alloc_zeroed(size: usize, _align: usize) -> *mut u8 {
+fn __rust_alloc_zeroed(size: usize, _align: usize) -> *mut u8 {
     unsafe {
         bindings::krealloc(
             core::ptr::null(),

--- a/rust/kernel/amba.rs
+++ b/rust/kernel/amba.rs
@@ -5,8 +5,8 @@
 //! C header: [`include/linux/amba/bus.h`](../../../../include/linux/amba/bus.h)
 
 use crate::{
-    bindings, c_types, device, driver, from_kernel_result, io_mem::Resource, power, str::CStr,
-    to_result, types::PointerWrapper, Error, Result,
+    bindings, c_types, device, driver, error::from_kernel_result, io_mem::Resource, power,
+    str::CStr, to_result, types::PointerWrapper, Error, Result,
 };
 use core::{marker::PhantomData, ops::Deref};
 

--- a/rust/kernel/bindings.rs
+++ b/rust/kernel/bindings.rs
@@ -14,6 +14,7 @@
     non_upper_case_globals,
     non_snake_case,
     improper_ctypes,
+    unreachable_pub,
     unsafe_op_in_unsafe_fn
 )]
 

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -427,8 +427,7 @@ impl From<AllocError> for Error {
 // # Invariant: `-bindings::MAX_ERRNO` fits in an `i16`.
 crate::static_assert!(bindings::MAX_ERRNO <= -(i16::MIN as i32) as u32);
 
-#[doc(hidden)]
-pub fn from_kernel_result_helper<T>(r: Result<T>) -> T
+pub(crate) fn from_kernel_result_helper<T>(r: Result<T>) -> T
 where
     T: From<i16>,
 {
@@ -465,7 +464,6 @@ where
 ///     }
 /// }
 /// ```
-#[macro_export]
 macro_rules! from_kernel_result {
     ($($tt:tt)*) => {{
         $crate::error::from_kernel_result_helper((|| {
@@ -473,6 +471,8 @@ macro_rules! from_kernel_result {
         })())
     }};
 }
+
+pub(crate) use from_kernel_result;
 
 /// Transform a kernel "error pointer" to a normal pointer.
 ///

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -11,9 +11,8 @@ use alloc::boxed::Box;
 
 use crate::{
     bindings, c_types,
-    error::{Error, Result},
+    error::{from_kernel_result, Error, Result},
     file::{File, FileRef},
-    from_kernel_result,
     io_buffer::{IoBufferReader, IoBufferWriter},
     iov_iter::IovIter,
     sync::CondVar,

--- a/rust/kernel/gpio.rs
+++ b/rust/kernel/gpio.rs
@@ -4,7 +4,9 @@
 //!
 //! C header: [`include/linux/gpio/driver.h`](../../../../include/linux/gpio/driver.h)
 
-use crate::{bindings, c_types, device, from_kernel_result, types::PointerWrapper, Error, Result};
+use crate::{
+    bindings, c_types, device, error::from_kernel_result, types::PointerWrapper, Error, Result,
+};
 use core::{
     cell::UnsafeCell,
     marker::{PhantomData, PhantomPinned},

--- a/rust/kernel/irq.rs
+++ b/rust/kernel/irq.rs
@@ -9,7 +9,7 @@
 
 #![allow(dead_code)]
 
-use crate::{bindings, c_types, from_kernel_result, types::PointerWrapper, Error, Result};
+use crate::{bindings, c_types, error::from_kernel_result, types::PointerWrapper, Error, Result};
 use core::ops::Deref;
 
 type IrqHwNumber = bindings::irq_hw_number_t;

--- a/rust/kernel/platdev.rs
+++ b/rust/kernel/platdev.rs
@@ -8,8 +8,7 @@
 
 use crate::{
     bindings, c_types,
-    error::{Error, Result},
-    from_kernel_result,
+    error::{from_kernel_result, Error, Result},
     of::OfMatchTable,
     str::CStr,
     types::PointerWrapper,

--- a/rust/kernel/power.rs
+++ b/rust/kernel/power.rs
@@ -6,7 +6,7 @@
 
 #![allow(dead_code)]
 
-use crate::{bindings, c_types, from_kernel_result, types::PointerWrapper, Result};
+use crate::{bindings, c_types, error::from_kernel_result, types::PointerWrapper, Result};
 use core::marker::PhantomData;
 
 /// Corresponds to the kernel's `struct dev_pm_ops`.

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -86,17 +86,20 @@ impl<T> CreatableLock for Mutex<T> {
     }
 }
 
+pub struct EmptyGuardContext;
+
 // SAFETY: The underlying kernel `struct mutex` object ensures mutual exclusion.
 unsafe impl<T: ?Sized> Lock for Mutex<T> {
     type Inner = T;
-    type GuardContext = ();
+    type GuardContext = EmptyGuardContext;
 
-    fn lock_noguard(&self) {
+    fn lock_noguard(&self) -> EmptyGuardContext {
         // SAFETY: `mutex` points to valid memory.
         unsafe { bindings::mutex_lock(self.mutex.get()) };
+        EmptyGuardContext
     }
 
-    unsafe fn unlock(&self, _: &mut ()) {
+    unsafe fn unlock(&self, _: &mut EmptyGuardContext) {
         // SAFETY: The safety requirements of the function ensure that the mutex is owned by the
         // caller.
         unsafe { bindings::mutex_unlock(self.mutex.get()) };

--- a/rust/macros/helpers.rs
+++ b/rust/macros/helpers.rs
@@ -2,7 +2,7 @@
 
 use proc_macro::{token_stream, Group, TokenTree};
 
-pub fn try_ident(it: &mut token_stream::IntoIter) -> Option<String> {
+pub(crate) fn try_ident(it: &mut token_stream::IntoIter) -> Option<String> {
     if let Some(TokenTree::Ident(ident)) = it.next() {
         Some(ident.to_string())
     } else {
@@ -10,7 +10,7 @@ pub fn try_ident(it: &mut token_stream::IntoIter) -> Option<String> {
     }
 }
 
-pub fn try_literal(it: &mut token_stream::IntoIter) -> Option<String> {
+pub(crate) fn try_literal(it: &mut token_stream::IntoIter) -> Option<String> {
     if let Some(TokenTree::Literal(literal)) = it.next() {
         Some(literal.to_string())
     } else {
@@ -18,7 +18,7 @@ pub fn try_literal(it: &mut token_stream::IntoIter) -> Option<String> {
     }
 }
 
-pub fn try_byte_string(it: &mut token_stream::IntoIter) -> Option<String> {
+pub(crate) fn try_byte_string(it: &mut token_stream::IntoIter) -> Option<String> {
     try_literal(it).and_then(|byte_string| {
         if byte_string.starts_with("b\"") && byte_string.ends_with('\"') {
             Some(byte_string[2..byte_string.len() - 1].to_string())
@@ -28,11 +28,11 @@ pub fn try_byte_string(it: &mut token_stream::IntoIter) -> Option<String> {
     })
 }
 
-pub fn expect_ident(it: &mut token_stream::IntoIter) -> String {
+pub(crate) fn expect_ident(it: &mut token_stream::IntoIter) -> String {
     try_ident(it).expect("Expected Ident")
 }
 
-pub fn expect_punct(it: &mut token_stream::IntoIter) -> char {
+pub(crate) fn expect_punct(it: &mut token_stream::IntoIter) -> char {
     if let TokenTree::Punct(punct) = it.next().expect("Reached end of token stream for Punct") {
         punct.as_char()
     } else {
@@ -40,11 +40,11 @@ pub fn expect_punct(it: &mut token_stream::IntoIter) -> char {
     }
 }
 
-pub fn expect_literal(it: &mut token_stream::IntoIter) -> String {
+pub(crate) fn expect_literal(it: &mut token_stream::IntoIter) -> String {
     try_literal(it).expect("Expected Literal")
 }
 
-pub fn expect_group(it: &mut token_stream::IntoIter) -> Group {
+pub(crate) fn expect_group(it: &mut token_stream::IntoIter) -> Group {
     if let TokenTree::Group(group) = it.next().expect("Reached end of token stream for Group") {
         group
     } else {
@@ -52,17 +52,17 @@ pub fn expect_group(it: &mut token_stream::IntoIter) -> Group {
     }
 }
 
-pub fn expect_byte_string(it: &mut token_stream::IntoIter) -> String {
+pub(crate) fn expect_byte_string(it: &mut token_stream::IntoIter) -> String {
     try_byte_string(it).expect("Expected byte string")
 }
 
-pub fn expect_end(it: &mut token_stream::IntoIter) {
+pub(crate) fn expect_end(it: &mut token_stream::IntoIter) {
     if it.next().is_some() {
         panic!("Expected end");
     }
 }
 
-pub fn get_literal(it: &mut token_stream::IntoIter, expected_name: &str) -> String {
+pub(crate) fn get_literal(it: &mut token_stream::IntoIter, expected_name: &str) -> String {
     assert_eq!(expect_ident(it), expected_name);
     assert_eq!(expect_punct(it), ':');
     let literal = expect_literal(it);
@@ -70,7 +70,7 @@ pub fn get_literal(it: &mut token_stream::IntoIter, expected_name: &str) -> Stri
     literal
 }
 
-pub fn get_byte_string(it: &mut token_stream::IntoIter, expected_name: &str) -> String {
+pub(crate) fn get_byte_string(it: &mut token_stream::IntoIter, expected_name: &str) -> String {
     assert_eq!(expect_ident(it), expected_name);
     assert_eq!(expect_punct(it), ':');
     let byte_string = expect_byte_string(it);

--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -303,7 +303,7 @@ impl ModuleInfo {
     }
 }
 
-pub fn module(ts: TokenStream) -> TokenStream {
+pub(crate) fn module(ts: TokenStream) -> TokenStream {
     let mut it = ts.into_iter();
 
     let info = ModuleInfo::parse(&mut it);


### PR DESCRIPTION
This simplifies a bit the `Makefile` and enables some extra lints:

    -Dunreachable_pub
    -Dnon_ascii_idents
    
    -Drustdoc::missing_crate_level_docs
    
    -Dclippy::suspicious
    -Dclippy::let_unit_value
    -Dclippy::mut_mut
    -Dclippy::needless_bitwise_bool
    -Dclippy::needless_continue
    -Wclippy::dbg_macro

If some of these end up being too painful, we can always disable them later. But in general they sound like a good idea as long as they are not too annoying (i.e. an `allow` here or there). So far, most code "just worked". The only cases I had to change were:

  - `unreachable_pub` has found a few improvements already, and while its docs say it is pending some fixes on top, it seems good enough.
  - `let_unit_value` requires a small change for the unit guard, but I think it makes the code a bit more clear anyway.

I am also contemplating always using the Clippy driver and let kernel developers get accustomed to it -- i.e. no `CLIPPY=1` anymore. This has the downside that it has a slight but noticeable performance penalty even if everything is `allow` (I guess it is going through the AST on its own, i.e. independently of `rustc`, which I guess could be improved if it was integrated with `rustc` instead). But it is not that big, so if Clippy upstream confirms there is no other downside apart from performance (https://github.com/rust-lang/rust-clippy/issues/8035), then I think it may be the best path forward. In such a case, we could also consider moving some of them to `W=` instead, and possibly enabling others in other groups too.