### PR TITLE
rust: Implement Debug and Display for BStr

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -4,7 +4,7 @@
 
 use kernel::{
     device, file::File, file_operations::FileOperations, io_buffer::IoBufferWriter, miscdev,
-    module_platform_driver, of, platform, prelude::*, sync::Ref,
+    module_platform_driver, of, platform, prelude::*, sync::Ref, str::BStr, b_str,
 };
 
 module_platform_driver! {
@@ -42,7 +42,7 @@ impl platform::Driver for RngDriver {
     type Data = Ref<DeviceData>;
 
     kernel::define_of_id_table! {(), [
-        (of::DeviceId::Compatible(b"brcm,bcm2835-rng"), None),
+        (of::DeviceId::Compatible(b_str!("brcm,bcm2835-rng")), None),
     ]}
 
     fn probe(dev: &mut platform::Device, _id_info: Option<&Self::IdInfo>) -> Result<Self::Data> {

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -384,7 +384,7 @@ impl fmt::Debug for Error {
             None => f.debug_tuple("Error").field(&-self.0).finish(),
             // SAFETY: These strings are ASCII-only.
             Some(name) => f
-                .debug_tuple(unsafe { str::from_utf8_unchecked(name) })
+                .debug_tuple(unsafe { str::from_utf8_unchecked(name.as_bytes()) })
                 .finish(),
         }
     }

--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -22,11 +22,13 @@ pub enum DeviceId {
 ///
 /// ```
 /// # use kernel::define_of_id_table;
+/// # use kernel::b_str;
+/// # use kernel::str::BStr;
 /// use kernel::of;
 ///
 /// define_of_id_table! {u32, [
-///     (of::DeviceId::Compatible(b"test-device1,test-device2"), Some(0xff)),
-///     (of::DeviceId::Compatible(b"test-device3"), None),
+///     (of::DeviceId::Compatible(b_str!("test-device1,test-device2")), Some(0xff)),
+///     (of::DeviceId::Compatible(b_str!("test-device3")), None),
 /// ]};
 /// ```
 #[macro_export]
@@ -53,7 +55,7 @@ unsafe impl const driver::RawDeviceId for DeviceId {
         while i < compatible.len() {
             // If `compatible` does not fit in `id.compatible`, an "index out of bounds" build time
             // error will be triggered.
-            id.compatible[i] = compatible[i] as _;
+            id.compatible[i] = compatible.as_bytes()[i] as _;
             i += 1;
         }
         id.compatible[i] = b'\0' as _;

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -197,6 +197,7 @@ unsafe impl device::RawDevice for Device {
 /// ```ignore
 /// # use kernel::prelude::*;
 /// # use kernel::{platform, define_of_id_table, module_platform_driver};
+/// # use kernel::{str::BStr, b_str};
 /// #
 /// struct MyDriver;
 /// impl platform::Driver for MyDriver {
@@ -205,7 +206,7 @@ unsafe impl device::RawDevice for Device {
 /// #       Ok(())
 /// #   }
 /// #   define_of_id_table! {(), [
-/// #       (of::DeviceId::Compatible(b"brcm,bcm2835-rng"), None),
+/// #       (of::DeviceId::Compatible(b_str!("brcm,bcm2835-rng")), None),
 /// #   ]}
 /// }
 ///

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -10,8 +10,77 @@ use crate::{bindings, c_types, Error};
 
 /// Byte string without UTF-8 validity guarantee.
 ///
-/// `BStr` is simply an alias to `[u8]`, but has a more evident semantical meaning.
-pub type BStr = [u8];
+/// `BStr` is a wrapper over `[u8]`, but has a more evident semantical meaning.
+#[repr(transparent)]
+pub struct BStr([u8]);
+
+impl BStr {
+    /// Returns the length of this string.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the string is empty.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Creates a [`BStr`] from a `[u8]`.
+    #[inline]
+    pub const fn from_bytes(bytes: &[u8]) -> &BStr {
+        // SAFETY: BStr is transparent to [u8]
+        unsafe { &*(bytes as *const [u8] as *const BStr) }
+    }
+
+    /// Convert the string to a byte slice without the trailing 0 byte.
+    #[inline]
+    pub const fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+}
+
+impl fmt::Display for BStr {
+    /// Formats printable ASCII characters, escaping the rest.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
+        for &b in &self.0 {
+            match b {
+                // common escape codes
+                b'\t' => f.write_str("\\t")?,
+                b'\n' => f.write_str("\\n")?,
+                b'\r' => f.write_str("\\r")?,
+                // printable characters
+                0x20..=0x7e => f.write_char(b.into())?,
+                _ => write!(f, "\\x{:02x}", b)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for BStr {
+    /// Formats printable ASCII characters with a double quote on either end, escaping the rest.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
+        f.write_char('"')?;
+        for &b in &self.0 {
+            match b {
+                // common escape codes
+                b'\t' => f.write_str("\\t")?,
+                b'\n' => f.write_str("\\n")?,
+                b'\r' => f.write_str("\\r")?,
+                // string escape characters
+                b'\\' => f.write_str("\\\\")?,
+                b'\"' => f.write_str("\\\"")?,
+                // printable characters
+                0x20..=0x7e => f.write_char(b.into())?,
+                _ => write!(f, "\\x{:02x}", b)?,
+            }
+        }
+        f.write_char('"')
+    }
+}
 
 /// Creates a new [`BStr`] from a string literal.
 ///
@@ -29,7 +98,7 @@ pub type BStr = [u8];
 macro_rules! b_str {
     ($str:literal) => {{
         const S: &'static str = $str;
-        const C: &'static $crate::str::BStr = S.as_bytes();
+        const C: &'static $crate::str::BStr = BStr::from_bytes(S.as_bytes());
         C
     }};
 }
@@ -223,15 +292,7 @@ impl fmt::Display for CStr {
     /// assert_eq!(format!("{}", ascii), "so \"cool\"");
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for &c in self.as_bytes() {
-            if (0x20..0x7f).contains(&c) {
-                // Printable character
-                f.write_char(c as char)?;
-            } else {
-                write!(f, "\\x{:02x}", c)?;
-            }
-        }
-        Ok(())
+        fmt::Display::fmt(self.as_ref(), f)
     }
 }
 
@@ -249,23 +310,14 @@ impl fmt::Debug for CStr {
     /// assert_eq!(format!("{:?}", ascii), "\"so \\\"cool\\\"\"");
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("\"")?;
-        for &c in self.as_bytes() {
-            match c {
-                // Printable characters
-                b'\"' => f.write_str("\\\"")?,
-                0x20..=0x7e => f.write_char(c as char)?,
-                _ => write!(f, "\\x{:02x}", c)?,
-            }
-        }
-        f.write_str("\"")
+        fmt::Debug::fmt(self.as_ref(), f)
     }
 }
 
 impl AsRef<BStr> for CStr {
     #[inline]
     fn as_ref(&self) -> &BStr {
-        self.as_bytes()
+        BStr::from_bytes(self.as_bytes())
     }
 }
 
@@ -274,7 +326,7 @@ impl Deref for CStr {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.as_bytes()
+        BStr::from_bytes(self.as_bytes())
     }
 }
 
@@ -321,7 +373,7 @@ where
 
     #[inline]
     fn index(&self, index: Idx) -> &Self::Output {
-        &self.as_bytes()[index]
+        &self.as_ref()[index]
     }
 }
 
@@ -348,6 +400,21 @@ macro_rules! c_str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::format;
+
+    const ALL_ASCII_CHARS: &'static str =
+        "\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f\
+        \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f \
+        !\"#$%&'()*+,-./0123456789:;<=>?@\
+        ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\x7f\
+        \\x80\\x81\\x82\\x83\\x84\\x85\\x86\\x87\\x88\\x89\\x8a\\x8b\\x8c\\x8d\\x8e\\x8f\
+        \\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\\x98\\x99\\x9a\\x9b\\x9c\\x9d\\x9e\\x9f\
+        \\xa0\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\
+        \\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\
+        \\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\
+        \\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xdf\
+        \\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\
+        \\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff";
 
     #[test]
     fn test_cstr_to_str() {
@@ -371,6 +438,73 @@ mod tests {
         let checked_cstr = CStr::from_bytes_with_nul(good_bytes).unwrap();
         let unchecked_str = unsafe { checked_cstr.as_str_unchecked() };
         assert_eq!(unchecked_str, "🐧");
+    }
+
+    #[test]
+    fn test_cstr_display() {
+        let hello_world = CStr::from_bytes_with_nul(b"hello, world!\0").unwrap();
+        assert_eq!(format!("{}", hello_world), "hello, world!");
+        let escapes = CStr::from_bytes_with_nul(b"_\t_\n_\r_\\_\'_\"_\0").unwrap();
+        assert_eq!(format!("{}", escapes), "_\\t_\\n_\\r_\\_'_\"_");
+        let others = CStr::from_bytes_with_nul(b"\x01\0").unwrap();
+        assert_eq!(format!("{}", others), "\\x01");
+        let non_ascii = CStr::from_bytes_with_nul(b"d\xe9j\xe0 vu\0").unwrap();
+        assert_eq!(format!("{}", non_ascii), "d\\xe9j\\xe0 vu");
+        let good_bytes = CStr::from_bytes_with_nul(b"\xf0\x9f\xa6\x80\0").unwrap();
+        assert_eq!(format!("{}", good_bytes), "\\xf0\\x9f\\xa6\\x80");
+    }
+
+    #[test]
+    fn test_cstr_debug() {
+        let hello_world = CStr::from_bytes_with_nul(b"hello, world!\0").unwrap();
+        assert_eq!(format!("{:?}", hello_world), "\"hello, world!\"");
+        let escapes = CStr::from_bytes_with_nul(b"_\t_\n_\r_\\_\'_\"_\0").unwrap();
+        assert_eq!(format!("{:?}", escapes), "\"_\\t_\\n_\\r_\\\\_'_\\\"_\"");
+        let others = CStr::from_bytes_with_nul(b"\x01\0").unwrap();
+        assert_eq!(format!("{:?}", others), "\"\\x01\"");
+        let non_ascii = CStr::from_bytes_with_nul(b"d\xe9j\xe0 vu\0").unwrap();
+        assert_eq!(format!("{:?}", non_ascii), "\"d\\xe9j\\xe0 vu\"");
+        let good_bytes = CStr::from_bytes_with_nul(b"\xf0\x9f\xa6\x80\0").unwrap();
+        assert_eq!(format!("{:?}", good_bytes), "\"\\xf0\\x9f\\xa6\\x80\"");
+    }
+
+    #[test]
+    fn test_bstr_display() {
+        let hello_world = BStr::from_bytes(b"hello, world!");
+        assert_eq!(format!("{}", hello_world), "hello, world!");
+        let escapes = BStr::from_bytes(b"_\t_\n_\r_\\_\'_\"_");
+        assert_eq!(format!("{}", escapes), "_\\t_\\n_\\r_\\_'_\"_");
+        let others = BStr::from_bytes(b"\x01");
+        assert_eq!(format!("{}", others), "\\x01");
+        let non_ascii = BStr::from_bytes(b"d\xe9j\xe0 vu");
+        assert_eq!(format!("{}", non_ascii), "d\\xe9j\\xe0 vu");
+        let good_bytes = BStr::from_bytes(b"\xf0\x9f\xa6\x80");
+        assert_eq!(format!("{}", good_bytes), "\\xf0\\x9f\\xa6\\x80");
+    }
+
+    #[test]
+    fn test_bstr_debug() {
+        let hello_world = BStr::from_bytes(b"hello, world!");
+        assert_eq!(format!("{:?}", hello_world), "\"hello, world!\"");
+        let escapes = BStr::from_bytes(b"_\t_\n_\r_\\_\'_\"_");
+        assert_eq!(format!("{:?}", escapes), "\"_\\t_\\n_\\r_\\\\_'_\\\"_\"");
+        let others = BStr::from_bytes(b"\x01");
+        assert_eq!(format!("{:?}", others), "\"\\x01\"");
+        let non_ascii = BStr::from_bytes(b"d\xe9j\xe0 vu");
+        assert_eq!(format!("{:?}", non_ascii), "\"d\\xe9j\\xe0 vu\"");
+        let good_bytes = BStr::from_bytes(b"\xf0\x9f\xa6\x80");
+        assert_eq!(format!("{:?}", good_bytes), "\"\\xf0\\x9f\\xa6\\x80\"");
+    }
+
+    #[test]
+    fn test_cstr_display_all_bytes() {
+        let mut bytes: [u8; 256] = [0; 256];
+        // fill `bytes` with [1..=255] + [0]
+        for i in u8::MIN..=u8::MAX {
+            bytes[i as usize] = i.wrapping_add(1);
+        }
+        let cstr = CStr::from_bytes_with_nul(&bytes).unwrap();
+        assert_eq!(format!("{}", cstr), ALL_ASCII_CHARS);
     }
 }
 

--- a/rust/kernel/sysctl.rs
+++ b/rust/kernel/sysctl.rs
@@ -136,7 +136,7 @@ impl<T: SysctlStorage> Sysctl<T> {
         storage: T,
         mode: types::Mode,
     ) -> error::Result<Sysctl<T>> {
-        if name.contains(&b'/') {
+        if name.as_bytes().contains(&b'/') {
             return Err(error::Error::EINVAL);
         }
 

--- a/samples/rust/rust_platform.rs
+++ b/samples/rust/rust_platform.rs
@@ -2,7 +2,7 @@
 
 //! Rust platform device driver sample.
 
-use kernel::{module_platform_driver, of, platform, prelude::*};
+use kernel::{module_platform_driver, of, platform, prelude::*, str::BStr, b_str};
 
 module_platform_driver! {
     type: Driver,
@@ -13,7 +13,7 @@ module_platform_driver! {
 struct Driver;
 impl platform::Driver for Driver {
     kernel::define_of_id_table! {(), [
-        (of::DeviceId::Compatible(b"rust,sample"), None),
+        (of::DeviceId::Compatible(b_str!("rust,sample")), None),
     ]}
 
     fn probe(_dev: &mut platform::Device, _id_info: Option<&Self::IdInfo>) -> Result {


### PR DESCRIPTION
* BStr needs to be a structure and not a type alias to have traits implemented
* Moved the implementation of Debug and Display from CStr to BStr
* I added a couple of common escape sequences (\r, \n, \t)

Closes #534