### PR TITLE
rust: miscdev: support names created at runtime

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -105,7 +105,7 @@ struct BinderModule {
 impl KernelModule for BinderModule {
     fn init(name: &'static CStr, _module: &'static kernel::ThisModule) -> Result<Self> {
         let ctx = Context::new()?;
-        let reg = Registration::new_pinned(name, ctx)?;
+        let reg = Registration::new_pinned(fmt!("{name}"), ctx)?;
         Ok(Self { _reg: reg })
     }
 }

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -3,7 +3,7 @@
 //! Broadcom BCM2835 Random Number Generator support.
 
 use kernel::{
-    c_str, device, file::File, file_operations::FileOperations, io_buffer::IoBufferWriter, miscdev,
+    device, file::File, file_operations::FileOperations, io_buffer::IoBufferWriter, miscdev,
     module_platform_driver, of, platform, prelude::*, sync::Ref,
 };
 
@@ -57,7 +57,7 @@ impl platform::Driver for RngDriver {
         data.registrations()
             .ok_or(Error::ENXIO)?
             .as_pinned_mut()
-            .register(c_str!("rust_hwrng"), ())?;
+            .register(fmt!("rust_hwrng"), ())?;
         Ok(data.into())
     }
 }

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -132,7 +132,7 @@ impl KernelModule for RustMiscdev {
         let state = SharedState::try_new()?;
 
         Ok(RustMiscdev {
-            _dev: miscdev::Registration::new_pinned(name, state)?,
+            _dev: miscdev::Registration::new_pinned(fmt!("{name}"), state)?,
         })
     }
 }

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -133,7 +133,7 @@ impl KernelModule for RustSemaphore {
         mutex_init!(pinned, "Semaphore::inner");
 
         Ok(Self {
-            _dev: Registration::new_pinned(name, sema.into())?,
+            _dev: Registration::new_pinned(fmt!("{name}"), sema.into())?,
         })
     }
 }


### PR DESCRIPTION
The registration now holds an owned C string while the miscdev is
registered, and frees it on drop.

Now names are formatted with the `fmt` macro instead of being static
C strings. This enables scenarios when the device name is constructed at
runtime, i.e., where a static C string does not exist.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>