### PR TITLE
rust: binder: use credentials in binder security callbacks.

### DIFF
--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -48,7 +48,7 @@ impl Context {
         if manager.node.is_some() {
             return Err(Error::EBUSY);
         }
-        security::binder_set_context_mgr(&node_ref.node.owner.task)?;
+        security::binder_set_context_mgr(&node_ref.node.owner.cred)?;
 
         // TODO: Get the actual caller id.
         let caller_uid = bindings::kuid_t::default();

--- a/rust/kernel/security.rs
+++ b/rust/kernel/security.rs
@@ -4,69 +4,33 @@
 //!
 //! C header: [`include/linux/security.h`](../../../../include/linux/security.h).
 
-use crate::{file::File, task::Task, Result};
+use crate::{bindings, cred::Credential, file::File, to_result, Result};
 
 /// Calls the security modules to determine if the given task can become the manager of a binder
 /// context.
-pub fn binder_set_context_mgr(_mgr: &Task) -> Result {
-    // TODO
-    //
-    // // SAFETY: By the `Task` invariants, `mgr.ptr` is valid.
-    // let ret = unsafe { bindings::security_binder_set_context_mgr(mgr.ptr) };
-    // if ret != 0 {
-    //     Err(Error::from_kernel_errno(ret))
-    // } else {
-    //     Ok(())
-    // }
-
-    Ok(())
+pub fn binder_set_context_mgr(mgr: &Credential) -> Result {
+    // SAFETY: By the `Credential` invariants, `mgr.ptr` is valid.
+    to_result(|| unsafe { bindings::security_binder_set_context_mgr(mgr.ptr) })
 }
 
 /// Calls the security modules to determine if binder transactions are allowed from task `from` to
 /// task `to`.
-pub fn binder_transaction(_from: &Task, _to: &Task) -> Result {
-    // TODO
-    //
-    // // SAFETY: By the `Task` invariants, `from.ptr` and `to.ptr` are valid.
-    // let ret = unsafe { bindings::security_binder_transaction(from.ptr, to.ptr) };
-    // if ret != 0 {
-    //     Err(Error::from_kernel_errno(ret))
-    // } else {
-    //     Ok(())
-    // }
-
-    Ok(())
+pub fn binder_transaction(from: &Credential, to: &Credential) -> Result {
+    // SAFETY: By the `Credential` invariants, `from.ptr` and `to.ptr` are valid.
+    to_result(|| unsafe { bindings::security_binder_transaction(from.ptr, to.ptr) })
 }
 
 /// Calls the security modules to determine if task `from` is allowed to send binder objects
 /// (owned by itself or other processes) to task `to` through a binder transaction.
-pub fn binder_transfer_binder(_from: &Task, _to: &Task) -> Result {
-    // TODO
-    //
-    // // SAFETY: By the `Task` invariants, `from.ptr` and `to.ptr` are valid.
-    // let ret = unsafe { bindings::security_binder_transfer_binder(from.ptr, to.ptr) };
-    // if ret != 0 {
-    //     Err(Error::from_kernel_errno(ret))
-    // } else {
-    //     Ok(())
-    // }
-
-    Ok(())
+pub fn binder_transfer_binder(from: &Credential, to: &Credential) -> Result {
+    // SAFETY: By the `Credential` invariants, `from.ptr` and `to.ptr` are valid.
+    to_result(|| unsafe { bindings::security_binder_transfer_binder(from.ptr, to.ptr) })
 }
 
 /// Calls the security modules to determine if task `from` is allowed to send the given file to
 /// task `to` (which would get its own file descriptor) through a binder transaction.
-pub fn binder_transfer_file(_from: &Task, _to: &Task, _file: &File) -> Result {
-    // TODO
-    //
-    // // SAFETY: By the `Task` invariants, `from.ptr` and `to.ptr` are valid. Similarly, by the
-    // // `File` invariants, `file.ptr` is also valid.
-    // let ret = unsafe { bindings::security_binder_transfer_file(from.ptr, to.ptr, file.ptr) };
-    // if ret != 0 {
-    //     Err(Error::from_kernel_errno(ret))
-    // } else {
-    //     Ok(())
-    // }
-
-    Ok(())
+pub fn binder_transfer_file(from: &Credential, to: &Credential, file: &File) -> Result {
+    // SAFETY: By the `Credential` invariants, `from.ptr` and `to.ptr` are valid. Similarly, by the
+    // `File` invariants, `file.ptr` is also valid.
+    to_result(|| unsafe { bindings::security_binder_transfer_file(from.ptr, to.ptr, file.ptr) })
 }


### PR DESCRIPTION
Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>