### PR TITLE
rust: skip `.rmeta` generation for leaves

### DIFF
--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -357,7 +357,7 @@ rust_handle_depfile = \
 
 quiet_cmd_rustc_o_rs = $(RUSTC_OR_CLIPPY_QUIET) $(quiet_modtag) $@
       cmd_rustc_o_rs = \
-	$(rust_common_cmd) --emit=dep-info,obj,metadata $<; \
+	$(rust_common_cmd) --emit=dep-info,obj $<; \
 	$(rust_handle_depfile)
 
 $(obj)/%.o: $(src)/%.rs FORCE


### PR DESCRIPTION
The previous refactor of `--emit` allows us to disable it. Later on we will likely have a way to have a graph of TUs, but right now, we do not need to generate the metadata.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>