### PR TITLE
rust: add pm_runtime bindings

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -29,6 +29,7 @@
 #include <linux/errname.h>
 #include <linux/mutex.h>
 #include <linux/platform_device.h>
+#include <linux/pm_runtime.h>
 #include <linux/security.h>
 #include <asm/io.h>
 #include <linux/irq.h>
@@ -44,6 +45,36 @@ __noreturn void rust_helper_BUG(void)
 	BUG();
 }
 EXPORT_SYMBOL_GPL(rust_helper_BUG);
+
+void rust_helper_pm_runtime_put_noidle(struct device *dev)
+{
+	pm_runtime_put_noidle(dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_pm_runtime_put_noidle);
+
+void rust_helper_pm_runtime_enable(struct device *dev)
+{
+	pm_runtime_enable(dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_pm_runtime_enable);
+
+void rust_helper_pm_runtime_disable(struct device *dev)
+{
+	pm_runtime_disable(dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_pm_runtime_disable);
+
+int rust_helper_pm_runtime_put_sync(struct device *dev)
+{
+	return pm_runtime_put_sync(dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_pm_runtime_put_sync);
+
+int rust_helper_pm_runtime_resume_and_get(struct device *dev)
+{
+	return pm_runtime_resume_and_get(dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_pm_runtime_resume_and_get);
 
 void rust_helper_clk_disable_unprepare(struct clk *clk)
 {

--- a/rust/kernel/amba.rs
+++ b/rust/kernel/amba.rs
@@ -5,8 +5,8 @@
 //! C header: [`include/linux/amba/bus.h`](../../../../include/linux/amba/bus.h)
 
 use crate::{
-    bindings, c_types, device, driver, error::from_kernel_result, io_mem::Resource, power,
-    str::CStr, to_result, types::PointerWrapper, Result, ThisModule,
+    bindings, c_types, device, driver, error::from_kernel_result, io_mem::Resource, pm, str::CStr,
+    to_result, types::PointerWrapper, Result, ThisModule,
 };
 
 /// A registration of an amba driver.
@@ -49,7 +49,7 @@ pub trait Driver {
     ///
     /// The default is a type that implements no power-management operations. Drivers that do
     /// implement them need to specify the type (commonly [`Self`]).
-    type PowerOps: power::Operations<Data = Self::Data> = power::NoOperations<Self::Data>;
+    type PowerOps: pm::Operations<Data = Self::Data> = pm::NoOperations<Self::Data>;
 
     /// The type holding information about each device id supported by the driver.
     type IdInfo: 'static = ();
@@ -91,7 +91,7 @@ impl<T: Driver> driver::DriverOps for Adapter<T> {
             // SAFETY: `probe_callback` sets the driver data after calling `T::Data::into_pointer`,
             // and we guarantee that `T::Data` is the same as `T::PowerOps::Data` by a constraint
             // in the type declaration.
-            amba.drv.pm = unsafe { power::OpsTable::<T::PowerOps>::build() };
+            amba.drv.pm = unsafe { pm::OpsTable::<T::PowerOps>::build() };
         }
         // SAFETY: By the safety requirements of this function, `reg` is valid and fully
         // initialised.

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -60,7 +60,7 @@ pub mod mm;
 #[cfg(CONFIG_NET)]
 pub mod net;
 pub mod pages;
-pub mod power;
+pub mod pm;
 pub mod revocable;
 pub mod security;
 pub mod str;

--- a/rust/kernel/pm.rs
+++ b/rust/kernel/pm.rs
@@ -6,6 +6,9 @@
 
 #![allow(dead_code)]
 
+/// Device run-time power management helper functions.
+pub mod runtime;
+
 use crate::{bindings, c_types, error::from_kernel_result, types::PointerWrapper, Result};
 use core::marker::PhantomData;
 

--- a/rust/kernel/pm/runtime.rs
+++ b/rust/kernel/pm/runtime.rs
@@ -1,0 +1,66 @@
+/// Device run-time power management helper functions.
+///
+/// C header: [`include/linux/pm_runtime.h`](../../../../../include/linux/pm_runtime.h)
+use crate::{
+    bindings,
+    device::{self, RawDevice},
+    to_result, Result,
+};
+
+/// Enable runtime PM of device `dev`.
+pub fn enable(dev: &impl RawDevice) -> DisableGuard {
+    // SAFETY: Satisfied by the safety requirements of `RawDevice`.
+    unsafe { bindings::pm_runtime_enable(dev.raw_device()) };
+    DisableGuard::new(device::Device::from_dev(dev))
+}
+
+/// Guard that disables runtime PM of device `dev`.
+pub struct DisableGuard {
+    dev: device::Device,
+}
+
+impl DisableGuard {
+    /// Create new instance of a guard of device `dev`.
+    fn new(dev: device::Device) -> Self {
+        Self { dev }
+    }
+}
+
+impl Drop for DisableGuard {
+    fn drop(&mut self) {
+        // SAFETY: Satisfied by the safety requirements of `RawDevice`.
+        unsafe { bindings::pm_runtime_disable(self.dev.raw_device()) };
+    }
+}
+
+/// Drop runtime PM usage counter of a device.
+/// Decrement the runtime PM usage counter of `dev` unless it is 0 already.
+pub fn put_noidle(dev: &impl RawDevice) {
+    // SAFETY: Satisfied by the safety requirements of `RawDevice`.
+    unsafe { bindings::pm_runtime_put_noidle(dev.raw_device()) };
+}
+
+/// Drop device `dev` usage counter and run "idle check" if 0.
+///
+/// Decrement the runtime PM usage counter of `dev` and if it turns out to be
+/// equal to 0, invoke the "idle check" callback of `dev` and, depending on its
+/// return value, set up autosuspend of `dev` or suspend it (depending on whether
+/// or not autosuspend has been enabled for it).
+///
+/// The possible return values of this function are the same as for
+/// pm_runtime_idle() and the runtime PM usage counter of `dev` remains
+/// decremented in all cases, even when an error is returned.
+pub fn put_sync(dev: &impl RawDevice) {
+    // SAFETY: Satisfied by the safety requirements of `RawDevice`.
+    unsafe { bindings::pm_runtime_put_sync(dev.raw_device()) };
+}
+
+/// Bump up usage counter of a device `dev` and resume it.
+///
+/// Resume `dev` synchronously and if that is successful, increment its runtime
+/// PM usage counter. Return error if the runtime PM usage counter of `dev`
+/// has not been incremented.
+pub fn resume_and_get(dev: &impl RawDevice) -> Result {
+    // SAFETY: Satisfied by the safety requirements of `RawDevice`.
+    to_result(|| unsafe { bindings::pm_runtime_resume_and_get(dev.raw_device()) })
+}


### PR DESCRIPTION
This patch adds bindings of PM runtime helpers:
  - Renames `power` to `pm` as it is done on the C side.
  - Adds new `runtime` module under `pm` module
    to match `pm_runtime` namespace.
  - `pm_runtime_enable()` with a `DisableGuard`
    that ensure proper cleanup by calling `pm_runtime_disable()`
  - `pm_runtime_put_sync()`, `pm_runtime_resume_and_get()`,
    `pm_runtime_put_noidle()`

This patch is a dependency of a Samsung Exynos trng driver provided initially in https://github.com/Rust-for-Linux/linux/pull/554.

Changes v2 -> v3:
  - Moved `runtime` module to the separate file `runtime.rs` https://github.com/Rust-for-Linux/linux/pull/700#discussion_r870467532,
  - `SAFETY:` comment fixes https://github.com/Rust-for-Linux/linux/pull/700#discussion_r869381562,
  - Documentation fixes https://github.com/Rust-for-Linux/linux/pull/700#discussion_r869364848.

Changes v1 -> v2:
  - `DisableGuard::new()` is made private https://github.com/Rust-for-Linux/linux/pull/700#discussion_r822892176,
  - Converted `power` to `pm` module and moved the codebase
    to the `runtime` submodule of `pm`,
  - Documentation fixes https://github.com/Rust-for-Linux/linux/pull/700#discussion_r822895372.

Signed-off-by: Maciej Falkowski <m.falkowski@samsung.com>