### PR TITLE
fixed apt get error and added schedule for the github CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,8 @@
 on:
   pull_request: {}
+  schedule:
+    - cron:  '30 5,17 * * *'
   push:
-    branches: [rust]
 
 jobs:
   ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,7 +201,7 @@ jobs:
             sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main' ||
             sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main'
       - run: sudo apt-get update -y
-      - run: sudo apt-get install -y llvm-12 clang-12 lld-12
+      - run: sudo apt-get install -y llvm-12 clang-12 lld-12 --fix-missing
       - run: echo $(llvm-config-12 --bindir) >> $GITHUB_PATH
 
       # Setup: GCC


### PR DESCRIPTION
This made a daily check and workflow `ci (x86_64, clang, debug, 1.57.0, src, rustup, common, none)` will not fail anymore.

I made this change because I saw https://github.com/Rust-for-Linux/linux/commit/675846f923385f32310b61f0409581d89806273d failing.