### PR TITLE
gpio: pl061: fix 32-bit builds of PL061 Rust driver.

### DIFF
--- a/drivers/gpio/gpio_pl061_rust.rs
+++ b/drivers/gpio/gpio_pl061_rust.rs
@@ -223,7 +223,7 @@ impl irq::Chip for PL061Device {
     }
 
     fn mask(data: RefBorrow<'_, DeviceData>, irq_data: &IrqData) {
-        let mask = bit(irq_data.hwirq() % u64::from(PL061_GPIO_NR));
+        let mask = bit(irq_data.hwirq() % irq::HwNumber::from(PL061_GPIO_NR));
         let _guard = data.lock();
         if let Some(pl061) = data.resources() {
             let gpioie = pl061.base.readb(GPIOIE) & !mask;
@@ -232,7 +232,7 @@ impl irq::Chip for PL061Device {
     }
 
     fn unmask(data: RefBorrow<'_, DeviceData>, irq_data: &IrqData) {
-        let mask = bit(irq_data.hwirq() % u64::from(PL061_GPIO_NR));
+        let mask = bit(irq_data.hwirq() % irq::HwNumber::from(PL061_GPIO_NR));
         let _guard = data.lock();
         if let Some(pl061) = data.resources() {
             let gpioie = pl061.base.readb(GPIOIE) | mask;
@@ -244,7 +244,7 @@ impl irq::Chip for PL061Device {
     // (interrupt-clear) register. For level IRQs this is not needed: these go away when the level
     // signal goes away.
     fn ack(data: RefBorrow<'_, DeviceData>, irq_data: &IrqData) {
-        let mask = bit(irq_data.hwirq() % u64::from(PL061_GPIO_NR));
+        let mask = bit(irq_data.hwirq() % irq::HwNumber::from(PL061_GPIO_NR));
         let _guard = data.lock();
         if let Some(pl061) = data.resources() {
             pl061.base.writeb(mask.into(), GPIOIC);

--- a/rust/kernel/irq.rs
+++ b/rust/kernel/irq.rs
@@ -12,7 +12,8 @@
 use crate::{bindings, c_types, error::from_kernel_result, types::PointerWrapper, Error, Result};
 use core::ops::Deref;
 
-type IrqHwNumber = bindings::irq_hw_number_t;
+/// The type of irq hardware numbers.
+pub type HwNumber = bindings::irq_hw_number_t;
 
 /// Wraps the kernel's `struct irq_data`.
 ///
@@ -37,7 +38,7 @@ impl IrqData {
     }
 
     /// Returns the hardware irq number.
-    pub fn hwirq(&self) -> IrqHwNumber {
+    pub fn hwirq(&self) -> HwNumber {
         // SAFETY: By the type invariants, it's ok to dereference `ptr`.
         unsafe { (*self.ptr).hwirq }
     }


### PR DESCRIPTION
Hw irq numbers are 32 bits in 32-bit archs, so use the type alias to
convert to it.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>