### PR TITLE
scripts: fix clang version detection on certain Linux distributions

### DIFF
--- a/scripts/rust-is-available.sh
+++ b/scripts/rust-is-available.sh
@@ -129,8 +129,7 @@ if [ "$1" = -v ]; then
 	if [ "$cc_name" = Clang ]; then
 		clang_version=$( \
 			LC_ALL=C "$CC" --version 2>/dev/null \
-				| head -n 1 \
-				| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+				| sed -nE '1s:.*version ([0-9]+\.[0-9]+\.[0-9]+).*:\1:p'
 		)
 		if [ "$clang_version" != "$bindgen_libclang_version" ]; then
 			echo >&2 "***"


### PR DESCRIPTION
Prevents the libclang vs clang version mismatch warning message from showing up when the clang version reported by 'clang --version' contains a trailing Linux distro version.

Example of non-working scenario:

```sh
$ LC_ALL=C clang --version 2>/dev/null
Ubuntu clang version 11.0.0-2~ubuntu20.04.1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```
Signed-off-by: Miguel Cano <macanroj@gmail.com>