### PR TITLE
rust: add `ThisModule` to the arguments of driver registration

### DIFF
--- a/rust/kernel/amba.rs
+++ b/rust/kernel/amba.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     bindings, c_types, device, driver, error::from_kernel_result, io_mem::Resource, power,
-    str::CStr, to_result, types::PointerWrapper, Error, Result,
+    str::CStr, to_result, types::PointerWrapper, Error, Result, ThisModule,
 };
 use core::{marker::PhantomData, ops::Deref};
 
@@ -72,12 +72,14 @@ where
     unsafe fn register(
         reg: *mut bindings::amba_driver,
         name: &'static CStr,
+        module: &'static ThisModule,
         id_table: *const bindings::amba_id,
     ) -> Result {
         // SAFETY: By the safety requirements of this function (defined in the trait defintion),
         // `reg` is non-null and valid.
         let amba = unsafe { &mut *reg };
         amba.drv.name = name.as_char_ptr();
+        amba.drv.owner = module.0;
         amba.id_table = id_table;
         amba.probe = Some(probe_callback::<T>);
         amba.remove = Some(remove_callback::<T>);


### PR DESCRIPTION
So that the kernel is aware of any loadable modules hosting drivers and
can therefore increment/decrement refcounts as appropriate to prevent
unload when the driver is in use.

This should be transparent to all drivers registered with macros. Those
registered with direct calls will need to pass the extra argument.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>