### PR TITLE
rust: file: Add flags() method to `File`

### DIFF
--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -54,6 +54,12 @@ impl File {
         // change over the lifetime of a file).
         unsafe { CredentialRef::from_ptr(ptr) }
     }
+
+    /// Returns the flags associated with the file.
+    pub fn flags(&self) -> u32 {
+        // SAFETY: `File::ptr` is guaranteed to be valid by the type invariants.
+        unsafe { (*self.ptr).f_flags }
+    }
 }
 
 impl Drop for File {


### PR DESCRIPTION
It's useful to know the flags associated with a file.

Signed-off-by: Daniel Xu <dxu@dxuuu.xyz>