### PR TITLE
rust: simplify lock guards by using marker types

### DIFF
--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -5,7 +5,7 @@ use kernel::{
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, Links, List},
     prelude::*,
-    sync::{GuardMut, LockedBy, Mutex, Ref, SpinLock},
+    sync::{Guard, LockedBy, Mutex, Ref, SpinLock},
     user_ptr::UserSlicePtrWriter,
 };
 
@@ -244,7 +244,7 @@ impl Node {
 
     pub(crate) fn next_death(
         &self,
-        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
+        guard: &mut Guard<'_, Mutex<ProcessInner>>,
     ) -> Option<Ref<NodeDeath>> {
         self.inner.access_mut(guard).death_list.pop_front()
     }
@@ -252,7 +252,7 @@ impl Node {
     pub(crate) fn add_death(
         &self,
         death: Ref<NodeDeath>,
-        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
+        guard: &mut Guard<'_, Mutex<ProcessInner>>,
     ) {
         self.inner.access_mut(guard).death_list.push_back(death);
     }
@@ -306,7 +306,7 @@ impl Node {
     pub(crate) fn populate_counts(
         &self,
         out: &mut BinderNodeInfoForRef,
-        guard: &GuardMut<'_, Mutex<ProcessInner>>,
+        guard: &Guard<'_, Mutex<ProcessInner>>,
     ) {
         let inner = self.inner.access(guard);
         out.strong_count = inner.strong.count as _;
@@ -316,7 +316,7 @@ impl Node {
     pub(crate) fn populate_debug_info(
         &self,
         out: &mut BinderNodeDebugInfo,
-        guard: &GuardMut<'_, Mutex<ProcessInner>>,
+        guard: &Guard<'_, Mutex<ProcessInner>>,
     ) {
         out.ptr = self.ptr as _;
         out.cookie = self.cookie as _;
@@ -329,7 +329,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn force_has_count(&self, guard: &mut GuardMut<'_, Mutex<ProcessInner>>) {
+    pub(crate) fn force_has_count(&self, guard: &mut Guard<'_, Mutex<ProcessInner>>) {
         let inner = self.inner.access_mut(guard);
         inner.strong.has_count = true;
         inner.weak.has_count = true;

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -11,7 +11,7 @@ use kernel::{
     pages::Pages,
     prelude::*,
     rbtree::RBTree,
-    sync::{GuardMut, Mutex, Ref, RefBorrow, UniqueRef},
+    sync::{Guard, Mutex, Ref, RefBorrow, UniqueRef},
     task::Task,
     user_ptr::{UserSlicePtr, UserSlicePtrReader},
 };
@@ -949,7 +949,7 @@ impl<'a> Registration<'a> {
     fn new(
         process: &'a Process,
         thread: &'a Ref<Thread>,
-        guard: &mut GuardMut<'_, Mutex<ProcessInner>>,
+        guard: &mut Guard<'_, Mutex<ProcessInner>>,
     ) -> Self {
         guard.ready_threads.push_back(thread.clone());
         Self { process, thread }

--- a/rust/kernel/sync/locked_by.rs
+++ b/rust/kernel/sync/locked_by.rs
@@ -2,7 +2,7 @@
 
 //! A wrapper for data protected by a lock that does not wrap it.
 
-use super::{GuardMut, Lock};
+use super::{Guard, Lock};
 use core::{cell::UnsafeCell, ops::Deref, ptr};
 
 /// Allows access to some data to be serialised by a lock that does not wrap it.
@@ -77,8 +77,8 @@ impl<T, L: Lock + ?Sized> LockedBy<T, L> {
 
 impl<T: ?Sized, L: Lock + ?Sized> LockedBy<T, L> {
     /// Returns a reference to the protected data when the caller provides evidence (via a
-    /// [`GuardMut`]) that the owner is locked.
-    pub fn access<'a>(&'a self, guard: &'a GuardMut<'_, L>) -> &'a T {
+    /// [`Guard`]) that the owner is locked.
+    pub fn access<'a>(&'a self, guard: &'a Guard<'_, L>) -> &'a T {
         if !ptr::eq(guard.deref(), self.owner) {
             panic!("guard does not match owner");
         }
@@ -88,8 +88,8 @@ impl<T: ?Sized, L: Lock + ?Sized> LockedBy<T, L> {
     }
 
     /// Returns a mutable reference to the protected data when the caller provides evidence (via a
-    /// mutable [`GuardMut`]) that the owner is locked mutably.
-    pub fn access_mut<'a>(&'a self, guard: &'a mut GuardMut<'_, L>) -> &'a mut T {
+    /// mutable [`Guard`]) that the owner is locked mutably.
+    pub fn access_mut<'a>(&'a self, guard: &'a mut Guard<'_, L>) -> &'a mut T {
         if !ptr::eq(guard.deref().deref(), self.owner) {
             panic!("guard does not match owner");
         }

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -34,7 +34,7 @@ mod spinlock;
 
 pub use arc::{Ref, RefBorrow, UniqueRef};
 pub use condvar::CondVar;
-pub use guard::{CreatableLock, Guard, GuardMut, Lock};
+pub use guard::{CreatableLock, Guard, Lock, ReadLock, WriteLock};
 pub use locked_by::LockedBy;
 pub use mutex::Mutex;
 pub use revocable_mutex::{RevocableMutex, RevocableMutexGuard};

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -4,7 +4,7 @@
 //!
 //! This module allows Rust code to use the kernel's [`struct mutex`].
 
-use super::{CreatableLock, GuardMut, Lock};
+use super::{CreatableLock, Guard, Lock};
 use crate::{bindings, str::CStr, Opaque};
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
 
@@ -65,10 +65,10 @@ impl<T> Mutex<T> {
 impl<T: ?Sized> Mutex<T> {
     /// Locks the mutex and gives the caller access to the data protected by it. Only one thread at
     /// a time is allowed to access the protected data.
-    pub fn lock(&self) -> GuardMut<'_, Self> {
+    pub fn lock(&self) -> Guard<'_, Self> {
         let ctx = self.lock_noguard();
         // SAFETY: The mutex was just acquired.
-        unsafe { GuardMut::new(self, ctx) }
+        unsafe { Guard::new(self, ctx) }
     }
 }
 

--- a/rust/kernel/sync/revocable_mutex.rs
+++ b/rust/kernel/sync/revocable_mutex.rs
@@ -5,7 +5,7 @@
 use crate::{
     bindings,
     str::CStr,
-    sync::{GuardMut, Mutex, NeedsLockClass},
+    sync::{Guard, Mutex, NeedsLockClass},
 };
 use core::{
     mem::ManuallyDrop,
@@ -153,11 +153,11 @@ impl<T: ?Sized> Drop for RevocableMutex<T> {
 
 /// A guard that allows access to a revocable object and keeps it alive.
 pub struct RevocableMutexGuard<'a, T: ?Sized> {
-    guard: GuardMut<'a, Mutex<RevocableMutexInner<T>>>,
+    guard: Guard<'a, Mutex<RevocableMutexInner<T>>>,
 }
 
 impl<'a, T: ?Sized> RevocableMutexGuard<'a, T> {
-    fn new(guard: GuardMut<'a, Mutex<RevocableMutexInner<T>>>) -> Self {
+    fn new(guard: Guard<'a, Mutex<RevocableMutexInner<T>>>) -> Self {
         Self { guard }
     }
 


### PR DESCRIPTION
Unify `Guard` and `GuardMut` into a single type parametrised by a
marker. The new guard implementation is the same as the existing `Guard`
except that if the marker is `WriteLock`, it also implements `DerefMut`
(which was only implemented by `GuardMut` previously).

This is in preparation for adding abstractions for read/write locks,
which means that a single lock primitive needs to implement the `Lock`
primitive in both shared and mutable modes, which is enabled by this
change as well.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>