### PR TITLE
rust: iomem: add `try_memcpy_fromio` method for `IoMem<T>`

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -182,6 +182,13 @@ void rust_helper_writeq_relaxed(u64 value, volatile void __iomem *addr)
 }
 EXPORT_SYMBOL_GPL(rust_helper_writeq_relaxed);
 #endif
+
+void rust_helper_memcpy_fromio(void *to, const volatile void __iomem *from, long count)
+{
+	memcpy_fromio(to, from, count);
+}
+EXPORT_SYMBOL_GPL(rust_helper_memcpy_fromio);
+
 void rust_helper___spin_lock_init(spinlock_t *lock, const char *name,
 				  struct lock_class_key *key)
 {


### PR DESCRIPTION
This patch adds only runtime-checked bindings version of
`memcpy_fromio()` function prefixed with `try_` similarly
to read/write methods of `IoMem<T>` that is `readx` and `try_readx`.

This patch is a dependency of a Samsung Exynos trng driver provided initially in https://github.com/Rust-for-Linux/linux/pull/554.

Changes v3 -> v4:
  - Removed unneeded generic parameter specifier
    in favor of type inference https://github.com/Rust-for-Linux/linux/pull/681#discussion_r829167711,
  - Removed unneeded comment https://github.com/Rust-for-Linux/linux/pull/681#discussion_r829190553,

Changes v2 -> v3:
  - `Error::EINVAL` -> `EINVAL`,

Changes v1 -> v2:
  - Fixed naming of function's argument https://github.com/Rust-for-Linux/linux/pull/681#discussion_r809992411,
  - `[i8]` -> `[u8]` for input buffer https://github.com/Rust-for-Linux/linux/pull/681#discussion_r810093866,
  - Added `as *mut _` and `as *const _` if possible https://github.com/Rust-for-Linux/linux/pull/681#discussion_r809993306,
  - Removed `count` argument to take advantage of slicing https://github.com/Rust-for-Linux/linux/pull/681#discussion_r810142009,
  - `IoMem::<SIZE>` -> `Self` https://github.com/Rust-for-Linux/linux/pull/681#discussion_r810149520,
  - Replaced existing size checks with `Self::offset_ok_of_val()` https://github.com/Rust-for-Linux/linux/pull/681#discussion_r810150848.

Signed-off-by: Maciej Falkowski <m.falkowski@samsung.com>