### PR TITLE
rust: move all file operation callbacks into `FileOperationsVtable`

### DIFF
--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -78,263 +78,284 @@ pub enum SeekFrom {
     Current(i64),
 }
 
-/// Called by the VFS when an inode should be opened.
-///
-/// Calls `T::open` on the returned value of `A::convert`.
-///
-/// # Safety
-///
-/// The returned value of `A::convert` must be a valid non-null pointer and
-/// `T:open` must return a valid non-null pointer on an `Ok` result.
-unsafe extern "C" fn open_callback<A: FileOpenAdapter<T::OpenData>, T: FileOperations>(
-    inode: *mut bindings::inode,
-    file: *mut bindings::file,
-) -> c_types::c_int {
-    from_kernel_result! {
-        // SAFETY: `A::convert` must return a valid non-null pointer that
-        // should point to data in the inode or file that lives longer
-        // than the following use of `T::open`.
-        let arg = unsafe { A::convert(inode, file) };
-        // SAFETY: The C contract guarantees that `file` is valid. Additionally,
-        // `fileref` never outlives this function, so it is guaranteed to be
-        // valid.
-        let fileref = unsafe { FileRef::from_ptr(file) };
-        // SAFETY: `arg` was previously returned by `A::convert` and must
-        // be a valid non-null pointer.
-        let ptr = T::open(unsafe { &*arg }, &fileref)?.into_pointer();
-        // SAFETY: The C contract guarantees that `private_data` is available
-        // for implementers of the file operations (no other C code accesses
-        // it), so we know that there are no concurrent threads/CPUs accessing
-        // it (it's not visible to any other Rust code).
-        unsafe { (*file).private_data = ptr as *mut c_types::c_void };
-        Ok(0)
-    }
-}
-
-unsafe extern "C" fn read_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    buf: *mut c_types::c_char,
-    len: c_types::c_size_t,
-    offset: *mut bindings::loff_t,
-) -> c_types::c_ssize_t {
-    from_kernel_result! {
-        let mut data = unsafe { UserSlicePtr::new(buf as *mut c_types::c_void, len).writer() };
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
-        // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
-        let read = T::read(f, unsafe { &FileRef::from_ptr(file) }, &mut data, unsafe { *offset }.try_into()?)?;
-        unsafe { (*offset) += bindings::loff_t::try_from(read).unwrap() };
-        Ok(read as _)
-    }
-}
-
-unsafe extern "C" fn read_iter_callback<T: FileOperations>(
-    iocb: *mut bindings::kiocb,
-    raw_iter: *mut bindings::iov_iter,
-) -> isize {
-    from_kernel_result! {
-        let mut iter = unsafe { IovIter::from_ptr(raw_iter) };
-        let file = unsafe { (*iocb).ki_filp };
-        let offset = unsafe { (*iocb).ki_pos };
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        let read = T::read(f, unsafe { &FileRef::from_ptr(file) }, &mut iter, offset.try_into()?)?;
-        unsafe { (*iocb).ki_pos += bindings::loff_t::try_from(read).unwrap() };
-        Ok(read as _)
-    }
-}
-
-unsafe extern "C" fn write_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    buf: *const c_types::c_char,
-    len: c_types::c_size_t,
-    offset: *mut bindings::loff_t,
-) -> c_types::c_ssize_t {
-    from_kernel_result! {
-        let mut data = unsafe { UserSlicePtr::new(buf as *mut c_types::c_void, len).reader() };
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
-        // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
-        let written = T::write(f, unsafe { &FileRef::from_ptr(file) }, &mut data, unsafe { *offset }.try_into()?)?;
-        unsafe { (*offset) += bindings::loff_t::try_from(written).unwrap() };
-        Ok(written as _)
-    }
-}
-
-unsafe extern "C" fn write_iter_callback<T: FileOperations>(
-    iocb: *mut bindings::kiocb,
-    raw_iter: *mut bindings::iov_iter,
-) -> isize {
-    from_kernel_result! {
-        let mut iter = unsafe { IovIter::from_ptr(raw_iter) };
-        let file = unsafe { (*iocb).ki_filp };
-        let offset = unsafe { (*iocb).ki_pos };
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        let written = T::write(f, unsafe { &FileRef::from_ptr(file) }, &mut iter, offset.try_into()?)?;
-        unsafe { (*iocb).ki_pos += bindings::loff_t::try_from(written).unwrap() };
-        Ok(written as _)
-    }
-}
-
-unsafe extern "C" fn release_callback<T: FileOperations>(
-    _inode: *mut bindings::inode,
-    file: *mut bindings::file,
-) -> c_types::c_int {
-    let ptr = mem::replace(unsafe { &mut (*file).private_data }, ptr::null_mut());
-    T::release(unsafe { T::Wrapper::from_pointer(ptr as _) }, unsafe {
-        &FileRef::from_ptr(file)
-    });
-    0
-}
-
-unsafe extern "C" fn llseek_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    offset: bindings::loff_t,
-    whence: c_types::c_int,
-) -> bindings::loff_t {
-    from_kernel_result! {
-        let off = match whence as u32 {
-            bindings::SEEK_SET => SeekFrom::Start(offset.try_into()?),
-            bindings::SEEK_CUR => SeekFrom::Current(offset),
-            bindings::SEEK_END => SeekFrom::End(offset),
-            _ => return Err(Error::EINVAL),
-        };
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        let off = T::seek(f, unsafe { &FileRef::from_ptr(file) }, off)?;
-        Ok(off as bindings::loff_t)
-    }
-}
-
-unsafe extern "C" fn unlocked_ioctl_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    cmd: c_types::c_uint,
-    arg: c_types::c_ulong,
-) -> c_types::c_long {
-    from_kernel_result! {
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        let mut cmd = IoctlCommand::new(cmd as _, arg as _);
-        let ret = T::ioctl(f, unsafe { &FileRef::from_ptr(file) }, &mut cmd)?;
-        Ok(ret as _)
-    }
-}
-
-unsafe extern "C" fn compat_ioctl_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    cmd: c_types::c_uint,
-    arg: c_types::c_ulong,
-) -> c_types::c_long {
-    from_kernel_result! {
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        let mut cmd = IoctlCommand::new(cmd as _, arg as _);
-        let ret = T::compat_ioctl(f, unsafe { &FileRef::from_ptr(file) }, &mut cmd)?;
-        Ok(ret as _)
-    }
-}
-
-unsafe extern "C" fn mmap_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    vma: *mut bindings::vm_area_struct,
-) -> c_types::c_int {
-    from_kernel_result! {
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        T::mmap(f, unsafe { &FileRef::from_ptr(file) }, unsafe { &mut *vma })?;
-        Ok(0)
-    }
-}
-
-unsafe extern "C" fn fsync_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    start: bindings::loff_t,
-    end: bindings::loff_t,
-    datasync: c_types::c_int,
-) -> c_types::c_int {
-    from_kernel_result! {
-        let start = start.try_into()?;
-        let end = end.try_into()?;
-        let datasync = datasync != 0;
-        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-        // callback, which the C API guarantees that will be called only when all references to
-        // `file` have been released, so we know it can't be called while this function is running.
-        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-        let res = T::fsync(f, unsafe { &FileRef::from_ptr(file) }, start, end, datasync)?;
-        Ok(res.try_into().unwrap())
-    }
-}
-
-unsafe extern "C" fn poll_callback<T: FileOperations>(
-    file: *mut bindings::file,
-    wait: *mut bindings::poll_table_struct,
-) -> bindings::__poll_t {
-    // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
-    // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
-    // callback, which the C API guarantees that will be called only when all references to `file`
-    // have been released, so we know it can't be called while this function is running.
-    let f = unsafe { T::Wrapper::borrow((*file).private_data) };
-    match T::poll(f, unsafe { &FileRef::from_ptr(file) }, unsafe {
-        &PollTable::from_ptr(wait)
-    }) {
-        Ok(v) => v,
-        Err(_) => bindings::POLLERR,
-    }
-}
-
 pub(crate) struct FileOperationsVtable<A, T>(marker::PhantomData<A>, marker::PhantomData<T>);
 
 impl<A: FileOpenAdapter<T::OpenData>, T: FileOperations> FileOperationsVtable<A, T> {
+    /// Called by the VFS when an inode should be opened.
+    ///
+    /// Calls `T::open` on the returned value of `A::convert`.
+    ///
+    /// # Safety
+    ///
+    /// The returned value of `A::convert` must be a valid non-null pointer and
+    /// `T:open` must return a valid non-null pointer on an `Ok` result.
+    unsafe extern "C" fn open_callback(
+        inode: *mut bindings::inode,
+        file: *mut bindings::file,
+    ) -> c_types::c_int {
+        from_kernel_result! {
+            // SAFETY: `A::convert` must return a valid non-null pointer that
+            // should point to data in the inode or file that lives longer
+            // than the following use of `T::open`.
+            let arg = unsafe { A::convert(inode, file) };
+            // SAFETY: The C contract guarantees that `file` is valid. Additionally,
+            // `fileref` never outlives this function, so it is guaranteed to be
+            // valid.
+            let fileref = unsafe { FileRef::from_ptr(file) };
+            // SAFETY: `arg` was previously returned by `A::convert` and must
+            // be a valid non-null pointer.
+            let ptr = T::open(unsafe { &*arg }, &fileref)?.into_pointer();
+            // SAFETY: The C contract guarantees that `private_data` is available
+            // for implementers of the file operations (no other C code accesses
+            // it), so we know that there are no concurrent threads/CPUs accessing
+            // it (it's not visible to any other Rust code).
+            unsafe { (*file).private_data = ptr as *mut c_types::c_void };
+            Ok(0)
+        }
+    }
+
+    unsafe extern "C" fn read_callback(
+        file: *mut bindings::file,
+        buf: *mut c_types::c_char,
+        len: c_types::c_size_t,
+        offset: *mut bindings::loff_t,
+    ) -> c_types::c_ssize_t {
+        from_kernel_result! {
+            let mut data = unsafe { UserSlicePtr::new(buf as *mut c_types::c_void, len).writer() };
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
+            // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
+            let read = T::read(
+                f,
+                unsafe { &FileRef::from_ptr(file) },
+                &mut data,
+                unsafe { *offset }.try_into()?,
+            )?;
+            unsafe { (*offset) += bindings::loff_t::try_from(read).unwrap() };
+            Ok(read as _)
+        }
+    }
+
+    unsafe extern "C" fn read_iter_callback(
+        iocb: *mut bindings::kiocb,
+        raw_iter: *mut bindings::iov_iter,
+    ) -> isize {
+        from_kernel_result! {
+            let mut iter = unsafe { IovIter::from_ptr(raw_iter) };
+            let file = unsafe { (*iocb).ki_filp };
+            let offset = unsafe { (*iocb).ki_pos };
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            let read =
+                T::read(f, unsafe { &FileRef::from_ptr(file) }, &mut iter, offset.try_into()?)?;
+            unsafe { (*iocb).ki_pos += bindings::loff_t::try_from(read).unwrap() };
+            Ok(read as _)
+        }
+    }
+
+    unsafe extern "C" fn write_callback(
+        file: *mut bindings::file,
+        buf: *const c_types::c_char,
+        len: c_types::c_size_t,
+        offset: *mut bindings::loff_t,
+    ) -> c_types::c_ssize_t {
+        from_kernel_result! {
+            let mut data = unsafe { UserSlicePtr::new(buf as *mut c_types::c_void, len).reader() };
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
+            // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
+            let written = T::write(
+                f,
+                unsafe { &FileRef::from_ptr(file) },
+                &mut data,
+                unsafe { *offset }.try_into()?
+            )?;
+            unsafe { (*offset) += bindings::loff_t::try_from(written).unwrap() };
+            Ok(written as _)
+        }
+    }
+
+    unsafe extern "C" fn write_iter_callback(
+        iocb: *mut bindings::kiocb,
+        raw_iter: *mut bindings::iov_iter,
+    ) -> isize {
+        from_kernel_result! {
+            let mut iter = unsafe { IovIter::from_ptr(raw_iter) };
+            let file = unsafe { (*iocb).ki_filp };
+            let offset = unsafe { (*iocb).ki_pos };
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            let written =
+                T::write(f, unsafe { &FileRef::from_ptr(file) }, &mut iter, offset.try_into()?)?;
+            unsafe { (*iocb).ki_pos += bindings::loff_t::try_from(written).unwrap() };
+            Ok(written as _)
+        }
+    }
+
+    unsafe extern "C" fn release_callback(
+        _inode: *mut bindings::inode,
+        file: *mut bindings::file,
+    ) -> c_types::c_int {
+        let ptr = mem::replace(unsafe { &mut (*file).private_data }, ptr::null_mut());
+        T::release(unsafe { T::Wrapper::from_pointer(ptr as _) }, unsafe {
+            &FileRef::from_ptr(file)
+        });
+        0
+    }
+
+    unsafe extern "C" fn llseek_callback(
+        file: *mut bindings::file,
+        offset: bindings::loff_t,
+        whence: c_types::c_int,
+    ) -> bindings::loff_t {
+        from_kernel_result! {
+            let off = match whence as u32 {
+                bindings::SEEK_SET => SeekFrom::Start(offset.try_into()?),
+                bindings::SEEK_CUR => SeekFrom::Current(offset),
+                bindings::SEEK_END => SeekFrom::End(offset),
+                _ => return Err(Error::EINVAL),
+            };
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            let off = T::seek(f, unsafe { &FileRef::from_ptr(file) }, off)?;
+            Ok(off as bindings::loff_t)
+        }
+    }
+
+    unsafe extern "C" fn unlocked_ioctl_callback(
+        file: *mut bindings::file,
+        cmd: c_types::c_uint,
+        arg: c_types::c_ulong,
+    ) -> c_types::c_long {
+        from_kernel_result! {
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            let mut cmd = IoctlCommand::new(cmd as _, arg as _);
+            let ret = T::ioctl(f, unsafe { &FileRef::from_ptr(file) }, &mut cmd)?;
+            Ok(ret as _)
+        }
+    }
+
+    unsafe extern "C" fn compat_ioctl_callback(
+        file: *mut bindings::file,
+        cmd: c_types::c_uint,
+        arg: c_types::c_ulong,
+    ) -> c_types::c_long {
+        from_kernel_result! {
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            let mut cmd = IoctlCommand::new(cmd as _, arg as _);
+            let ret = T::compat_ioctl(f, unsafe { &FileRef::from_ptr(file) }, &mut cmd)?;
+            Ok(ret as _)
+        }
+    }
+
+    unsafe extern "C" fn mmap_callback(
+        file: *mut bindings::file,
+        vma: *mut bindings::vm_area_struct,
+    ) -> c_types::c_int {
+        from_kernel_result! {
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            T::mmap(f, unsafe { &FileRef::from_ptr(file) }, unsafe { &mut *vma })?;
+            Ok(0)
+        }
+    }
+
+    unsafe extern "C" fn fsync_callback(
+        file: *mut bindings::file,
+        start: bindings::loff_t,
+        end: bindings::loff_t,
+        datasync: c_types::c_int,
+    ) -> c_types::c_int {
+        from_kernel_result! {
+            let start = start.try_into()?;
+            let end = end.try_into()?;
+            let datasync = datasync != 0;
+            // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+            // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the
+            // `release` callback, which the C API guarantees that will be called only when all
+            // references to `file` have been released, so we know it can't be called while this
+            // function is running.
+            let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+            let res = T::fsync(f, unsafe { &FileRef::from_ptr(file) }, start, end, datasync)?;
+            Ok(res.try_into().unwrap())
+        }
+    }
+
+    unsafe extern "C" fn poll_callback(
+        file: *mut bindings::file,
+        wait: *mut bindings::poll_table_struct,
+    ) -> bindings::__poll_t {
+        // SAFETY: `private_data` was initialised by `open_callback` with a value returned by
+        // `T::Wrapper::into_pointer`. `T::Wrapper::from_pointer` is only called by the `release`
+        // callback, which the C API guarantees that will be called only when all references to
+        // `file` have been released, so we know it can't be called while this function is running.
+        let f = unsafe { T::Wrapper::borrow((*file).private_data) };
+        match T::poll(f, unsafe { &FileRef::from_ptr(file) }, unsafe {
+            &PollTable::from_ptr(wait)
+        }) {
+            Ok(v) => v,
+            Err(_) => bindings::POLLERR,
+        }
+    }
+
     const VTABLE: bindings::file_operations = bindings::file_operations {
-        open: Some(open_callback::<A, T>),
-        release: Some(release_callback::<T>),
+        open: Some(Self::open_callback),
+        release: Some(Self::release_callback),
         read: if T::TO_USE.read {
-            Some(read_callback::<T>)
+            Some(Self::read_callback)
         } else {
             None
         },
         write: if T::TO_USE.write {
-            Some(write_callback::<T>)
+            Some(Self::write_callback)
         } else {
             None
         },
         llseek: if T::TO_USE.seek {
-            Some(llseek_callback::<T>)
+            Some(Self::llseek_callback)
         } else {
             None
         },
 
         check_flags: None,
         compat_ioctl: if T::TO_USE.compat_ioctl {
-            Some(compat_ioctl_callback::<T>)
+            Some(Self::compat_ioctl_callback)
         } else {
             None
         },
@@ -345,7 +366,7 @@ impl<A: FileOpenAdapter<T::OpenData>, T: FileOperations> FileOperationsVtable<A,
         flock: None,
         flush: None,
         fsync: if T::TO_USE.fsync {
-            Some(fsync_callback::<T>)
+            Some(Self::fsync_callback)
         } else {
             None
         },
@@ -355,19 +376,19 @@ impl<A: FileOpenAdapter<T::OpenData>, T: FileOperations> FileOperationsVtable<A,
         iopoll: None,
         lock: None,
         mmap: if T::TO_USE.mmap {
-            Some(mmap_callback::<T>)
+            Some(Self::mmap_callback)
         } else {
             None
         },
         mmap_supported_flags: 0,
         owner: ptr::null_mut(),
         poll: if T::TO_USE.poll {
-            Some(poll_callback::<T>)
+            Some(Self::poll_callback)
         } else {
             None
         },
         read_iter: if T::TO_USE.read_iter {
-            Some(read_iter_callback::<T>)
+            Some(Self::read_iter_callback)
         } else {
             None
         },
@@ -378,12 +399,12 @@ impl<A: FileOpenAdapter<T::OpenData>, T: FileOperations> FileOperationsVtable<A,
         splice_read: None,
         splice_write: None,
         unlocked_ioctl: if T::TO_USE.ioctl {
-            Some(unlocked_ioctl_callback::<T>)
+            Some(Self::unlocked_ioctl_callback)
         } else {
             None
         },
         write_iter: if T::TO_USE.write_iter {
-            Some(write_iter_callback::<T>)
+            Some(Self::write_iter_callback)
         } else {
             None
         },


### PR DESCRIPTION
This is a pure refactor with no functional change intended.

Since the callbacks are only used to build the table, they logically
belong together; it also obviates the need to repeat the generic
parameter and bound `T: FileOperations` in all callbacks.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>