### PR TITLE
rust: add `&File` argument to `open` callback.

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -802,7 +802,7 @@ impl IoctlHandler for Process {
 }
 
 impl FileOpener<Ref<Context>> for Process {
-    fn open(ctx: &Ref<Context>) -> Result<Self::Wrapper> {
+    fn open(ctx: &Ref<Context>, _file: &File) -> Result<Self::Wrapper> {
         Self::new(ctx.clone())
     }
 }

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -6,15 +6,8 @@
 #![feature(allocator_api, global_asm)]
 
 use kernel::{
-    file::File,
-    file_operations::{FileOpener, FileOperations},
-    io_buffer::IoBufferWriter,
-    miscdev,
-    of::ConstOfMatchTable,
-    platdev::PlatformDriver,
-    prelude::*,
-    str::CStr,
-    ThisModule, {c_str, platdev},
+    c_str, file::File, file_operations::FileOperations, io_buffer::IoBufferWriter, miscdev,
+    of::ConstOfMatchTable, platdev, platdev::PlatformDriver, prelude::*,
 };
 
 module! {
@@ -25,13 +18,8 @@ module! {
     license: b"GPL v2",
 }
 
+#[derive(Default)]
 struct RngDevice;
-
-impl FileOpener<()> for RngDevice {
-    fn open(_state: &()) -> Result<Self::Wrapper> {
-        Ok(Box::try_new(RngDevice)?)
-    }
-}
 
 impl FileOperations for RngDevice {
     kernel::declare_file_operations!(read);

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -57,7 +57,7 @@ impl SharedState {
 struct Token;
 
 impl FileOpener<Ref<SharedState>> for Token {
-    fn open(shared: &Ref<SharedState>) -> Result<Self::Wrapper> {
+    fn open(shared: &Ref<SharedState>, _file: &File) -> Result<Self::Wrapper> {
         Ok(shared.clone())
     }
 }

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -66,7 +66,7 @@ impl FileState {
 }
 
 impl FileOpener<Ref<Semaphore>> for FileState {
-    fn open(shared: &Ref<Semaphore>) -> Result<Box<Self>> {
+    fn open(shared: &Ref<Semaphore>, _file: &File) -> Result<Box<Self>> {
         Ok(Box::try_new(Self {
             read_count: AtomicU64::new(0),
             shared: shared.clone(),


### PR DESCRIPTION
This is for cases when drivers need to get information from `File`
during `open`, for example, the credentials. Such a need occurs is
Binder.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>