### PR TITLE
rust: add initial common clock framework bindings

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -2,6 +2,7 @@
 
 #include <linux/bug.h>
 #include <linux/build_bug.h>
+#include <linux/clk.h>
 #include <linux/uaccess.h>
 #include <linux/sched/signal.h>
 #include <linux/gfp.h>
@@ -21,6 +22,18 @@ __noreturn void rust_helper_BUG(void)
 {
 	BUG();
 }
+
+void rust_helper_clk_disable_unprepare(struct clk *clk)
+{
+	return clk_disable_unprepare(clk);
+}
+EXPORT_SYMBOL_GPL(rust_helper_clk_disable_unprepare);
+
+int rust_helper_clk_prepare_enable(struct clk *clk)
+{
+	return clk_prepare_enable(clk);
+}
+EXPORT_SYMBOL_GPL(rust_helper_clk_prepare_enable);
 
 unsigned long rust_helper_copy_from_user(void *to, const void __user *from, unsigned long n)
 {

--- a/rust/kernel/bindings_helper.h
+++ b/rust/kernel/bindings_helper.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 
 #include <linux/cdev.h>
+#include <linux/clk.h>
 #include <linux/errname.h>
 #include <linux/fs.h>
 #include <linux/module.h>

--- a/rust/kernel/clk.rs
+++ b/rust/kernel/clk.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Common clock framework.
+//!
+//! C header: [`include/linux/clk.h`](../../../../include/linux/clk.h)
+
+use crate::{bindings, error::Result, to_result};
+use core::mem::ManuallyDrop;
+
+/// Represents `struct clk *`.
+///
+/// # Invariants
+///
+/// The pointer is valid.
+pub struct Clk(*mut bindings::clk);
+
+impl Clk {
+    /// Creates new clock structure from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be valid.
+    pub unsafe fn new(clk: *mut bindings::clk) -> Self {
+        Self(clk)
+    }
+
+    /// Returns value of the rate field of `struct clk`.
+    pub fn get_rate(&self) -> usize {
+        // SAFETY: the pointer is valid by the type invariant.
+        unsafe { bindings::clk_get_rate(self.0) as usize }
+    }
+
+    /// Prepares and enables the underlying hardware clock.
+    ///
+    /// This function should not be called in atomic context.
+    pub fn prepare_enable(self) -> Result<EnabledClk> {
+        // SAFETY: the pointer is valid by the type invariant.
+        to_result(|| unsafe { bindings::clk_prepare_enable(self.0) })?;
+        Ok(EnabledClk(self))
+    }
+}
+
+impl Drop for Clk {
+    fn drop(&mut self) {
+        // SAFETY: the pointer is valid by the type invariant.
+        unsafe { bindings::clk_put(self.0) };
+    }
+}
+
+/// A clock variant that is prepared and enabled.
+pub struct EnabledClk(Clk);
+
+impl EnabledClk {
+    /// Returns value of the rate field of `struct clk`.
+    pub fn get_rate(&self) -> usize {
+        self.0.get_rate()
+    }
+
+    /// Disables and later unprepares the underlying hardware clock prematurely.
+    ///
+    /// This function should not be called in atomic context.
+    pub fn disable_unprepare(self) -> Clk {
+        let mut clk = ManuallyDrop::new(self);
+        // SAFETY: the pointer is valid by the type invariant.
+        unsafe { bindings::clk_disable_unprepare(clk.0 .0) };
+        core::mem::replace(&mut clk.0, Clk(core::ptr::null_mut()))
+    }
+}
+
+impl Drop for EnabledClk {
+    fn drop(&mut self) {
+        // SAFETY: the pointer is valid by the type invariant.
+        unsafe { bindings::clk_disable_unprepare(self.0 .0) };
+    }
+}

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -45,6 +45,8 @@ pub mod amba;
 pub mod buffer;
 pub mod c_types;
 pub mod chrdev;
+#[cfg(CONFIG_COMMON_CLK)]
+pub mod clk;
 pub mod cred;
 pub mod device;
 pub mod driver;


### PR DESCRIPTION
This patch adds initial abstractions including:
  - `Clk` wrapper around `struct clk *`.
  - Binding of clk_get() method implemented
    once as an associated method of `Clk` type
    and second as a method of `device::RawDevice` trait.
  - Routines get_rate() and prepare_enable(),
    implemented as methods of `Clk` type.
  
  This patch is a dependency of a Samsung Exynos trng driver provided initially in https://github.com/Rust-for-Linux/linux/pull/554.

Changes v3 -> v4:
  - Removed unnecessary method `Clk::get()`. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r776485671
  - Documentation improvement https://github.com/Rust-for-Linux/linux/pull/593#discussion_r778129292
  - Added `EnableClk` variant of the `Clk` type that manages the use
    of the `bindings::clk_disable_unprepare()` function. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r776501490

Changes v2 -> v3:
  - Binding of `devm_clk_get()` has been removed and replaces
    with `bindings::clk_get()` variant. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r767156916
  - Implemented `Drop` trait for `Clk` structure that calls `bindings::clk_put`.
  - `(*self).0` -> `self.0`. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r767156209
  - Used `to_result()` method instead of checking error code explicitly. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r767156423
  - `id` field of `Clk::get()` method is now optional, precisely `Option<&CStr>`. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r767157089 and https://github.com/Rust-for-Linux/linux/pull/593#discussion_r767157089
  - Added a variant of `Clk::get()` to `device::RawDevice` trait. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r767157499
  - Docs fixes. https://github.com/Rust-for-Linux/linux/pull/593#discussion_r767155992

Changes v1 (https://github.com/Rust-for-Linux/linux/pull/554) -> v2:
  - Added invariant description for `Clk` type https://github.com/Rust-for-Linux/linux/pull/554#discussion_r749355831
  - Made prepare_enable() a method of `Clk` type https://github.com/Rust-for-Linux/linux/pull/554#discussion_r749357290
  - Added `#[cfg(CONFIG_COMMON_CLK)]` in a module declaration at `rust/kernel/lib.rs`.
  - `devm_clk_get()` uses now `device::RawDevice` to get access to a raw device pointer based on https://github.com/Rust-for-Linux/linux/commit/6f94f6a76296cc8af6ce14bb7d43dc67a95b0ef6.

Signed-off-by: Maciej Falkowski <m.falkowski@samsung.com>