### PR TITLE
hw_random: depend on `RUST`, not `HAS_RUST`

### DIFF
--- a/drivers/char/hw_random/Kconfig
+++ b/drivers/char/hw_random/Kconfig
@@ -100,7 +100,7 @@ config HW_RANDOM_BCM2835
 
 config HW_RANDOM_BCM2835_RUST
 	tristate "Rust implementation of Broadcom BCM2835 Random Number Generator"
-	depends on HAS_RUST && ARCH_BCM2835
+	depends on RUST && ARCH_BCM2835
 	help
 	  This driver provides alternative Rust-based kernel-side support
 	  for the Random Number Generator hardware found on the Broadcom


### PR DESCRIPTION
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>