### PR TITLE
Makefile: avoid running `rustc` for targets like `clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1162,7 +1162,11 @@ export MODULES_NSDEPS := $(extmod_prefix)modules.nsdeps
 ifeq ($(KBUILD_EXTMOD),)
 core-y			+= kernel/ certs/ mm/ fs/ ipc/ security/ crypto/
 core-$(CONFIG_BLOCK)	+= block/
-core-$(CONFIG_RUST)	+= rust/
+
+# Keep this one as an `ifdef` block since its `Makefile` runs `rustc`.
+ifdef CONFIG_RUST
+core-y			+= rust/
+endif
 
 vmlinux-dirs	:= $(patsubst %/,%,$(filter %/, \
 		     $(core-y) $(core-m) $(drivers-y) $(drivers-m) \


### PR DESCRIPTION
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>