### PR TITLE
docs: rust: fix warnings due to spurious literal block

### DIFF
--- a/Documentation/rust/coding-guidelines.rst
+++ b/Documentation/rust/coding-guidelines.rst
@@ -51,7 +51,7 @@ the one at:
 
 	https://commonmark.org/help/
 
-This is how a well-documented Rust function may look like::
+This is how a well-documented Rust function may look like:
 
 .. code-block:: rust
 


### PR DESCRIPTION
Reported-by: Stephen Rothwell <sfr@canb.auug.org.au>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>