### PR TITLE
rust: use `.init_array` instead of `.ctors` in `init_static_sync`

### DIFF
--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -120,7 +120,7 @@ macro_rules! init_static_sync {
         $(
             $(#[$outer])*
             $v static $id: $t = {
-                #[link_section = ".ctors"]
+                #[link_section = ".init_array"]
                 #[used]
                 static TMP: extern "C" fn() = {
                     extern "C" fn constructor() {


### PR DESCRIPTION
When KASAN is enabled, it creates an entry in the `.init_array` section,
for example:

```
RELOCATION RECORDS FOR [.init_array]:
OFFSET   TYPE              VALUE
00000000 R_ARM_TARGET1     asan.module_ctor
```

When this is compiled into a loadable module that also contains a
`.ctors` section, the kernel fails to load it, for example:

```
[   27.699160] rust_sync: has both .ctors and .init_array.
insmod: can't insert 'rust_sync.ko': invalid parameter
```

Using `.init_array` for static synchronisation primitives avoids this
error.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>