### PR TITLE
rust: add support for creating a `Buffer` from a raw pointer.

### DIFF
--- a/rust/kernel/buffer.rs
+++ b/rust/kernel/buffer.rs
@@ -14,9 +14,22 @@ pub struct Buffer<'a> {
 }
 
 impl<'a> Buffer<'a> {
-    /// Create a new buffer from an existing array.
+    /// Creates a new buffer from an existing array.
     pub fn new(slice: &'a mut [u8]) -> Self {
         Buffer { slice, pos: 0 }
+    }
+
+    /// Creates a new buffer from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be valid for read and writes, have at least `len` bytes in
+    /// size, and remain valid and not be used by other threads for the lifetime
+    /// of the returned instance.
+    pub unsafe fn from_raw(ptr: *mut u8, len: usize) -> Self {
+        // SAFETY: The safety requirements of the function satisfy those of
+        // `from_raw_parts_mut`.
+        Self::new(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
     }
 
     /// Number of bytes that have already been written to the buffer.
@@ -26,7 +39,7 @@ impl<'a> Buffer<'a> {
     }
 }
 
-impl<'a> fmt::Write for Buffer<'a> {
+impl fmt::Write for Buffer<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         if s.len() > self.slice.len() - self.pos {
             Err(fmt::Error)

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -396,6 +396,12 @@ impl From<LayoutError> for Error {
     }
 }
 
+impl From<core::fmt::Error> for Error {
+    fn from(_: core::fmt::Error) -> Error {
+        Error::EINVAL
+    }
+}
+
 /// A [`Result`] with an [`Error`] error type.
 ///
 /// To be used as the return type for functions that may fail.


### PR DESCRIPTION
This is going to be used in the `show` method of sysfs files.

Also add a generic conversion from format errors to kernel result errors
so that we can use the `?`-operator in functions that return `Result`.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>