### PR TITLE
rust: add `dev_*` print macros.

### DIFF
--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -19,7 +19,10 @@ pub use macros::module;
 
 pub use super::build_assert;
 
-pub use super::{dbg, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info, pr_notice, pr_warn};
+pub use super::{
+    dbg, dev_alert, dev_crit, dev_dbg, dev_emerg, dev_err, dev_info, dev_notice, dev_warn,
+    pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info, pr_notice, pr_warn,
+};
 
 pub use super::module_misc_device;
 


### PR DESCRIPTION
It behaves like the macros with the same names in C, i.e., it prints
messages to the console with the given level, and prefixes the message
with device information.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>