### PR TITLE
rust: convert `platform` to use `driver`

### DIFF
--- a/drivers/gpio/gpio_pl061_rust.rs
+++ b/drivers/gpio/gpio_pl061_rust.rs
@@ -8,7 +8,7 @@
 #![feature(global_asm, allocator_api)]
 
 use kernel::{
-    amba, bit, bits_iter, declare_amba_id_table, device, gpio,
+    amba, bit, bits_iter, define_amba_id_table, device, gpio,
     io_mem::IoMem,
     irq::{self, ExtraResult, IrqData, LockedIrqData},
     power,
@@ -261,11 +261,11 @@ impl amba::Driver for PL061Device {
     type Data = Ref<DeviceData>;
     type PowerOps = Self;
 
-    declare_amba_id_table! [
-        { id: 0x00041061, mask: 0x000fffff, data: () },
-    ];
+    define_amba_id_table! {(), [
+        ({id: 0x00041061, mask: 0x000fffff}, None),
+    ]}
 
-    fn probe(dev: &mut amba::Device, _id: &amba::DeviceId) -> Result<Ref<DeviceData>> {
+    fn probe(dev: &mut amba::Device, _data: Option<&Self::IdInfo>) -> Result<Ref<DeviceData>> {
         let res = dev.take_resource().ok_or(Error::ENXIO)?;
         let irq = dev.irq(0).ok_or(Error::ENXIO)?;
 

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -17,6 +17,7 @@
 #include <linux/irqchip/chained_irq.h>
 #include <linux/irqdomain.h>
 #include <linux/amba/bus.h>
+#include <linux/of_device.h>
 
 __noreturn void rust_helper_BUG(void)
 {
@@ -476,6 +477,13 @@ void rust_helper_put_cred(const struct cred *cred) {
 	put_cred(cred);
 }
 EXPORT_SYMBOL_GPL(rust_helper_put_cred);
+
+const struct of_device_id *rust_helper_of_match_device(
+		const struct of_device_id *matches, const struct device *dev)
+{
+	return of_match_device(matches, dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_of_match_device);
 
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -18,7 +18,6 @@
     concat_idents,
     const_fn_trait_bound,
     const_mut_refs,
-    const_precise_live_drops, // TODO: Remove once we go to 1.58.x.
     const_ptr_offset_from,
     const_refs_to_cell,
     const_trait_impl,

--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -4,98 +4,60 @@
 //!
 //! C header: [`include/linux/of_*.h`](../../../../include/linux/of_*.h)
 
-use crate::{bindings, c_types, str::CStr};
+use crate::{bindings, driver, str::BStr};
 
-use core::ops::Deref;
-use core::ptr;
-
-/// A kernel Open Firmware / devicetree match table.
-///
-/// Can only exist as an `&OfMatchTable` reference (akin to `&str` or
-/// `&Path` in Rust std).
-///
-/// # Invariants
-///
-/// The inner reference points to a sentinel-terminated C array.
-#[repr(transparent)]
-pub struct OfMatchTable(bindings::of_device_id);
-
-impl OfMatchTable {
-    /// Returns the table as a reference to a static lifetime, sentinel-terminated C array.
-    ///
-    /// This is suitable to be coerced into the kernel's `of_match_table` field.
-    pub fn as_ptr(&'static self) -> &'static bindings::of_device_id {
-        // The inner reference points to a sentinel-terminated C array, as per
-        // the type invariant.
-        &self.0
-    }
+/// An open firmware device id.
+#[derive(Clone, Copy)]
+pub enum DeviceId {
+    /// An open firmware device id where only a compatible string is specified.
+    Compatible(&'static BStr),
 }
 
-/// An Open Firmware Match Table that can be constructed at build time.
+/// Defines a const open firmware device id table that also carries per-entry data/context/info.
 ///
-/// # Invariants
+/// The name of the const is `OF_DEVICE_ID_TABLE`, which is what buses are expected to name their
+/// open firmware tables.
 ///
-/// `sentinel` always contains zeroes.
-#[repr(C)]
-pub struct ConstOfMatchTable<const N: usize> {
-    table: [bindings::of_device_id; N],
-    sentinel: bindings::of_device_id,
+/// # Examples
+///
+/// ```
+/// # use kernel::define_of_id_table;
+/// use kernel::of;
+///
+/// define_of_id_table! {u32, [
+///     (of::DeviceId::Compatible(b"test-device1,test-device2"), Some(0xff)),
+///     (of::DeviceId::Compatible(b"test-device3"), None),
+/// ]};
+/// ```
+#[macro_export]
+macro_rules! define_of_id_table {
+    ($data_type:ty, $($t:tt)*) => {
+        $crate::define_id_table!(OF_DEVICE_ID_TABLE, $crate::of::DeviceId, $data_type, $($t)*);
+    };
 }
 
-impl<const N: usize> ConstOfMatchTable<N> {
-    /// Creates a new Open Firmware Match Table from a list of compatible strings.
-    pub const fn new_const(compatibles: [&'static CStr; N]) -> Self {
-        let mut table = [Self::zeroed_of_device_id(); N];
-        let mut i = 0;
-        while i < N {
-            table[i] = Self::new_of_device_id(compatibles[i]);
-            i += 1;
-        }
-        Self {
-            table,
-            // INVARIANTS: we zero the sentinel here, and never change it
-            // anywhere. Therefore it always contains zeroes.
-            sentinel: Self::zeroed_of_device_id(),
-        }
-    }
+// SAFETY: `ZERO` is all zeroed-out and `to_rawid` stores `offset` in `of_device_id::data`.
+unsafe impl const driver::RawDeviceId for DeviceId {
+    type RawType = bindings::of_device_id;
+    const ZERO: Self::RawType = bindings::of_device_id {
+        name: [0; 32],
+        type_: [0; 32],
+        compatible: [0; 128],
+        data: core::ptr::null(),
+    };
 
-    const fn zeroed_of_device_id() -> bindings::of_device_id {
-        bindings::of_device_id {
-            name: [0; 32],
-            type_: [0; 32],
-            compatible: [0; 128],
-            data: ptr::null(),
-        }
-    }
-
-    const fn new_of_device_id(compatible: &'static CStr) -> bindings::of_device_id {
-        let mut id = Self::zeroed_of_device_id();
-        let compatible = compatible.as_bytes_with_nul();
+    fn to_rawid(&self, offset: isize) -> Self::RawType {
+        let DeviceId::Compatible(compatible) = self;
+        let mut id = Self::ZERO;
         let mut i = 0;
         while i < compatible.len() {
-            // If `compatible` does not fit in `id.compatible`, an
-            // "index out of bounds" build time error will be triggered.
-            id.compatible[i] = compatible[i] as c_types::c_char;
+            // If `compatible` does not fit in `id.compatible`, an "index out of bounds" build time
+            // error will be triggered.
+            id.compatible[i] = compatible[i] as _;
             i += 1;
         }
+        id.compatible[i] = b'\0' as _;
+        id.data = offset as _;
         id
-    }
-}
-
-impl<const N: usize> Deref for ConstOfMatchTable<N> {
-    type Target = OfMatchTable;
-
-    fn deref(&self) -> &OfMatchTable {
-        // INVARIANTS: `head` points to a sentinel-terminated C array,
-        // as per the `ConstOfMatchTable` type invariant, therefore
-        // `&OfMatchTable`'s inner reference will point to a sentinel-terminated C array.
-        let head = &self.table[0] as *const bindings::of_device_id as *const OfMatchTable;
-
-        // SAFETY: The returned reference must remain valid for the lifetime of `self`.
-        // The raw pointer `head` points to memory inside `self`. So the reference created
-        // from this raw pointer has the same lifetime as `self`.
-        // Therefore this reference remains valid for the lifetime of `self`, and
-        // is safe to return.
-        unsafe { &*head }
     }
 }

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Platform devices.
+//! Platform devices and drivers.
 //!
 //! Also called `platdev`, `pdev`.
 //!
@@ -8,145 +8,217 @@
 
 use crate::{
     bindings, c_types,
-    error::{from_kernel_result, Error, Result},
-    of::OfMatchTable,
+    device::{self, RawDevice},
+    driver,
+    error::{from_kernel_result, Result},
+    of,
     str::CStr,
+    to_result,
     types::PointerWrapper,
+    ThisModule,
 };
-use alloc::boxed::Box;
-use core::{marker::PhantomPinned, pin::Pin};
 
-/// A registration of a platform device.
-#[derive(Default)]
-pub struct Registration {
-    registered: bool,
-    pdrv: bindings::platform_driver,
-    _pin: PhantomPinned,
-}
+/// A registration of a platform driver.
+pub type Registration<T> = driver::Registration<Adapter<T>>;
 
-// SAFETY: `Registration` does not expose any of its state across threads
-// (it is fine for multiple threads to have a shared reference to it).
-unsafe impl Sync for Registration {}
+/// An adapter for the registration of platform drivers.
+pub struct Adapter<T: Driver>(T);
 
-extern "C" fn probe_callback<P: PlatformDriver>(
-    pdev: *mut bindings::platform_device,
-) -> c_types::c_int {
-    from_kernel_result! {
-        // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
-        let device_id = unsafe { (*pdev).id };
-        let drv_data = P::probe(device_id)?;
-        let drv_data = drv_data.into_pointer() as *mut c_types::c_void;
-        // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
-        unsafe {
-            bindings::platform_set_drvdata(pdev, drv_data);
-        }
-        Ok(0)
-    }
-}
+impl<T: Driver> driver::DriverOps for Adapter<T> {
+    type RegType = bindings::platform_driver;
 
-extern "C" fn remove_callback<P: PlatformDriver>(
-    pdev: *mut bindings::platform_device,
-) -> c_types::c_int {
-    from_kernel_result! {
-        // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
-        let device_id = unsafe { (*pdev).id };
-        // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
-        let ptr = unsafe { bindings::platform_get_drvdata(pdev) };
-        // SAFETY:
-        //   - we allocated this pointer using `P::DrvData::into_pointer`,
-        //     so it is safe to turn back into a `P::DrvData`.
-        //   - the allocation happened in `probe`, no-one freed the memory,
-        //     `remove` is the canonical kernel location to free driver data. so OK
-        //     to convert the pointer back to a Rust structure here.
-        let drv_data = unsafe { P::DrvData::from_pointer(ptr) };
-        P::remove(device_id, drv_data)?;
-        Ok(0)
-    }
-}
-
-impl Registration {
-    fn register<P: PlatformDriver>(
-        self: Pin<&mut Self>,
+    unsafe fn register(
+        reg: *mut bindings::platform_driver,
         name: &'static CStr,
-        of_match_table: Option<&'static OfMatchTable>,
-        module: &'static crate::ThisModule,
+        module: &'static ThisModule,
     ) -> Result {
-        // SAFETY: We must ensure that we never move out of `this`.
-        let this = unsafe { self.get_unchecked_mut() };
-        if this.registered {
-            // Already registered.
-            return Err(Error::EINVAL);
+        // SAFETY: By the safety requirements of this function (defined in the trait defintion),
+        // `reg` is non-null and valid.
+        let pdrv = unsafe { &mut *reg };
+
+        pdrv.driver.name = name.as_char_ptr();
+        pdrv.probe = Some(Self::probe_callback);
+        pdrv.remove = Some(Self::remove_callback);
+        if let Some(t) = T::OF_DEVICE_ID_TABLE {
+            pdrv.driver.of_match_table = t.as_ref();
         }
-        this.pdrv.driver.name = name.as_char_ptr();
-        if let Some(tbl) = of_match_table {
-            this.pdrv.driver.of_match_table = tbl.as_ptr();
-        }
-        this.pdrv.probe = Some(probe_callback::<P>);
-        this.pdrv.remove = Some(remove_callback::<P>);
         // SAFETY:
-        //   - `this.pdrv` lives at least until the call to `platform_driver_unregister()` returns.
+        //   - `pdrv` lives at least until the call to `platform_driver_unregister()` returns.
         //   - `name` pointer has static lifetime.
         //   - `module.0` lives at least as long as the module.
         //   - `probe()` and `remove()` are static functions.
         //   - `of_match_table` is either a raw pointer with static lifetime,
-        //      as guaranteed by the [`of::OfMatchTable::as_ptr()`] return type,
-        //      or null.
-        let ret = unsafe { bindings::__platform_driver_register(&mut this.pdrv, module.0) };
-        if ret < 0 {
-            return Err(Error::from_kernel_errno(ret));
-        }
-        this.registered = true;
-        Ok(())
+        //      as guaranteed by the [`driver::IdTable`] type, or null.
+        to_result(|| unsafe { bindings::__platform_driver_register(reg, module.0) })
     }
 
-    /// Registers a platform device.
-    ///
-    /// Returns a pinned heap-allocated representation of the registration.
-    pub fn new_pinned<P: PlatformDriver>(
-        name: &'static CStr,
-        of_match_tbl: Option<&'static OfMatchTable>,
-        module: &'static crate::ThisModule,
-    ) -> Result<Pin<Box<Self>>> {
-        let mut r = Pin::from(Box::try_new(Self::default())?);
-        r.as_mut().register::<P>(name, of_match_tbl, module)?;
-        Ok(r)
+    unsafe fn unregister(reg: *mut bindings::platform_driver) {
+        // SAFETY: By the safety requirements of this function (defined in the trait definition),
+        // `reg` was passed (and updated) by a previous successful call to
+        // `platform_driver_register`.
+        unsafe { bindings::platform_driver_unregister(reg) };
     }
 }
 
-impl Drop for Registration {
-    fn drop(&mut self) {
-        if self.registered {
-            // SAFETY: if `registered` is true, then `self.pdev` was registered
-            // previously, which means `platform_driver_unregister` is always
-            // safe to call.
-            unsafe { bindings::platform_driver_unregister(&mut self.pdrv) }
+impl<T: Driver> Adapter<T> {
+    fn get_id_info(dev: &Device) -> Option<&'static T::IdInfo> {
+        let table = T::OF_DEVICE_ID_TABLE?;
+
+        // SAFETY: `table` has static lifetime, so it is valid for read. `dev` is guaranteed to be
+        // valid while it's alive, so is the raw device returned by it.
+        let id = unsafe { bindings::of_match_device(table.as_ref(), dev.raw_device()) };
+        if id.is_null() {
+            return None;
+        }
+
+        // SAFETY: `id` is a pointer within the static table, so it's always valid.
+        let offset = unsafe { (*id).data };
+        if offset.is_null() {
+            return None;
+        }
+
+        // SAFETY: The offset comes from a previous call to `offset_from` in `IdArray::new`, which
+        // guarantees that the resulting pointer is within the table.
+        let ptr = unsafe {
+            id.cast::<u8>()
+                .offset(offset as _)
+                .cast::<Option<T::IdInfo>>()
+        };
+
+        // SAFETY: The id table has a static lifetime, so `ptr` is guaranteed to be valid for read.
+        unsafe { (&*ptr).as_ref() }
+    }
+
+    extern "C" fn probe_callback(pdev: *mut bindings::platform_device) -> c_types::c_int {
+        from_kernel_result! {
+            // SAFETY: `pdev` is valid by the contract with the C code. `dev` is alive only for the
+            // duration of this call, so it is guaranteed to remain alive for the lifetime of
+            // `pdev`.
+            let mut dev = unsafe { Device::from_ptr(pdev) };
+            let info = Self::get_id_info(&dev);
+            let data = T::probe(&mut dev, info)?;
+            // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
+            unsafe { bindings::platform_set_drvdata(pdev, data.into_pointer() as _) };
+            Ok(0)
+        }
+    }
+
+    extern "C" fn remove_callback(pdev: *mut bindings::platform_device) -> c_types::c_int {
+        from_kernel_result! {
+            // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
+            let ptr = unsafe { bindings::platform_get_drvdata(pdev) };
+            // SAFETY:
+            //   - we allocated this pointer using `T::Data::into_pointer`,
+            //     so it is safe to turn back into a `T::Data`.
+            //   - the allocation happened in `probe`, no-one freed the memory,
+            //     `remove` is the canonical kernel location to free driver data. so OK
+            //     to convert the pointer back to a Rust structure here.
+            let data = unsafe { T::Data::from_pointer(ptr) };
+            let ret = T::remove(&data);
+            <T::Data as driver::DeviceRemoval>::device_remove(&data);
+            ret?;
+            Ok(0)
         }
     }
 }
 
-/// Trait for implementers of platform drivers.
-///
-/// Implement this trait whenever you create a platform driver.
-pub trait PlatformDriver {
-    /// Device driver data.
+/// A platform driver.
+pub trait Driver {
+    /// Data stored on device by driver.
     ///
     /// Corresponds to the data set or retrieved via the kernel's
     /// `platform_{set,get}_drvdata()` functions.
     ///
-    /// Require that `DrvData` implements `PointerWrapper`. We guarantee to
+    /// Require that `Data` implements `PointerWrapper`. We guarantee to
     /// never move the underlying wrapped data structure. This allows
-    /// driver writers to use pinned or self-referential data structures.
-    type DrvData: PointerWrapper;
+    type Data: PointerWrapper + Send + Sync + driver::DeviceRemoval = ();
+
+    /// The type holding information about each device id supported by the driver.
+    type IdInfo: 'static = ();
+
+    /// The table of device ids supported by the driver.
+    const OF_DEVICE_ID_TABLE: Option<driver::IdTable<'static, of::DeviceId, Self::IdInfo>> = None;
 
     /// Platform driver probe.
     ///
     /// Called when a new platform device is added or discovered.
     /// Implementers should attempt to initialize the device here.
-    fn probe(device_id: i32) -> Result<Self::DrvData>;
+    fn probe(dev: &mut Device, id_info: Option<&Self::IdInfo>) -> Result<Self::Data>;
 
     /// Platform driver remove.
     ///
     /// Called when a platform device is removed.
     /// Implementers should prepare the device for complete removal here.
-    fn remove(device_id: i32, drv_data: Self::DrvData) -> Result;
+    fn remove(_data: &Self::Data) -> Result {
+        Ok(())
+    }
+}
+
+/// A platform device.
+///
+/// # Invariants
+///
+/// The field `ptr` is non-null and valid for the lifetime of the object.
+pub struct Device {
+    ptr: *mut bindings::platform_device,
+}
+
+impl Device {
+    /// Creates a new device from the given pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null and valid. It must remain valid for the lifetime of the returned
+    /// instance.
+    unsafe fn from_ptr(ptr: *mut bindings::platform_device) -> Self {
+        // INVARIANT: The safety requirements of the function ensure the lifetime invariant.
+        Self { ptr }
+    }
+
+    /// Returns id of the platform device.
+    pub fn id(&self) -> i32 {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { (*self.ptr).id }
+    }
+}
+
+// SAFETY: The device returned by `raw_device` is the raw platform device.
+unsafe impl device::RawDevice for Device {
+    fn raw_device(&self) -> *mut bindings::device {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { &mut (*self.ptr).dev }
+    }
+}
+
+/// Declares a kernel module that exposes a single platform driver.
+///
+/// # Examples
+///
+/// ```ignore
+/// # use kernel::prelude::*;
+/// # use kernel::{platform, define_of_id_table, module_platform_driver};
+/// #
+/// struct MyDriver;
+/// impl platform::Driver for MyDriver {
+///     // [...]
+/// #   fn probe(_dev: &mut platform::Device, _id_info: Option<&Self::IdInfo>) -> Result {
+/// #       Ok(())
+/// #   }
+/// #   define_of_id_table! {(), [
+/// #       (of::DeviceId::Compatible(b"brcm,bcm2835-rng"), None),
+/// #   ]}
+/// }
+///
+/// module_platform_driver! {
+///     type: MyDriver,
+///     name: b"module_name",
+///     author: b"Author name",
+///     license: b"GPL v2",
+/// }
+/// ```
+#[macro_export]
+macro_rules! module_platform_driver {
+    ($($f:tt)*) => {
+        $crate::module_driver!(<T>, $crate::platform::Adapter<T>, { $($f)* });
+    };
 }

--- a/samples/rust/Kconfig
+++ b/samples/rust/Kconfig
@@ -110,4 +110,14 @@ config SAMPLE_RUST_RANDOM
 
 	  If unsure, say N.
 
+config SAMPLE_RUST_PLATFORM
+	tristate "Platform device driver"
+	help
+	  This option builds the Rust platform device driver sample.
+
+	  To compile this as a module, choose M here:
+	  the module will be called rust_platform.
+
+	  If unsure, say N.
+
 endif # SAMPLES_RUST

--- a/samples/rust/Makefile
+++ b/samples/rust/Makefile
@@ -10,3 +10,4 @@ obj-$(CONFIG_SAMPLE_RUST_STACK_PROBING)		+= rust_stack_probing.o
 obj-$(CONFIG_SAMPLE_RUST_SEMAPHORE)		+= rust_semaphore.o
 obj-$(CONFIG_SAMPLE_RUST_SEMAPHORE_C)		+= rust_semaphore_c.o
 obj-$(CONFIG_SAMPLE_RUST_RANDOM)		+= rust_random.o
+obj-$(CONFIG_SAMPLE_RUST_PLATFORM)		+= rust_platform.o

--- a/samples/rust/rust_platform.rs
+++ b/samples/rust/rust_platform.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Rust platform device driver sample.
+
+#![no_std]
+#![feature(allocator_api, global_asm)]
+
+use kernel::{module_platform_driver, of, platform, prelude::*};
+
+module_platform_driver! {
+    type: Driver,
+    name: b"rust_platform",
+    license: b"GPL v2",
+}
+
+struct Driver;
+impl platform::Driver for Driver {
+    kernel::define_of_id_table! {(), [
+        (of::DeviceId::Compatible(b"rust,sample"), None),
+    ]}
+
+    fn probe(_dev: &mut platform::Device, _id_info: Option<&Self::IdInfo>) -> Result {
+        Ok(())
+    }
+}


### PR DESCRIPTION
A platform driver is now defined by implementing a trait, very much like
`amba`. There is also a module macro used that can used if a module is
just a platform driver. Lastly, drivers can specify additional data with
each supported id (to be passed back to them on `probe`).

Please review three commits from this series:
1. rust: update `amba` to use the new constant device id table
2. rust: convert `platform` to use `driver`
3. samples/rust: add platform device driver sample

The compiler changes are temporary. We'll switch to 1.58.0 once it's released in a couple of days. The other commits will be uploaded as separate PRs. 

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>