### PR TITLE
@bjorn3 review

### DIFF
--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -2703,7 +2703,7 @@ config RUST_OPT_LEVEL_SIMILAR_AS_CHOSEN_FOR_C
 
 	      -O2 is currently mapped to -Copt-level=2
 	      -O3 is currently mapped to -Copt-level=3
-	      -Os is currently mapped to -Copt-level=z
+	      -Os is currently mapped to -Copt-level=s
 
 	  The mapping may change over time to follow the intended semantics
 	  of the choice for C as sensibly as possible.

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -329,10 +329,9 @@ $(objtree)/rust/build_error.o: $(srctree)/rust/build_error.rs \
     $(objtree)/rust/compiler_builtins.o FORCE
 	$(call if_changed_dep,rustc_library)
 
-# ICE on `--extern macros`: https://github.com/rust-lang/rust/issues/56935
 $(objtree)/rust/kernel.o: private rustc_target_flags = --extern alloc \
     --extern build_error \
-    --extern macros=$(objtree)/rust/libmacros.so
+    --extern macros
 $(objtree)/rust/kernel.o: $(srctree)/rust/kernel/lib.rs $(objtree)/rust/alloc.o \
     $(objtree)/rust/build_error.o \
     $(objtree)/rust/libmacros.so $(objtree)/rust/bindings_generated.rs \

--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -7,7 +7,7 @@
 //! by providing this file.
 //!
 //! At the moment, some builtins are required that should not be. For instance,
-//! [`core`] has floating-point functionality which we should not be compiling
+//! [`core`] has 128-bit integers functionality which we should not be compiling
 //! in. We will work with upstream [`core`] to provide feature flags to disable
 //! the parts we do not need. For the moment, we define them to [`panic!`] at
 //! runtime for simplicity to catch mistakes, instead of performing surgery


### PR DESCRIPTION
This PR addresses @bjorn3's review at https://rust-for-linux.zulipchat.com/#narrow/stream/288089-General/topic/patch.20v3.20review except the `unsafe` bit (#629) which will be given a go by Abhik Jain.

Suggested/Reported-by: bjorn3 <bjorn3_gh@protonmail.com>