### PR TITLE
rust: Remove unused including <linux/version.h>

### DIFF
--- a/rust/kernel/bindings_helper.h
+++ b/rust/kernel/bindings_helper.h
@@ -10,7 +10,6 @@
 #include <linux/sysctl.h>
 #include <linux/uaccess.h>
 #include <linux/uio.h>
-#include <linux/version.h>
 #include <linux/miscdevice.h>
 #include <linux/poll.h>
 #include <linux/mm.h>


### PR DESCRIPTION
Eliminate the follow versioncheck warning:

./rust/kernel/bindings_helper.h: 13 linux/version.h not needed.

Reported-by: Abaci Robot <abaci@linux.alibaba.com>
Signed-off-by: Jiapeng Chong <jiapeng.chong@linux.alibaba.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>