### PR TITLE
include: make `rust.h` private to `lib`

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16590,7 +16590,7 @@ T:	git https://github.com/Rust-for-Linux/linux.git rust-next
 F:	rust/
 F:	samples/rust/
 F:	Documentation/rust/
-F:	include/linux/rust.h
+F:	lib/rust.h
 K:	\b(?i:rust)\b
 
 RXRPC SOCKETS (AF_RXRPC)

--- a/lib/rust.h
+++ b/lib/rust.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-#ifndef __LINUX_RUST_H
-#define __LINUX_RUST_H
+#ifndef _LIB_RUST_H
+#define _LIB_RUST_H
 
 #ifdef CONFIG_RUST
 char *rust_fmt_argument(char* buf, char* end, void *ptr);
@@ -11,4 +11,4 @@ static inline char *rust_fmt_argument(char* buf, char* end, void *ptr)
 }
 #endif
 
-#endif /* __LINUX_RUST_H */
+#endif /* _LIB_RUST_H */

--- a/lib/vsprintf.c
+++ b/lib/vsprintf.c
@@ -41,7 +41,6 @@
 #include <linux/siphash.h>
 #include <linux/compiler.h>
 #include <linux/property.h>
-#include <linux/rust.h>
 #ifdef CONFIG_BLOCK
 #include <linux/blkdev.h>
 #endif
@@ -53,6 +52,7 @@
 
 #include <linux/string_helpers.h>
 #include "kstrtox.h"
+#include "rust.h"
 
 static noinline unsigned long long simple_strntoull(const char *startp, size_t max_chars, char **endp, unsigned int base)
 {


### PR DESCRIPTION
No need to have it available for others (at least in this case).

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>