### PR TITLE
rust: implement `PointerWrapper` for unit type.

### DIFF
--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -144,6 +144,19 @@ impl<T> PointerWrapper for *mut T {
     }
 }
 
+impl PointerWrapper for () {
+    type Borrowed<'a> = ();
+
+    fn into_pointer(self) -> *const c_types::c_void {
+        // We use 1 to be different from a null pointer.
+        1usize as _
+    }
+
+    unsafe fn borrow<'a>(_: *const c_types::c_void) -> Self::Borrowed<'a> {}
+
+    unsafe fn from_pointer(_: *const c_types::c_void) -> Self {}
+}
+
 /// Runs a cleanup function/closure when dropped.
 ///
 /// The [`ScopeGuard::dismiss`] function prevents the cleanup function from running.


### PR DESCRIPTION
This is useful for cases when we don't need to store any information as
context. Implementing `PointerWrapper` for `()` allows us to directly
use it as the context type.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>