### PR TITLE
rust: Add kvmalloc() allocator type

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -28,6 +28,7 @@
 #![feature(coerce_unsized)]
 #![feature(dispatch_from_dyn)]
 #![feature(unsize)]
+#![feature(nonnull_slice_from_raw_parts)]
 
 // Ensure conditional compilation based on the kernel configuration works;
 // otherwise we may silently break things like initcall handling.
@@ -36,7 +37,7 @@ compile_error!("Missing kernel configuration for conditional compilation");
 
 #[cfg(not(test))]
 #[cfg(not(testlib))]
-mod allocator;
+pub mod allocator;
 
 #[doc(hidden)]
 pub mod bindings;


### PR DESCRIPTION
The current global allocator is for `kmalloc()` family of functions.
Usually this is fine, but if we try to allocate a large structure on the
heap, `kmalloc()` might fail because there is not enough contiguous
memory available left in the system.

There is currently no way to use a different allocator if you know you
will need a large allocation but don't necessarily need it to be
contiguous memory. This is the motivation for this commit.

This commit adds the `KernelVirtualAllocator` type that implements the
`Allocator` trait for kvmalloc() family of functions.

Signed-off-by: Daniel Xu <dxu@dxuuu.xyz>