### PR TITLE
doc: rust: add missing `code-block` tag

### DIFF
--- a/Documentation/rust/coding-guidelines.rst
+++ b/Documentation/rust/coding-guidelines.rst
@@ -53,6 +53,8 @@ the one at:
 
 This is how a well-documented Rust function may look like::
 
+.. code-block:: rust
+
 	/// Returns the contained [`Some`] value, consuming the `self` value,
 	/// without checking that the value is not [`None`].
 	///


### PR DESCRIPTION
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>