### PR TITLE
rust: platform: add `ioremap_resource` and `get_resource` methods

### DIFF
--- a/rust/kernel/io_mem.rs
+++ b/rust/kernel/io_mem.rs
@@ -9,6 +9,12 @@
 use crate::{bindings, error::code::*, Result};
 use core::convert::TryInto;
 
+/// The type of `Resource`.
+pub enum IoResource {
+    /// i/o memory
+    Mem = bindings::IORESOURCE_MEM as _,
+}
+
 /// Represents a memory resource.
 pub struct Resource {
     offset: bindings::resource_size_t,

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -7,15 +7,16 @@
 //! C header: [`include/linux/platform_device.h`](../../../../include/linux/platform_device.h)
 
 use crate::{
-    bindings, c_types,
+    bindings, bit, c_types,
     device::{self, RawDevice},
     driver,
-    error::{from_kernel_result, Result},
+    error::{code::*, from_kernel_result},
+    io_mem::{IoMem, IoResource, Resource},
     of,
     str::CStr,
     to_result,
     types::PointerWrapper,
-    ThisModule,
+    Result, ThisModule,
 };
 
 /// A registration of a platform driver.
@@ -161,6 +162,7 @@ pub trait Driver {
 /// The field `ptr` is non-null and valid for the lifetime of the object.
 pub struct Device {
     ptr: *mut bindings::platform_device,
+    used_resource: u64,
 }
 
 impl Device {
@@ -172,13 +174,67 @@ impl Device {
     /// instance.
     unsafe fn from_ptr(ptr: *mut bindings::platform_device) -> Self {
         // INVARIANT: The safety requirements of the function ensure the lifetime invariant.
-        Self { ptr }
+        Self {
+            ptr,
+            used_resource: 0,
+        }
     }
 
     /// Returns id of the platform device.
     pub fn id(&self) -> i32 {
         // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
         unsafe { (*self.ptr).id }
+    }
+
+    /// Gets a system resources of a platform device.
+    pub fn get_resource(&mut self, rtype: IoResource, num: usize) -> Result<Resource> {
+        // SAFETY: `self.ptr` is valid by the type invariant.
+        let res = unsafe { bindings::platform_get_resource(self.ptr, rtype as _, num as _) };
+        if res.is_null() {
+            return Err(EINVAL);
+        }
+
+        // Get the position of the found resource in the array.
+        // SAFETY:
+        //   - `self.ptr` is valid by the type invariant.
+        //   - `res` is a displaced pointer to one of the array's elements,
+        //     and `resource` is its base pointer.
+        let index = unsafe { res.offset_from((*self.ptr).resource) } as usize;
+
+        // Make sure that the index does not exceed the 64-bit mask.
+        assert!(index < 64);
+
+        if self.used_resource >> index & bit(0) == 1 {
+            return Err(EBUSY);
+        }
+        self.used_resource |= bit(index);
+
+        // SAFETY: The pointer `res` is returned from `bindings::platform_get_resource`
+        // above and checked if it is not a NULL.
+        unsafe { Resource::new((*res).start, (*res).end) }.ok_or(EINVAL)
+    }
+
+    /// Ioremaps resources of a platform device.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that either (a) the resulting interface cannot be used to initiate DMA
+    /// operations, or (b) that DMA operations initiated via the returned interface use DMA handles
+    /// allocated through the `dma` module.
+    pub unsafe fn ioremap_resource<const SIZE: usize>(
+        &mut self,
+        index: usize,
+    ) -> Result<IoMem<SIZE>> {
+        let mask = self.used_resource;
+        let res = self.get_resource(IoResource::Mem, index)?;
+
+        // SAFETY: Valid by the safety contract.
+        let iomem = unsafe { IoMem::<SIZE>::try_new(res) };
+        // If remapping fails, the given resource won't be used, so restore the old mask.
+        if iomem.is_err() {
+            self.used_resource = mask;
+        }
+        iomem
     }
 }
 


### PR DESCRIPTION
This patch adds a logic similar to `devm_platform_ioremap_resource`
function adding:
  - `IoResource` enumerated type that groups the `IORESOURCE_*` macros.
  - `get_resource()` method that is a binding of `platform_get_resource`
  - `ioremap_resource` that is newly written method similar to
    `devm_platform_ioremap_resource`.
    
This patch is a dependency of a Samsung Exynos trng driver provided initially in https://github.com/Rust-for-Linux/linux/pull/554.

Changes v3 -> v4:
  - Added 64-bit mask that is used to keep track of busy resources https://github.com/Rust-for-Linux/linux/pull/682#discussion_r871430420,
  - Changed implementation of `get_resource()` and `ioremap_resource()` so that they check if
    the resource was already taken https://github.com/Rust-for-Linux/linux/pull/682#discussion_r871430420,
  - Documentation fixes https://github.com/Rust-for-Linux/linux/pull/682#discussion_r865151174.
    
Changes v2 -> v3:
  - `Error::EINVAL` -> `EINVAL`,

Changes v1 -> v2:
  - Marked `ioremap_resource()` as unsafe.

Signed-off-by: Maciej Falkowski <m.falkowski@samsung.com>