### PR TITLE
rust: require `Sync` and `Send` on file operations context data

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -23,11 +23,11 @@ struct RngDevice;
 impl FileOperations for RngDevice {
     kernel::declare_file_operations!(read);
 
-    fn open(_open_data: &(), _file: &File) -> Result<Self::Wrapper> {
-        Ok(Box::try_new(RngDevice)?)
+    fn open(_open_data: &(), _file: &File) -> Result {
+        Ok(())
     }
 
-    fn read(_: &Self, _: &File, data: &mut impl IoBufferWriter, offset: u64) -> Result<usize> {
+    fn read(_: (), _: &File, data: &mut impl IoBufferWriter, offset: u64) -> Result<usize> {
         // Succeed if the caller doesn't provide a buffer or if not at the start.
         if data.is_empty() || offset != 0 {
             return Ok(0);

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -4,11 +4,6 @@
 //!
 //! C header: [`include/linux/fs.h`](../../../../include/linux/fs.h)
 
-use core::convert::{TryFrom, TryInto};
-use core::{marker, mem, ptr};
-
-use alloc::boxed::Box;
-
 use crate::{
     bindings, c_types,
     error::{from_kernel_result, Error, Result},
@@ -19,6 +14,8 @@ use crate::{
     types::PointerWrapper,
     user_ptr::{UserSlicePtr, UserSlicePtrReader, UserSlicePtrWriter},
 };
+use core::convert::{TryFrom, TryInto};
+use core::{marker, mem, ptr};
 
 /// Wraps the kernel's `struct poll_table_struct`.
 ///
@@ -589,12 +586,12 @@ pub trait FileOpenAdapter<T: Sync> {
 /// File descriptors may be used from multiple threads/processes concurrently, so your type must be
 /// [`Sync`]. It must also be [`Send`] because [`FileOperations::release`] will be called from the
 /// thread that decrements that associated file's refcount to zero.
-pub trait FileOperations: Send + Sync + Sized + 'static {
+pub trait FileOperations {
     /// The methods to use to populate [`struct file_operations`].
     const TO_USE: ToUse;
 
     /// The pointer type that will be used to hold ourselves.
-    type Wrapper: PointerWrapper = Box<Self>;
+    type Wrapper: PointerWrapper + Send + Sync = ();
 
     /// The type of the context data passed to [`FileOperations::open`].
     type OpenData: Sync = ();

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -21,8 +21,8 @@ struct RustFile;
 impl FileOperations for RustFile {
     kernel::declare_file_operations!();
 
-    fn open(_shared: &(), _file: &file::File) -> Result<Self::Wrapper> {
-        Ok(Box::try_new(RustFile)?)
+    fn open(_shared: &(), _file: &file::File) -> Result {
+        Ok(())
     }
 }
 

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -20,11 +20,11 @@ struct RandomFile;
 impl FileOperations for RandomFile {
     kernel::declare_file_operations!(read, write, read_iter, write_iter);
 
-    fn open(_open_data: &(), _file: &File) -> Result<Self::Wrapper> {
-        Ok(Box::try_new(RandomFile)?)
+    fn open(_data: &(), _file: &File) -> Result {
+        Ok(())
     }
 
-    fn read(_this: &Self, file: &File, buf: &mut impl IoBufferWriter, _: u64) -> Result<usize> {
+    fn read(_this: (), file: &File, buf: &mut impl IoBufferWriter, _: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
 
@@ -42,7 +42,7 @@ impl FileOperations for RandomFile {
         Ok(total_len)
     }
 
-    fn write(_this: &Self, _file: &File, buf: &mut impl IoBufferReader, _: u64) -> Result<usize> {
+    fn write(_this: (), _file: &File, buf: &mut impl IoBufferReader, _: u64) -> Result<usize> {
         let total_len = buf.len();
         let mut chunkbuf = [0; 256];
         while !buf.is_empty() {

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -66,6 +66,7 @@ impl FileState {
 }
 
 impl FileOperations for FileState {
+    type Wrapper = Box<Self>;
     type OpenData = Ref<Semaphore>;
 
     declare_file_operations!(read, write, ioctl);


### PR DESCRIPTION
This is a requirement because a shared reference to the context data can
be used in arbitrary threads (requires `Sync`) and it can be destroyed
in an arbitrary read (requires `Send`), whenever the refcount on the
file goes to zero.

We change the default to `()` so that we don't have to impose the same
requirements on `Self`.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>