### PR TITLE
treewide: update/normalize comment style

### DIFF
--- a/Documentation/rust/coding-guidelines.rst
+++ b/Documentation/rust/coding-guidelines.rst
@@ -72,7 +72,7 @@ This is how a well-documented Rust function may look like::
 		match self {
 			Some(val) => val,
 
-			// SAFETY: the safety contract must be upheld by the caller.
+			// SAFETY: The safety contract must be upheld by the caller.
 			None => unsafe { hint::unreachable_unchecked() },
 		}
 	}

--- a/rust/kernel/bindings.rs
+++ b/rust/kernel/bindings.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Bindings
+//! Bindings.
 //!
 //! Imports the generated bindings by `bindgen`.
 

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -23,9 +23,9 @@ use crate::str::CStr;
 ///
 /// # Invariants
 ///
-/// - [`self.0`] is valid and non-null.
-/// - [`(*self.0).ops`] is valid, non-null and has static lifetime.
-/// - [`(*self.0).owner`] is valid and, if non-null, has module lifetime.
+///   - [`self.0`] is valid and non-null.
+///   - [`(*self.0).ops`] is valid, non-null and has static lifetime.
+///   - [`(*self.0).owner`] is valid and, if non-null, has module lifetime.
 struct Cdev(*mut bindings::cdev);
 
 impl Cdev {
@@ -45,20 +45,20 @@ impl Cdev {
             (*cdev).owner = module.0;
         }
         // INVARIANTS:
-        // - [`self.0`] is valid and non-null.
-        // - [`(*self.0).ops`] is valid, non-null and has static lifetime,
-        //   because it was coerced from a reference with static lifetime.
-        // - [`(*self.0).owner`] is valid and, if non-null, has module lifetime,
-        //   guaranteed by the [`ThisModule`] invariant.
+        //   - [`self.0`] is valid and non-null.
+        //   - [`(*self.0).ops`] is valid, non-null and has static lifetime,
+        //     because it was coerced from a reference with static lifetime.
+        //   - [`(*self.0).owner`] is valid and, if non-null, has module lifetime,
+        //     guaranteed by the [`ThisModule`] invariant.
         Ok(Self(cdev))
     }
 
     fn add(&mut self, dev: bindings::dev_t, count: c_types::c_uint) -> Result {
-        // SAFETY: according to the type invariants:
-        // - [`self.0`] can be safely passed to [`bindings::cdev_add`].
-        // - [`(*self.0).ops`] will live at least as long as [`self.0`].
-        // - [`(*self.0).owner`] will live at least as long as the
-        //   module, which is an implicit requirement.
+        // SAFETY: According to the type invariants:
+        //   - [`self.0`] can be safely passed to [`bindings::cdev_add`].
+        //   - [`(*self.0).ops`] will live at least as long as [`self.0`].
+        //   - [`(*self.0).owner`] will live at least as long as the
+        //     module, which is an implicit requirement.
         let rc = unsafe { bindings::cdev_add(self.0, dev, count) };
         if rc != 0 {
             return Err(Error::from_kernel_errno(rc));

--- a/rust/kernel/clk.rs
+++ b/rust/kernel/clk.rs
@@ -26,7 +26,7 @@ impl Clk {
 
     /// Returns value of the rate field of `struct clk`.
     pub fn get_rate(&self) -> usize {
-        // SAFETY: the pointer is valid by the type invariant.
+        // SAFETY: The pointer is valid by the type invariant.
         unsafe { bindings::clk_get_rate(self.0) as usize }
     }
 
@@ -34,7 +34,7 @@ impl Clk {
     ///
     /// This function should not be called in atomic context.
     pub fn prepare_enable(self) -> Result<EnabledClk> {
-        // SAFETY: the pointer is valid by the type invariant.
+        // SAFETY: The pointer is valid by the type invariant.
         to_result(|| unsafe { bindings::clk_prepare_enable(self.0) })?;
         Ok(EnabledClk(self))
     }
@@ -42,7 +42,7 @@ impl Clk {
 
 impl Drop for Clk {
     fn drop(&mut self) {
-        // SAFETY: the pointer is valid by the type invariant.
+        // SAFETY: The pointer is valid by the type invariant.
         unsafe { bindings::clk_put(self.0) };
     }
 }
@@ -61,7 +61,7 @@ impl EnabledClk {
     /// This function should not be called in atomic context.
     pub fn disable_unprepare(self) -> Clk {
         let mut clk = ManuallyDrop::new(self);
-        // SAFETY: the pointer is valid by the type invariant.
+        // SAFETY: The pointer is valid by the type invariant.
         unsafe { bindings::clk_disable_unprepare(clk.0 .0) };
         core::mem::replace(&mut clk.0, Clk(core::ptr::null_mut()))
     }
@@ -69,7 +69,7 @@ impl EnabledClk {
 
 impl Drop for EnabledClk {
     fn drop(&mut self) {
-        // SAFETY: the pointer is valid by the type invariant.
+        // SAFETY: The pointer is valid by the type invariant.
         unsafe { bindings::clk_disable_unprepare(self.0 .0) };
     }
 }

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -61,11 +61,11 @@ pub unsafe trait RawDevice {
             None => core::ptr::null(),
         };
 
-        // SAFETY: id_ptr is optional and may be either a valid pointer
+        // SAFETY: `id_ptr` is optional and may be either a valid pointer
         // from the type invariant or NULL otherwise.
         let clk_ptr = unsafe { from_kernel_err_ptr(bindings::clk_get(self.raw_device(), id_ptr)) }?;
 
-        // SAFETY: clock is initialized with valid pointer returned from `bindings::clk_get` call.
+        // SAFETY: Clock is initialized with valid pointer returned from `bindings::clk_get` call.
         unsafe { Ok(Clk::new(clk_ptr)) }
     }
 
@@ -222,10 +222,10 @@ impl Drop for Device {
 /// some device state must be freed and not used anymore, while others must remain accessible.
 ///
 /// This struct separates the device data into three categories:
-/// 1. Registrations: are destroyed when the device is removed, but before the io resources
-///    become inaccessible.
-/// 2. Io resources: are available until the device is removed.
-/// 3. General data: remain available as long as the ref count is nonzero.
+///   1. Registrations: are destroyed when the device is removed, but before the io resources
+///      become inaccessible.
+///   2. Io resources: are available until the device is removed.
+///   3. General data: remain available as long as the ref count is nonzero.
 ///
 /// This struct implements the `DeviceRemoval` trait so that it can clean resources up even if not
 /// explicitly called by the device drivers.

--- a/rust/kernel/driver.rs
+++ b/rust/kernel/driver.rs
@@ -116,8 +116,8 @@ impl<T: DriverOps> Drop for Registration<T> {
 /// # Safety
 ///
 /// Implementers must ensure that:
-///   * [`RawDeviceId::ZERO`] is actually a zeroed-out version of the raw device id.
-///   * [`RawDeviceId::to_rawid`] stores `offset` in the context/data field of the raw device id so
+///   - [`RawDeviceId::ZERO`] is actually a zeroed-out version of the raw device id.
+///   - [`RawDeviceId::to_rawid`] stores `offset` in the context/data field of the raw device id so
 ///     that buses can recover the pointer to the data.
 pub unsafe trait RawDeviceId {
     /// The raw type that holds the device id.

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -324,7 +324,7 @@ impl Error {
     /// be returned in such a case.
     pub(crate) fn from_kernel_errno(errno: c_types::c_int) -> Error {
         if errno < -(bindings::MAX_ERRNO as i32) || errno >= 0 {
-            // TODO: make it a `WARN_ONCE` once available.
+            // TODO: Make it a `WARN_ONCE` once available.
             crate::pr_warn!(
                 "attempted to create `Error` with out of range `errno`: {}",
                 errno
@@ -332,7 +332,7 @@ impl Error {
             return Error::EINVAL;
         }
 
-        // INVARIANT: the check above ensures the type invariant
+        // INVARIANT: The check above ensures the type invariant
         // will hold.
         Error(errno)
     }
@@ -343,7 +343,7 @@ impl Error {
     ///
     /// `errno` must be within error code range (i.e. `>= -MAX_ERRNO && < 0`).
     pub(crate) unsafe fn from_kernel_errno_unchecked(errno: c_types::c_int) -> Error {
-        // INVARIANT: the contract ensures the type invariant
+        // INVARIANT: The contract ensures the type invariant
         // will hold.
         Error(errno)
     }
@@ -507,16 +507,16 @@ pub(crate) use from_kernel_result;
 ///     }
 /// }
 /// ```
-// TODO: remove `dead_code` marker once an in-kernel client is available.
+// TODO: Remove `dead_code` marker once an in-kernel client is available.
 #[allow(dead_code)]
 pub(crate) fn from_kernel_err_ptr<T>(ptr: *mut T) -> Result<*mut T> {
-    // CAST: casting a pointer to `*const c_types::c_void` is always valid.
+    // CAST: Casting a pointer to `*const c_types::c_void` is always valid.
     let const_ptr: *const c_types::c_void = ptr.cast();
-    // SAFETY: the FFI function does not deref the pointer.
+    // SAFETY: The FFI function does not deref the pointer.
     if unsafe { bindings::IS_ERR(const_ptr) } {
-        // SAFETY: the FFI function does not deref the pointer.
+        // SAFETY: The FFI function does not deref the pointer.
         let err = unsafe { bindings::PTR_ERR(const_ptr) };
-        // CAST: if `IS_ERR()` returns `true`,
+        // CAST: If `IS_ERR()` returns `true`,
         // then `PTR_ERR()` is guaranteed to return a
         // negative value greater-or-equal to `-bindings::MAX_ERRNO`,
         // which always fits in an `i16`, as per the invariant above.
@@ -524,7 +524,7 @@ pub(crate) fn from_kernel_err_ptr<T>(ptr: *mut T) -> Result<*mut T> {
         // an `i32` can never overflow, and is always valid.
         //
         // SAFETY: `IS_ERR()` ensures `err` is a
-        // negative value greater-or-equal to `-bindings::MAX_ERRNO`
+        // negative value greater-or-equal to `-bindings::MAX_ERRNO`.
         return Err(unsafe { Error::from_kernel_errno_unchecked(err as i32) });
     }
     Ok(ptr)

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -711,7 +711,7 @@ pub trait FileOperations {
     /// Maps areas of the caller's virtual memory with device/file memory.
     ///
     /// Corresponds to the `mmap` function pointer in `struct file_operations`.
-    /// TODO: wrap `vm_area_struct` so that we don't have to expose it.
+    /// TODO: Wrap `vm_area_struct` so that we don't have to expose it.
     fn mmap(
         _this: <Self::Wrapper as PointerWrapper>::Borrowed<'_>,
         _file: &File,

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -194,7 +194,7 @@ impl<T: FileOperations> FileOpenAdapter<T::OpenData> for Registration<T> {
         _inode: *mut bindings::inode,
         file: *mut bindings::file,
     ) -> *const T::OpenData {
-        // SAFETY: the caller must guarantee that `file` is valid.
+        // SAFETY: The caller must guarantee that `file` is valid.
         let reg = crate::container_of!(unsafe { (*file).private_data }, Self, mdev);
 
         // SAFETY: This function is only called while the misc device is still registered, so the

--- a/rust/kernel/rbtree.rs
+++ b/rust/kernel/rbtree.rs
@@ -322,7 +322,7 @@ impl<K, V> RBTree<K, V> {
     where
         K: Ord,
     {
-        // SAFETY: the `find` return value is a node in the tree, so it is valid.
+        // SAFETY: The `find` return value is a node in the tree, so it is valid.
         self.find(key)
             .map(|mut node| unsafe { &mut node.as_mut().value })
     }
@@ -336,13 +336,13 @@ impl<K, V> RBTree<K, V> {
     {
         let mut node = self.find(key)?;
 
-        // SAFETY: the `find` return value is a node in the tree, so it is valid.
+        // SAFETY: The `find` return value is a node in the tree, so it is valid.
         unsafe { bindings::rb_erase(&mut node.as_mut().links, &mut self.root) };
 
         // INVARIANT: The node is being returned and the caller may free it, however, it was
         // removed from the tree. So the invariants still hold.
         Some(RBTreeNode {
-            // SAFETY: the `find` return value was a node in the tree, so it is valid.
+            // SAFETY: The `find` return value was a node in the tree, so it is valid.
             node: unsafe { Box::from_raw(node.as_ptr()) },
         })
     }

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -303,7 +303,7 @@ impl Index<ops::RangeFull> for CStr {
 mod private {
     use core::ops;
 
-    //  Marker trait for index types that can be forward to `BStr`.
+    // Marker trait for index types that can be forward to `BStr`.
     pub trait CStrIndex {}
 
     impl CStrIndex for usize {}

--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -320,7 +320,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
         modinfo.emit("alias", &alias);
     }
 
-    // Built-in modules also export the `file` modinfo string
+    // Built-in modules also export the `file` modinfo string.
     let file =
         std::env::var("RUST_MODFILE").expect("Unable to fetch RUST_MODFILE environmental variable");
     modinfo.emit_only_builtin("file", &file);
@@ -351,8 +351,8 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             let param_description = get_byte_string(&mut param_it, "description");
             expect_end(&mut param_it);
 
-            // TODO: more primitive types
-            // TODO: other kinds: unsafes, etc.
+            // TODO: More primitive types.
+            // TODO: Other kinds: unsafes, etc.
             let (param_kernel_type, ops): (String, _) = match param_type {
                 ParamType::Ident(ref param_type) => (
                     param_type.to_string(),
@@ -437,7 +437,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
                     // to undo GCC over-alignment of static structs of >32 bytes. It seems that is
                     // not the case anymore, so we simplify to a transparent representation here
                     // in the expectation that it is not needed anymore.
-                    // TODO: revisit this to confirm the above comment and remove it if it happened
+                    // TODO: Revisit this to confirm the above comment and remove it if it happened.
                     #[repr(transparent)]
                     struct __{name}_{param_name}_RacyKernelParam(kernel::bindings::kernel_param);
 
@@ -520,7 +520,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             #[cfg(not(MODULE))]
             static THIS_MODULE: kernel::ThisModule = unsafe {{ kernel::ThisModule::from_ptr(core::ptr::null_mut()) }};
 
-            // Loadable modules need to export the `{{init,cleanup}}_module` identifiers
+            // Loadable modules need to export the `{{init,cleanup}}_module` identifiers.
             #[cfg(MODULE)]
             #[doc(hidden)]
             #[no_mangle]
@@ -536,7 +536,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             }}
 
             // Built-in modules are initialized through an initcall pointer
-            // and the identifiers need to be unique
+            // and the identifiers need to be unique.
             #[cfg(not(MODULE))]
             #[cfg(not(CONFIG_HAVE_ARCH_PREL32_RELOCATIONS))]
             #[doc(hidden)]

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust character device sample
+//! Rust character device sample.
 
 use kernel::prelude::*;
 use kernel::{chrdev, file, file_operations::FileOperations};

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust minimal sample
+//! Rust minimal sample.
 
 use kernel::prelude::*;
 

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust miscellaneous device sample
+//! Rust miscellaneous device sample.
 
 use kernel::prelude::*;
 use kernel::{

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust module parameters sample
+//! Rust module parameters sample.
 
 use kernel::prelude::*;
 

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust printing macros sample
+//! Rust printing macros sample.
 
 use kernel::prelude::*;
 use kernel::{pr_cont, str::CStr, ThisModule};

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust random device
+//! Rust random device.
 //!
 //! Adapted from Alex Gaynor's original available at
 //! <https://github.com/alex/just-use/blob/master/src/lib.rs>.

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust semaphore sample
+//! Rust semaphore sample.
 //!
 //! A counting semaphore that can be used by userspace.
 //!

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust stack probing sample
+//! Rust stack probing sample.
 
 use kernel::prelude::*;
 

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Rust synchronisation primitives sample
+//! Rust synchronisation primitives sample.
 
 use kernel::prelude::*;
 use kernel::{


### PR DESCRIPTION
Includes: capitalization, end of sentence/title periods,
list marker and list indentation.

Also included a fix for a spurious space and missing code quotes.
No change in content intended otherwise.

`alloc` is excluded since we try not to diverge from upstream.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>