### PR TITLE
rust: define `LockInfo` trait that lock "type states" must implement

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -96,7 +96,7 @@ pub mod user_ptr;
 pub use build_error::build_error;
 
 pub use crate::error::{to_result, Error, Result};
-pub use crate::types::{bit, bits_iter, Mode, Opaque, ScopeGuard};
+pub use crate::types::{bit, bits_iter, Bool, False, Mode, Opaque, ScopeGuard, True};
 
 use core::marker::PhantomData;
 

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -5,7 +5,7 @@
 //! This module allows Rust code to use the kernel's [`struct wait_queue_head`] as a condition
 //! variable.
 
-use super::{Guard, Lock, NeedsLockClass};
+use super::{Guard, Lock, LockInfo, NeedsLockClass};
 use crate::{bindings, str::CStr, task::Task, Opaque};
 use core::{marker::PhantomPinned, pin::Pin};
 
@@ -61,7 +61,7 @@ impl CondVar {
     ///
     /// Returns whether there is a signal pending.
     #[must_use = "wait returns if a signal is pending, so the caller must check the return value"]
-    pub fn wait<L: Lock<M>, M>(&self, guard: &mut Guard<'_, L, M>) -> bool {
+    pub fn wait<L: Lock<I>, I: LockInfo>(&self, guard: &mut Guard<'_, L, I>) -> bool {
         let lock = guard.lock;
         let wait = Opaque::<bindings::wait_queue_entry>::uninit();
 

--- a/rust/kernel/sync/mod.rs
+++ b/rust/kernel/sync/mod.rs
@@ -35,7 +35,7 @@ mod spinlock;
 
 pub use arc::{Ref, RefBorrow, UniqueRef};
 pub use condvar::CondVar;
-pub use guard::{CreatableLock, Guard, Lock, ReadLock, WriteLock};
+pub use guard::{CreatableLock, Guard, Lock, LockInfo, ReadLock, WriteLock};
 pub use locked_by::LockedBy;
 pub use mutex::Mutex;
 pub use revocable_mutex::{RevocableMutex, RevocableMutexGuard};

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -73,7 +73,9 @@ impl<T: ?Sized> Mutex<T> {
 }
 
 impl<T> CreatableLock for Mutex<T> {
-    unsafe fn new_lock(data: Self::Inner) -> Self {
+    type CreateArgType = T;
+
+    unsafe fn new_lock(data: Self::CreateArgType) -> Self {
         // SAFETY: The safety requirements of `new_lock` also require that `init_lock` be called.
         unsafe { Self::new(data) }
     }

--- a/rust/kernel/sync/rwsem.rs
+++ b/rust/kernel/sync/rwsem.rs
@@ -86,7 +86,9 @@ impl<T: ?Sized> RwSemaphore<T> {
 }
 
 impl<T> CreatableLock for RwSemaphore<T> {
-    unsafe fn new_lock(data: Self::Inner) -> Self {
+    type CreateArgType = T;
+
+    unsafe fn new_lock(data: Self::CreateArgType) -> Self {
         // SAFETY: The safety requirements of `new_lock` also require that `init_lock` be called.
         unsafe { Self::new(data) }
     }

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -131,7 +131,9 @@ impl<T: ?Sized> SpinLock<T> {
 }
 
 impl<T> CreatableLock for SpinLock<T> {
-    unsafe fn new_lock(data: Self::Inner) -> Self {
+    type CreateArgType = T;
+
+    unsafe fn new_lock(data: Self::CreateArgType) -> Self {
         // SAFETY: The safety requirements of `new_lock` also require that `init_lock` be called.
         unsafe { Self::new(data) }
     }


### PR DESCRIPTION
This allows the definition of additional writable type states. Without
this patch, the `DerefMut` trait for guards is only implemented when the
type state is `WriteLock`; this is too restrictive for types that want
to implement more than one writable lock type state, for example, spin
locks that may have type states that have (or have not) disabled
interrupts.

This is in preparation for simplifying spinlocks, which comes in a
subsequent patch.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>