### PR TITLE
gpio: pl061: update `Kconfig` to include dependency on `RUST`.

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -473,7 +473,7 @@ config GPIO_PL061
 
 config GPIO_PL061_RUST
 	tristate "PrimeCell PL061 GPIO support written in Rust"
-	depends on ARM_AMBA
+	depends on ARM_AMBA && RUST
 	select IRQ_DOMAIN
 	select GPIOLIB_IRQCHIP
 	help


### PR DESCRIPTION
This is so that the `GPIO_PL061_RUST` can only be selected if `RUST` is
also selected.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>