### PR TITLE
docs: Add instructions on how to locally view rustdocs

### DIFF
--- a/Documentation/rust/docs.rst
+++ b/Documentation/rust/docs.rst
@@ -35,6 +35,9 @@ target with the same invocation used for compilation, e.g.::
 
 	make LLVM=1 rustdoc
 
+To read the docs locally in your web browser, run e.g.::
+
+	xdg-open rust/doc/kernel/index.html
 
 Writing the docs
 ----------------


### PR DESCRIPTION
For cargo-based projects I usually run `cargo doc --open` but I didn't
see an equivalent option with the makefile. Thought it would be nice to
document a manual option. A new makefile target feels like too much for
something so simple.

Signed-off-by: Daniel Xu <dxu@dxuuu.xyz>