### PR TITLE
kbuild: canonicalization of target path not needed anymore

### DIFF
--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -328,10 +328,7 @@ $(obj)/%.lst: $(src)/%.c FORCE
 # Compile Rust sources (.rs)
 # ---------------------------------------------------------------------------
 
-# Need to use absolute path here and have symbolic links resolved;
-# otherwise rustdoc and rustc compute different hashes for the target.
-rust_cross_flags := --target=$(realpath $(KBUILD_RUST_TARGET))
-
+rust_cross_flags := --target=$(KBUILD_RUST_TARGET)
 rust_allowed_features := allocator_api,bench_black_box,concat_idents,generic_associated_types
 
 rust_common_cmd = \


### PR DESCRIPTION
In https://github.com/Rust-for-Linux/linux/pull/272 `realpath`
was added to work around a bug in `rustdoc`, but it is not needed
anymore since https://github.com/rust-lang/rust/pull/85361, i.e.
since Rust 1.54.0.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>