### PR TITLE
treewide: Kconfig: remove `default n`

### DIFF
--- a/drivers/android/Kconfig
+++ b/drivers/android/Kconfig
@@ -23,7 +23,6 @@ config ANDROID_BINDER_IPC
 config ANDROID_BINDER_IPC_RUST
 	bool "Android Binder IPC Driver in Rust"
 	depends on MMU && RUST
-	default n
 	help
 	  Implementation of the Binder IPC in Rust.
 

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -2060,7 +2060,6 @@ config RUST
 	depends on !MODVERSIONS
 	depends on !GCC_PLUGIN_RANDSTRUCT
 	select CONSTRUCTORS
-	default n
 	help
 	  Enables Rust support in the kernel.
 

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -2691,7 +2691,6 @@ menu "Rust hacking"
 
 config RUST_DEBUG_ASSERTIONS
 	bool "Debug assertions"
-	default n
 	depends on RUST
 	help
 	  Enables rustc's `-Cdebug-assertions` codegen option.


### PR DESCRIPTION
`default n` is already the default.

Suggested-by: Russell King (Oracle) <linux@armlinux.org.uk>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>