### PR TITLE
rust: simplify file operations by removing `FileOpener`

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -5,7 +5,7 @@ use kernel::{
     bindings, c_types,
     cred::Credential,
     file::File,
-    file_operations::{FileOpener, FileOperations, IoctlCommand, IoctlHandler, PollTable},
+    file_operations::{FileOperations, IoctlCommand, IoctlHandler, PollTable},
     io_buffer::{IoBufferReader, IoBufferWriter},
     linked_list::List,
     pages::Pages,
@@ -806,16 +806,15 @@ impl IoctlHandler for Process {
     }
 }
 
-impl FileOpener<Ref<Context>> for Process {
+impl FileOperations for Process {
+    type Wrapper = Ref<Self>;
+    type OpenData = Ref<Context>;
+
+    kernel::declare_file_operations!(ioctl, compat_ioctl, mmap, poll);
+
     fn open(ctx: &Ref<Context>, file: &File) -> Result<Self::Wrapper> {
         Self::new(ctx.clone(), file.cred().clone())
     }
-}
-
-impl FileOperations for Process {
-    type Wrapper = Ref<Self>;
-
-    kernel::declare_file_operations!(ioctl, compat_ioctl, mmap, poll);
 
     fn release(obj: Self::Wrapper, _file: &File) {
         // Mark this process as dead. We'll do the same for the threads later.

--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -102,13 +102,13 @@ const fn ptr_align(value: usize) -> usize {
 unsafe impl Sync for BinderModule {}
 
 struct BinderModule {
-    _reg: Pin<Box<Registration<Ref<Context>>>>,
+    _reg: Pin<Box<Registration<process::Process>>>,
 }
 
 impl KernelModule for BinderModule {
     fn init(name: &'static CStr, _module: &'static kernel::ThisModule) -> Result<Self> {
         let ctx = Context::new()?;
-        let reg = Registration::new_pinned::<process::Process>(name, None, ctx)?;
+        let reg = Registration::new_pinned(name, None, ctx)?;
         Ok(Self { _reg: reg })
     }
 }

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -134,7 +134,9 @@ impl<const N: usize> Registration<{ N }> {
     /// Registers a character device.
     ///
     /// You may call this once per device type, up to `N` times.
-    pub fn register<T: file_operations::FileOpener<()>>(self: Pin<&mut Self>) -> Result {
+    pub fn register<T: file_operations::FileOperations<OpenData = ()>>(
+        self: Pin<&mut Self>,
+    ) -> Result {
         // SAFETY: We must ensure that we never move out of `this`.
         let this = unsafe { self.get_unchecked_mut() };
         if this.inner.is_none() {
@@ -177,13 +179,8 @@ impl<const N: usize> Registration<{ N }> {
     }
 }
 
-impl<const N: usize> file_operations::FileOpenAdapter for Registration<{ N }> {
-    type Arg = ();
-
-    unsafe fn convert(
-        _inode: *mut bindings::inode,
-        _file: *mut bindings::file,
-    ) -> *const Self::Arg {
+impl<const N: usize> file_operations::FileOpenAdapter<()> for Registration<{ N }> {
+    unsafe fn convert(_inode: *mut bindings::inode, _file: *mut bindings::file) -> *const () {
         // TODO: Update the SAFETY comment on the call to `FileOperationsVTable::build` above once
         // this is updated to retrieve state.
         &()

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -6,7 +6,7 @@
 #![feature(allocator_api, global_asm)]
 
 use kernel::prelude::*;
-use kernel::{chrdev, file_operations::FileOperations};
+use kernel::{chrdev, file, file_operations::FileOperations};
 
 module! {
     type: RustChrdev,
@@ -16,11 +16,14 @@ module! {
     license: b"GPL v2",
 }
 
-#[derive(Default)]
 struct RustFile;
 
 impl FileOperations for RustFile {
     kernel::declare_file_operations!();
+
+    fn open(_shared: &(), _file: &file::File) -> Result<Self::Wrapper> {
+        Ok(Box::try_new(RustFile)?)
+    }
 }
 
 struct RustChrdev {

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -15,11 +15,14 @@ use kernel::{
     prelude::*,
 };
 
-#[derive(Default)]
 struct RandomFile;
 
 impl FileOperations for RandomFile {
     kernel::declare_file_operations!(read, write, read_iter, write_iter);
+
+    fn open(_open_data: &(), _file: &File) -> Result<Self::Wrapper> {
+        Ok(Box::try_new(RandomFile)?)
+    }
 
     fn read(_this: &Self, file: &File, buf: &mut impl IoBufferWriter, _: u64) -> Result<usize> {
         let total_len = buf.len();


### PR DESCRIPTION
It is currently used to allow a single `FileOperations` implementation
to be shared by multiple `FileOpener` instances. But Binder is the only
intended user I've seen so far.

So we have the extra complexity because of a single exceptional case.
This commit simplifies things for the majority: they just need to
implement `FileOperations::open`.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>