### PR TITLE
`vsprintf`: avoid `#ifdef` in `.c` file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16574,6 +16574,7 @@ T:	git https://github.com/Rust-for-Linux/linux.git rust-next
 F:	rust/
 F:	samples/rust/
 F:	Documentation/rust/
+F:	include/linux/rust.h
 K:	\b(?i:rust)\b
 
 RXRPC SOCKETS (AF_RXRPC)

--- a/include/linux/rust.h
+++ b/include/linux/rust.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __LINUX_RUST_H
+#define __LINUX_RUST_H
+
+#ifdef CONFIG_RUST
+char *rust_fmt_argument(char* buf, char* end, void *ptr);
+#else
+static inline char *rust_fmt_argument(char* buf, char* end, void *ptr)
+{
+	return NULL;
+}
+#endif
+
+#endif /* __LINUX_RUST_H */

--- a/lib/vsprintf.c
+++ b/lib/vsprintf.c
@@ -41,6 +41,7 @@
 #include <linux/siphash.h>
 #include <linux/compiler.h>
 #include <linux/property.h>
+#include <linux/rust.h>
 #ifdef CONFIG_BLOCK
 #include <linux/blkdev.h>
 #endif
@@ -2233,10 +2234,6 @@ char *fwnode_string(char *buf, char *end, struct fwnode_handle *fwnode,
 	return widen_string(buf, buf - buf_start, end, spec);
 }
 
-#ifdef CONFIG_RUST
-char *rust_fmt_argument(char* buf, char* end, void *ptr);
-#endif
-
 /* Disable pointer hashing if requested */
 bool no_hash_pointers __ro_after_init;
 EXPORT_SYMBOL_GPL(no_hash_pointers);
@@ -2468,10 +2465,8 @@ char *pointer(const char *fmt, char *buf, char *end, void *ptr,
 		return device_node_string(buf, end, ptr, spec, fmt + 1);
 	case 'f':
 		return fwnode_string(buf, end, ptr, spec, fmt + 1);
-#ifdef CONFIG_RUST
 	case 'A':
 		return rust_fmt_argument(buf, end, ptr);
-#endif
 	case 'x':
 		return pointer_string(buf, end, ptr, spec);
 	case 'e':


### PR DESCRIPTION
Suggested-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>