### PR TITLE
rust: add optional parameters to the registration of misc devices

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -105,7 +105,7 @@ struct BinderModule {
 impl KernelModule for BinderModule {
     fn init(name: &'static CStr, _module: &'static kernel::ThisModule) -> Result<Self> {
         let ctx = Context::new()?;
-        let reg = Registration::new_pinned(name, None, ctx)?;
+        let reg = Registration::new_pinned(name, ctx)?;
         Ok(Self { _reg: reg })
     }
 }

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -57,7 +57,7 @@ impl platform::Driver for RngDriver {
         data.registrations()
             .ok_or(Error::ENXIO)?
             .as_pinned_mut()
-            .register(c_str!("rust_hwrng"), None, ())?;
+            .register(c_str!("rust_hwrng"), ())?;
         Ok(data.into())
     }
 }

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -132,7 +132,7 @@ impl KernelModule for RustMiscdev {
         let state = SharedState::try_new()?;
 
         Ok(RustMiscdev {
-            _dev: miscdev::Registration::new_pinned(name, None, state)?,
+            _dev: miscdev::Registration::new_pinned(name, state)?,
         })
     }
 }

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -133,7 +133,7 @@ impl KernelModule for RustSemaphore {
         mutex_init!(pinned, "Semaphore::inner");
 
         Ok(Self {
-            _dev: Registration::new_pinned(name, None, sema.into())?,
+            _dev: Registration::new_pinned(name, sema.into())?,
         })
     }
 }


### PR DESCRIPTION
We introduce the `Options` type that holds the optional paremeters.
Users who want to specify them do so by calling methods on the `Options`
instance followed by a call to `register` or `register_new`.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>