### PR TITLE
rust: fix PowerPC machine model typo & value

### DIFF
--- a/arch/powerpc/rust/target.json
+++ b/arch/powerpc/rust/target.json
@@ -1,6 +1,6 @@
 {
   "arch": "powerpc64",
-  "code-mode": "kernel",
+  "code-model": "large",
   "cpu": "ppc64le",
   "data-layout": "e-m:e-i64:64-n32:64",
   "env": "gnu",


### PR DESCRIPTION
We were getting a warning on an unknown key in the target spec file
because there was a typo in the key. This warning should be an error,
but it seems `-Dwarnings` does not cover it (reported upstream:
https://github.com/rust-lang/rust/issues/91262).

However, the value was also wrong: PowerPC does not support
the "kernel" machine model.

Given PPC_64 modules use the large model, use that value for the moment
for everything in PowerPC until we have proper target spec file generation
(at which point, we will need to pick the right model in each sitaution
for all architectures, properly).

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>

@mpe