### PR TITLE
docs: rust: documentation review

### DIFF
--- a/Documentation/rust/arch-support.rst
+++ b/Documentation/rust/arch-support.rst
@@ -4,9 +4,9 @@ Arch Support
 ============
 
 Currently, the Rust compiler (``rustc``) uses LLVM for code generation,
-which limits the supported architectures we can target. In addition, support
-for building the kernel with LLVM/Clang varies (see :ref:`kbuild_llvm`),
-which ``bindgen`` relies on through ``libclang``.
+which limits the supported architectures that can be targeted. In addition,
+support for building the kernel with LLVM/Clang varies (see :ref:`kbuild_llvm`).
+This support is needed for ``bindgen`` which uses ``libclang``.
 
 Below is a general summary of architectures that currently work. Level of
 support corresponds to ``S`` values in the ``MAINTAINERS`` file.

--- a/Documentation/rust/coding.rst
+++ b/Documentation/rust/coding.rst
@@ -9,31 +9,29 @@ This document describes how to write Rust code in the kernel.
 Coding style
 ------------
 
-The code is automatically formatted using the ``rustfmt`` tool. This is very
-good news!
-
-- If you contribute from time to time to the kernel, you do not need to learn
-  and remember one more style guide. You will also need less patch roundtrips
-  to land a change.
-
-- If you are a reviewer or a maintainer, you will not need to spend time on
-  pointing out style issues anymore.
+The code should be formatted using ``rustfmt``. In this way, a person
+contributing from time to time to the kernel does not need to learn and
+remember one more style guide. More importantly, reviewers and maintainers
+do not need to spend time pointing out style issues anymore, and thus
+less patch roundtrips may be needed to land a change.
 
 .. note:: Conventions on comments and documentation are not checked by
-  ``rustfmt``. Thus we still need to take care of those: please see
+  ``rustfmt``. Thus those are still needed to be taken care of: please see
   :ref:`Documentation/rust/docs.rst <rust_docs>`.
 
-We use the tool's default settings. This means we are following the idiomatic
-Rust style. For instance, we use 4 spaces for indentation rather than tabs.
+The default settings of ``rustfmt`` are used. This means the idiomatic Rust
+style is followed. For instance, 4 spaces are used for indentation rather
+than tabs.
 
-Typically, you will want to instruct your editor/IDE to format while you type,
-when you save or at commit time. However, if for some reason you want
-to reformat the entire kernel Rust sources at some point, you may run::
+It is convenient to instruct editors/IDEs to format while typing,
+when saving or at commit time. However, if for some reason reformatting
+the entire kernel Rust sources is needed at some point, the following can be
+run::
 
 	make LLVM=1 rustfmt
 
-To check if everything is formatted (printing a diff otherwise), e.g. if you
-have configured a CI for a tree as a maintainer, you may run::
+It is also possible to check if everything is formatted (printing a diff
+otherwise), for instance for a CI, with::
 
 	make LLVM=1 rustfmtcheck
 
@@ -45,31 +43,32 @@ even work with broken code.
 Extra lints
 -----------
 
-While ``rustc`` is a very helpful compiler, some extra lints and analysis are
+While ``rustc`` is a very helpful compiler, some extra lints and analyses are
 available via ``clippy``, a Rust linter. To enable it, pass ``CLIPPY=1`` to
-the same invocation you use for compilation, e.g.::
+the same invocation used for compilation, e.g.::
 
 	make LLVM=1 CLIPPY=1
 
-At the moment, we do not enforce a "clippy-free" compilation, so you can treat
-the output the same way as the extra warning levels for C, e.g. like ``W=2``.
-Still, we use the default configuration, which is relatively conservative, so
-it is a good idea to read any output it may produce from time to time and fix
-the pointed out issues. The list of enabled lists will be likely tweaked over
-time, and extra levels may end up being introduced, e.g. ``CLIPPY=2``.
+Please note that Clippy may change code generation, thus it should not be
+enabled while building a production kernel.
 
 
 Abstractions vs. bindings
 -------------------------
 
-We don't have abstractions for all the kernel internal APIs and concepts,
-but we would like to expand coverage as time goes on. Unless there is
-a good reason not to, always use the abstractions instead of calling
-the C bindings directly.
+Abstractions are Rust code wrapping kernel functionality from the C side.
 
-If you are writing some code that requires a call to an internal kernel API
-or concept that isn't abstracted yet, consider providing an (ideally safe)
-abstraction for everyone to use.
+In order to use functions and types from the C side, bindings are created.
+Bindings are the declarations for Rust of those functions and types from
+the C side.
+
+For instance, one may write a ``Mutex`` abstraction in Rust which wraps
+a ``struct mutex`` from the C side and calls its functions through the bindings.
+
+Abstractions are not available for all the kernel internal APIs and concepts,
+but it is intended that coverage is expanded as time goes on. "Leaf" modules
+(e.g. drivers) should not use the C bindings directly. Instead, subsystems
+should provide as-safe-as-possible abstractions as needed.
 
 
 Conditional compilation
@@ -80,10 +79,10 @@ configuration:
 
 .. code-block:: rust
 
-	#[cfg(CONFIG_X)]      // `CONFIG_X` is enabled (`y` or `m`)
-	#[cfg(CONFIG_X="y")]  // `CONFIG_X` is enabled as a built-in (`y`)
-	#[cfg(CONFIG_X="m")]  // `CONFIG_X` is enabled as a module   (`m`)
-	#[cfg(not(CONFIG_X))] // `CONFIG_X` is disabled
+	#[cfg(CONFIG_X)]       // Enabled               (`y` or `m`)
+	#[cfg(CONFIG_X="y")]   // Enabled as a built-in (`y`)
+	#[cfg(CONFIG_X="m")]   // Enabled as a module   (`m`)
+	#[cfg(not(CONFIG_X))]  // Disabled
 
 
 Documentation

--- a/Documentation/rust/docs.rst
+++ b/Documentation/rust/docs.rst
@@ -3,39 +3,35 @@
 Docs
 ====
 
-Rust kernel code is not documented like C kernel code (i.e. via kernel-doc).
-Instead, we use the usual system for documenting Rust code: the ``rustdoc``
-tool, which uses Markdown (a *very* lightweight markup language).
-
 This document describes how to make the most out of the kernel documentation
 for Rust.
+
+Rust kernel code is not documented like C kernel code (i.e. via kernel-doc).
+Instead, the usual system for documenting Rust code is used: the ``rustdoc``
+tool, which uses Markdown (a lightweight markup language).
+
+To learn Markdown, there are many guides available out there. For instance,
+the one at:
+
+	https://commonmark.org/help/
 
 
 Reading the docs
 ----------------
 
-An advantage of using Markdown is that it attempts to make text look almost as
-you would have written it in plain text. This makes the documentation quite
-pleasant to read even in its source form.
+The generated HTML docs produced by ``rustdoc`` include integrated search,
+linked items (e.g. types, functions, constants), source code, etc.
 
-However, the generated HTML docs produced by ``rustdoc`` provide a *very* nice
-experience, including integrated instant search, clickable items (types,
-functions, constants, etc. -- including to all the standard Rust library ones
-that we use in the kernel, e.g. ``core``), categorization, links to the source
-code, etc.
+The generated docs may be read at (TODO: link when in mainline and generated
+alongside the rest of the documentation):
 
-Like for the rest of the kernel documentation, pregenerated HTML docs for
-the libraries (crates) inside ``rust/`` that are used by the rest of the kernel
-are available at `kernel.org`_ (TODO: link when in mainline and generated
-alongside the rest of the documentation).
+	http://kernel.org/
 
-.. _kernel.org: http://kernel.org/
-
-Otherwise, you can generate them locally. This is quite fast (same order as
-compiling the code itself) and you do not need any special tools or environment.
-This has the added advantage that they will be tailored to your particular
-kernel configuration. To generate them, simply use the ``rustdoc`` target with
-the same invocation you use for compilation, e.g.::
+The docs can also be easily generated and read locally. This is quite fast
+(same order as compiling the code itself) and no special tools or environment
+are needed. This has the added advantage that they will be tailored to
+the particular kernel configuration used. To generate them, use the ``rustdoc``
+target with the same invocation used for compilation, e.g.::
 
 	make LLVM=1 rustdoc
 
@@ -43,15 +39,7 @@ the same invocation you use for compilation, e.g.::
 Writing the docs
 ----------------
 
-If you already know Markdown, learning how to write Rust documentation will be
-a breeze. If not, understanding the basics is a matter of minutes reading other
-code. There are also many guides available out there, a particularly nice one
-is at `GitHub`_.
-
-.. _GitHub: https://guides.github.com/features/mastering-markdown/#syntax
-
-This is how a well-documented Rust function may look like (derived from the Rust
-standard library)::
+This is how a well-documented Rust function may look like::
 
 	/// Returns the contained [`Some`] value, consuming the `self` value,
 	/// without checking that the value is not [`None`].
@@ -77,32 +65,35 @@ standard library)::
 		}
 	}
 
-This example showcases a few ``rustdoc`` features and some common conventions
-(that we also follow in the kernel):
+This example showcases a few ``rustdoc`` features and some conventions followed
+in the kernel:
 
-* The first paragraph must be a single sentence briefly describing what
-  the documented item does. Further explanations must go in extra paragraphs.
+  - The first paragraph must be a single sentence briefly describing what
+    the documented item does. Further explanations must go in extra paragraphs.
 
-* ``unsafe`` functions must document the preconditions needed for a call to be
-  safe under a ``Safety`` section.
+  - Unsafe functions must document their safety preconditions under
+    a ``# Safety`` section.
 
-* While not shown here, if a function may panic, the conditions under which
-  that happens must be described under a ``Panics`` section. Please note that
-  panicking should be very rare and used only with a good reason. In almost
-  all cases, you should use a fallible approach, returning a `Result`.
+  - While not shown here, if a function may panic, the conditions under which
+    that happens must be described under a ``# Panics`` section.
 
-* If providing examples of usage would help readers, they must be written in
-  a section called ``Examples``.
+    Please note that panicking should be very rare and used only with a good
+    reason. In almost all cases, a fallible approach should be used, typically
+    returning a ``Result``.
 
-* Rust items (functions, types, constants...) will be automatically linked
-  (``rustdoc`` will find out the URL for you).
+  - If providing examples of usage would help readers, they must be written in
+    a section called ``# Examples``.
 
-* Following the Rust standard library conventions, any ``unsafe`` block must be
-  preceded by a ``SAFETY`` comment describing why the code inside is sound.
+  - Rust items (functions, types, constants...) must be linked appropriately
+    (``rustdoc`` will create a link automatically).
 
-  While sometimes the reason might look trivial and therefore unneeded, writing
-  these comments is not just a good way of documenting what has been taken into
-  account, but also that there are no *extra* implicit constraints.
+  - Any ``unsafe`` block must be preceded by a ``// SAFETY:`` comment
+    describing why the code inside is sound.
+
+    While sometimes the reason might look trivial and therefore unneeded, writing
+    these comments is not just a good way of documenting what has been taken into
+    account, but most importantly, it provides a way to know that there are
+    no *extra* implicit constraints.
 
 To learn more about how to write documentation for Rust and extra features,
 please take a look at the ``rustdoc`` `book`_.

--- a/Documentation/rust/index.rst
+++ b/Documentation/rust/index.rst
@@ -1,8 +1,9 @@
 Rust
 ====
 
-Documentation related to Rust within the kernel. If you are starting out,
-read the :ref:`Documentation/rust/quick-start.rst <rust_quick_start>` guide.
+Documentation related to Rust within the kernel. To start using Rust
+in the kernel, please read the
+:ref:`Documentation/rust/quick-start.rst <rust_quick_start>` guide.
 
 .. toctree::
     :maxdepth: 1

--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -4,10 +4,6 @@ Quick Start
 ===========
 
 This document describes how to get started with kernel development in Rust.
-If you have worked previously with Rust, this will only take a moment.
-
-Please note that, at the moment, a very restricted subset of architectures
-is supported, see :doc:`/rust/arch-support`.
 
 
 Requirements: Building
@@ -15,25 +11,26 @@ Requirements: Building
 
 This section explains how to fetch the tools needed for building.
 
-Some of these requirements might be available from your Linux distribution
+Some of these requirements might be available from Linux distributions
 under names like ``rustc``, ``rust-src``, ``rust-bindgen``, etc. However,
-at the time of writing, they are likely to not be recent enough.
+at the time of writing, they are likely not to be recent enough.
 
 
 rustc
 *****
 
 A particular version of the Rust compiler is required. Newer versions may or
-may not work because, for the moment, we depend on some unstable Rust features.
+may not work because, for the moment, the kernel depends on some unstable
+Rust features.
 
-If you are using ``rustup``, enter the checked out source code directory
+If ``rustup`` is being used, enter the checked out source code directory
 and run::
 
-    rustup override set 1.56.0
+	rustup override set 1.56.0
 
 Otherwise, fetch a standalone installer or install ``rustup`` from:
 
-    https://www.rust-lang.org
+	https://www.rust-lang.org
 
 
 Rust standard library source
@@ -42,33 +39,33 @@ Rust standard library source
 The Rust standard library source is required because the build system will
 cross-compile ``core`` and ``alloc``.
 
-If you are using ``rustup``, run::
+If ``rustup`` is being used, run::
 
-    rustup component add rust-src
+	rustup component add rust-src
 
-Otherwise, if you used a standalone installer, you can clone the Rust
-repository into the installation folder of your nightly toolchain::
+Otherwise, if a standalone installer is used, the Rust repository may be cloned
+into the installation folder of the toolchain::
 
-    git clone --recurse-submodules https://github.com/rust-lang/rust $(rustc --print sysroot)/lib/rustlib/src/rust
+	git clone --recurse-submodules https://github.com/rust-lang/rust $(rustc --print sysroot)/lib/rustlib/src/rust
 
 
 libclang
 ********
 
 ``libclang`` (part of LLVM) is used by ``bindgen`` to understand the C code
-in the kernel, which means you will need an LLVM installed; like when
-you compile the kernel with ``CC=clang`` or ``LLVM=1``.
+in the kernel, which means LLVM needs to be installed; like when the kernel
+is compiled with ``CC=clang`` or ``LLVM=1``.
 
-Your Linux distribution is likely to have a suitable one available, so it is
-best if you check that first.
+Linux distributions are likely to have a suitable one available, so it is
+best to check that first.
 
 There are also some binaries for several systems and architectures uploaded at:
 
-    https://releases.llvm.org/download.html
+	https://releases.llvm.org/download.html
 
 Otherwise, building LLVM takes quite a while, but it is not a complex process:
 
-    https://llvm.org/docs/GettingStarted.html#getting-the-source-code-and-building-llvm
+	https://llvm.org/docs/GettingStarted.html#getting-the-source-code-and-building-llvm
 
 See Documentation/kbuild/llvm.rst for more information and further ways
 to fetch pre-built releases and distribution packages.
@@ -78,18 +75,18 @@ bindgen
 *******
 
 The bindings to the C side of the kernel are generated at build time using
-the ``bindgen`` tool. The version we currently support is ``0.56.0``.
+the ``bindgen`` tool. A particular version is required.
 
-Install it via (this will build the tool from source)::
+Install it via (note that this will download and build the tool from source)::
 
-    cargo install --locked --version 0.56.0 bindgen
+	cargo install --locked --version 0.56.0 bindgen
 
 
 Requirements: Developing
 ------------------------
 
 This section explains how to fetch the tools needed for developing. That is,
-if you only want to build the kernel, you do not need them.
+they are not needed when just building the kernel.
 
 
 rustfmt
@@ -99,11 +96,11 @@ The ``rustfmt`` tool is used to automatically format all the Rust kernel code,
 including the generated C bindings (for details, please see
 :ref:`Documentation/rust/coding.rst <rust_coding>`).
 
-If you are using ``rustup``, its ``default`` profile already installs the tool,
-so you should be good to go. If you are using another profile, you can install
-the component manually::
+If ``rustup`` is being used, its ``default`` profile already installs the tool,
+thus nothing needs to be done. If another profile is being used, the component
+can be installed manually::
 
-    rustup component add rustfmt
+	rustup component add rustfmt
 
 The standalone installers also come with ``rustfmt``.
 
@@ -111,15 +108,15 @@ The standalone installers also come with ``rustfmt``.
 clippy
 ******
 
-``clippy`` is a Rust linter. Installing it allows you to get extra warnings
-for Rust code passing ``CLIPPY=1`` to ``make`` (for details, please see
+``clippy`` is a Rust linter. Running it provides extra warnings for Rust code.
+It can be run by passing ``CLIPPY=1`` to ``make`` (for details, please see
 :ref:`Documentation/rust/coding.rst <rust_coding>`).
 
-If you are using ``rustup``, its ``default`` profile already installs the tool,
-so you should be good to go. If you are using another profile, you can install
-the component manually::
+If ``rustup`` is being used, its ``default`` profile already installs the tool,
+thus nothing needs to be done. If another profile is being used, the component
+can be installed manually::
 
-    rustup component add clippy
+	rustup component add clippy
 
 The standalone installers also come with ``clippy``.
 
@@ -128,11 +125,14 @@ cargo
 *****
 
 ``cargo`` is the Rust native build system. It is currently required to run
-the tests (``rusttest`` target) since we use it to build a custom standard
-library that contains the facilities provided by our custom ``alloc``.
+the tests since it is used to build a custom standard library that contains
+the facilities provided by the custom ``alloc`` in the kernel. The tests can
+be run using the ``rusttest`` Make target.
 
-If you are using ``rustup``, all the profiles already install the tool,
-so you should be good to go. The standalone installers also include ``cargo``.
+If ``rustup`` is being used, all the profiles already install the tool,
+thus nothing needs to be done.
+
+The standalone installers also come with ``cargo``.
 
 
 rustdoc
@@ -140,14 +140,16 @@ rustdoc
 
 ``rustdoc`` is the documentation tool for Rust. It generates pretty HTML
 documentation for Rust code (for details, please see
-:ref:`Documentation/rust/docs.rst <rust_docs>`.
+:ref:`Documentation/rust/docs.rst <rust_docs>`).
 
-``rustdoc`` is also able to test the examples provided in documented Rust code
-(called doctests or documentation tests). We use this feature, thus ``rustdoc``
-is required to run the tests (``rusttest`` target).
+``rustdoc`` is also used to test the examples provided in documented Rust code
+(called doctests or documentation tests). The ``rusttest`` Make target uses
+this feature.
 
-If you are using ``rustup``, all the profiles already install the tool,
-so you should be good to go. The standalone installers also include ``rustdoc``.
+If ``rustup`` is being used, all the profiles already install the tool,
+thus nothing needs to be done.
+
+The standalone installers also come with ``rustdoc``.
 
 
 rust-analyzer
@@ -157,11 +159,8 @@ The `rust-analyzer <https://rust-analyzer.github.io/>`_ language server can
 be used with many editors to enable syntax highlighting, completion, go to
 definition, and other features.
 
-``rust-analyzer`` will need to be
-`configured <https://rust-analyzer.github.io/manual.html#non-cargo-based-projects>`_
-to work with the kernel by adding a ``rust-project.json`` file in the root folder.
-A ``rust-project.json`` can be generated by building the Make target ``rust-analyzer``,
-which will create a ``rust-project.json`` in the root of the output directory.
+``rust-analyzer`` needs a configuration file, ``rust-project.json``, which
+can be generated by the ``rust-analyzer`` Make target.
 
 
 Configuration
@@ -173,9 +172,9 @@ In turn, this will make visible the rest of options that depend on Rust.
 
 Afterwards, go to::
 
-    Kernel hacking
-      -> Sample kernel code
-           -> Rust samples
+	Kernel hacking
+	    -> Sample kernel code
+	        -> Rust samples
 
 And enable some sample modules either as built-in or as loadable.
 
@@ -186,33 +185,28 @@ Building
 Building a kernel with a complete LLVM toolchain is the best supported setup
 at the moment. That is::
 
-    make LLVM=1
+	make LLVM=1
 
 For architectures that do not support a full LLVM toolchain, use::
 
-    make CC=clang
+	make CC=clang
 
-Using GCC also works for some configurations, but it is *very* experimental at
+Using GCC also works for some configurations, but it is very experimental at
 the moment.
 
 
 Hacking
 -------
 
-If you want to dive deeper, take a look at the source code of the samples
+To dive deeper, take a look at the source code of the samples
 at ``samples/rust/``, the Rust support code under ``rust/`` and
 the ``Rust hacking`` menu under ``Kernel hacking``.
 
-If you use GDB/Binutils and Rust symbols aren't getting demangled, the reason
-is your toolchain doesn't support Rust's new v0 mangling scheme yet. There are
-a few ways out:
+If GDB/Binutils is used and Rust symbols are not getting demangled, the reason
+is the toolchain does not support Rust's new v0 mangling scheme yet.
+There are a few ways out:
 
   - Install a newer release (GDB >= 10.2, Binutils >= 2.36).
 
-  - If you only need GDB and can enable ``CONFIG_DEBUG_INFO``, do so:
-    some versions of GDB (e.g. vanilla GDB 10.1) are able to use
-    the pre-demangled names embedded in the debug info.
-
-  - If you don't need loadable module support, you may compile without
-    the ``-Zsymbol-mangling-version=v0`` flag. However, we don't maintain
-    support for that, so avoid it unless you are in a hurry.
+  - Some versions of GDB (e.g. vanilla GDB 10.1) are able to use
+    the pre-demangled names embedded in the debug info (``CONFIG_DEBUG_INFO``).


### PR DESCRIPTION
  - Address Willy Tarreau "we"/"you" comments and use
    a more formal style overall.

  - Replaced outdated/broken links.

  - Homogenize style.

  - General review of content.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>