### PR TITLE
rust: avoid the need of crate attributes in kernel modules

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -4,9 +4,6 @@
 //!
 //! TODO: This module is a work in progress.
 
-#![no_std]
-#![feature(global_asm, allocator_api, concat_idents, generic_associated_types)]
-
 use kernel::{
     io_buffer::IoBufferWriter,
     linked_list::{GetLinks, GetLinksWrapped, Links},

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -2,9 +2,6 @@
 
 //! Broadcom BCM2835 Random Number Generator support.
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::{
     c_str, device, file::File, file_operations::FileOperations, io_buffer::IoBufferWriter, miscdev,
     module_platform_driver, of, platform, prelude::*, sync::Ref,

--- a/drivers/gpio/gpio_pl061_rust.rs
+++ b/drivers/gpio/gpio_pl061_rust.rs
@@ -4,9 +4,6 @@
 //!
 //! Based on the C driver written by Baruch Siach <baruch@tkos.co.il>.
 
-#![no_std]
-#![feature(global_asm, allocator_api)]
-
 use kernel::{
     amba, bit, bits_iter, define_amba_id_table, device, gpio,
     io_mem::IoMem,

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -2,9 +2,6 @@
 
 //! Rust character device sample
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::prelude::*;
 use kernel::{chrdev, file, file_operations::FileOperations};
 

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -2,9 +2,6 @@
 
 //! Rust minimal sample
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::prelude::*;
 
 module! {

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -2,9 +2,6 @@
 
 //! Rust miscellaneous device sample
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::prelude::*;
 use kernel::{
     file::File,

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -2,9 +2,6 @@
 
 //! Rust module parameters sample
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::prelude::*;
 
 module! {

--- a/samples/rust/rust_platform.rs
+++ b/samples/rust/rust_platform.rs
@@ -2,9 +2,6 @@
 
 //! Rust platform device driver sample.
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::{module_platform_driver, of, platform, prelude::*};
 
 module_platform_driver! {

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -2,9 +2,6 @@
 
 //! Rust printing macros sample
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::prelude::*;
 use kernel::{pr_cont, str::CStr, ThisModule};
 

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -5,9 +5,6 @@
 //! Adapted from Alex Gaynor's original available at
 //! <https://github.com/alex/just-use/blob/master/src/lib.rs>.
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::{
     file::File,
     file_operations::FileOperations,

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -13,9 +13,6 @@
 //! before decrementing); `echo -n 123 > semaphore` increments the semaphore by 3, potentially
 //! unblocking up to 3 blocked readers.
 
-#![no_std]
-#![feature(allocator_api, global_asm, generic_associated_types)]
-
 use core::sync::atomic::{AtomicU64, Ordering};
 use kernel::{
     condvar_init, declare_file_operations,

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -2,10 +2,6 @@
 
 //! Rust stack probing sample
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-#![feature(bench_black_box)]
-
 use kernel::prelude::*;
 
 module! {

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -2,9 +2,6 @@
 
 //! Rust synchronisation primitives sample
 
-#![no_std]
-#![feature(allocator_api, global_asm)]
-
 use kernel::prelude::*;
 use kernel::{
     condvar_init, mutex_init, spinlock_init,

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -331,11 +331,15 @@ $(obj)/%.lst: $(src)/%.c FORCE
 # otherwise rustdoc and rustc compute different hashes for the target.
 rust_cross_flags := --target=$(realpath $(KBUILD_RUST_TARGET))
 
+rust_allowed_features := allocator_api,bench_black_box,concat_idents,generic_associated_types,global_asm
+
 quiet_cmd_rustc_o_rs = $(RUSTC_OR_CLIPPY_QUIET) $(quiet_modtag) $@
       cmd_rustc_o_rs = \
 	RUST_MODFILE=$(modfile) \
 	$(RUSTC_OR_CLIPPY) $(rust_flags) $(rust_cross_flags) \
-		-Zallow-features=allocator_api,bench_black_box,concat_idents,generic_associated_types,global_asm \
+		-Zallow-features=$(rust_allowed_features) \
+		-Zcrate-attr=no_std \
+		-Zcrate-attr='feature($(rust_allowed_features))' \
 		--extern alloc --extern kernel \
 		--crate-type rlib --out-dir $(obj) -L $(objtree)/rust/ \
 		--crate-name $(patsubst %.o,%,$(notdir $@)) $<; \


### PR DESCRIPTION
Instead of enabling the features per-module, do it globally.
This removes the need to write boilerplate such as `#![no_std]`
in kernel modules, which does not bring much value given
the allowed features are constrained anyway.

There is the question of whether to enable only the most common ones
(`allocator_api` and `global_asm`) in order to easily see uncommon
features being used. However, we only have other three features,
and they are either going to get stabilized/workarounded/removed
at some point and/or they are easy to spot anyway.

We are using `-Zcrate-attr` for convenience here, but we do not
really depend on it: like for other unstable features, if this was
the last feature to get stabilized, we would simply workaround it.
Furthermore, it is likely we will change how modules are compiled
in a way that makes this not needed.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>