### PR TITLE
Update quick-start.rst

### DIFF
--- a/Documentation/rust/quick-start.rst
+++ b/Documentation/rust/quick-start.rst
@@ -185,7 +185,8 @@ Configuration
 
 ``Rust support`` (``CONFIG_RUST``) needs to be enabled in the ``General setup``
 menu. The option is only shown if a suitable Rust toolchain is found (see
-above). In turn, this will make visible the rest of options that depend on Rust.
+above), as long as the other requirements are met. In turn, this will make
+visible the rest of options that depend on Rust.
 
 Afterwards, go to::
 


### PR DESCRIPTION
CONFIG_RUST has few requirements (such as !CONFIG_MODVERSIONS) which are enabled by default and prevent CONFIG_RUST from appearing. Instead of listing all of them here in the quick start guide, this short grep may come in handy.

Signed-off-by: Julian Merkle <me@jvmerkle.de>