### PR TITLE
Makefile: run Rust `build` on `prepare`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1258,13 +1258,13 @@ archprepare: outputmakefile archheaders archscripts scripts include/config/kerne
 prepare0: archprepare
 	$(Q)$(MAKE) $(build)=scripts/mod
 	$(Q)$(MAKE) $(build)=.
+
+# All the preparing..
+prepare: prepare0
 ifdef CONFIG_RUST
 	$(Q)$(CONFIG_SHELL) $(srctree)/scripts/rust-is-available.sh -v
 	$(Q)$(MAKE) $(build)=rust
 endif
-
-# All the preparing..
-prepare: prepare0
 
 PHONY += remove-stale-files
 remove-stale-files:

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -252,8 +252,7 @@ else
 bindgen_c_flags_lto = $(bindgen_c_flags)
 endif
 
-# To avoid several recompilations in PowerPC, which inserts `-D_TASK_CPU`
-bindgen_c_flags_final = $(filter-out -D_TASK_CPU=%, $(bindgen_c_flags_lto))
+bindgen_c_flags_final = $(bindgen_c_flags_lto)
 
 quiet_cmd_bindgen = BINDGEN $@
       cmd_bindgen = \


### PR DESCRIPTION
Some architectures add flags between `prepare0` and `prepare`.
This makes e.g. `bindgen` think flags have changed.

Thus, instead of running `build` in `prepare0`, do it a bit later
in `prepare` since we do not need anything before.

This solves the arm64 CI issues we were seeing since the container
move: the CI now uses Clang 13 instead of 12, and Clang 13
introduced SysReg Stack Protector Guards which were being set.

This also makes the PowerPC hack unnecessary, which was no
longer needed anyway since commit 336868afbaae ("powerpc: smp:
remove hack to obtain offset of task_struct::cpu").

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>