### PR TITLE
rust: iopoll: add read_poll_timeout function

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -21,6 +21,7 @@
 #include <linux/build_bug.h>
 #include <linux/clk.h>
 #include <linux/delay.h>
+#include <linux/ktime.h>
 #include <linux/uaccess.h>
 #include <linux/sched/signal.h>
 #include <linux/gfp.h>
@@ -48,6 +49,18 @@ void rust_helper_usleep_range(unsigned long min, unsigned long max)
 	usleep_range(min, max);
 }
 EXPORT_SYMBOL_GPL(rust_helper_usleep_range);
+
+int rust_helper_ktime_compare(const ktime_t cmp1, const ktime_t cmp2)
+{
+	return ktime_compare(cmp1, cmp2);
+}
+EXPORT_SYMBOL_GPL(rust_helper_ktime_compare);
+
+ktime_t rust_helper_ktime_add_us(const ktime_t kt, const u64 usec)
+{
+	return ktime_add_us(kt, usec);
+}
+EXPORT_SYMBOL_GPL(rust_helper_ktime_add_us);
 
 void rust_helper_clk_disable_unprepare(struct clk *clk)
 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -22,6 +22,7 @@
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/ktime.h>
+#include <linux/kernel.h>
 #include <linux/uaccess.h>
 #include <linux/sched/signal.h>
 #include <linux/gfp.h>
@@ -49,6 +50,12 @@ void rust_helper_usleep_range(unsigned long min, unsigned long max)
 	usleep_range(min, max);
 }
 EXPORT_SYMBOL_GPL(rust_helper_usleep_range);
+
+void rust_helper_might_sleep(void)
+{
+	might_sleep();
+}
+EXPORT_SYMBOL_GPL(rust_helper_might_sleep);
 
 int rust_helper_ktime_compare(const ktime_t cmp1, const ktime_t cmp2)
 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -20,6 +20,7 @@
 #include <linux/bug.h>
 #include <linux/build_bug.h>
 #include <linux/clk.h>
+#include <linux/delay.h>
 #include <linux/uaccess.h>
 #include <linux/sched/signal.h>
 #include <linux/gfp.h>
@@ -41,6 +42,12 @@ __noreturn void rust_helper_BUG(void)
 	BUG();
 }
 EXPORT_SYMBOL_GPL(rust_helper_BUG);
+
+void rust_helper_usleep_range(unsigned long min, unsigned long max)
+{
+	usleep_range(min, max);
+}
+EXPORT_SYMBOL_GPL(rust_helper_usleep_range);
 
 void rust_helper_clk_disable_unprepare(struct clk *clk)
 {

--- a/rust/kernel/delay.rs
+++ b/rust/kernel/delay.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Delay routines
+//!
+//! C header: [`include/linux/delay.h`](../../../../include/linux/delay.h)
+
+use crate::bindings;
+
+/// Sleep between two microsecond values.
+pub fn usleep_range(min: usize, max: usize) {
+    // SAFETY: FFI call.
+    unsafe { bindings::usleep_range(min as _, max as _) };
+}

--- a/rust/kernel/io_mem.rs
+++ b/rust/kernel/io_mem.rs
@@ -6,7 +6,7 @@
 
 #![allow(dead_code)]
 
-use crate::{bindings, Error, Result};
+use crate::{bindings, iopoll, Error, Result};
 use core::convert::TryInto;
 
 /// Represents a memory resource.
@@ -127,6 +127,56 @@ macro_rules! define_write {
     };
 }
 
+macro_rules! define_readx_poll_timeout {
+    ($(#[$attr:meta])* $fname:ident, $try_name:ident, $callback_name:ident, $type_name:ty) => {
+        /// Polls i/o data from the given offset known, at compile time.
+        ///
+        /// The i/o data is polled until it matches specific condition or fails
+        /// at timeout.
+        ///
+        /// If the offset is not known at compile time, the build will fail.
+        $(#[$attr])*
+        pub fn $fname<F: Fn(&$type_name) -> bool>(
+            &self,
+            offset: usize,
+            cond: F,
+            sleep_us: usize,
+            timeout_us: u64,
+        ) -> Result<$type_name> {
+            Self::check_offset::<$type_name>(offset);
+            let ptr = self.ptr.wrapping_add(offset);
+            // SAFETY: The type invariants guarantee that `ptr` is a valid pointer. The check above
+            // guarantees that the code won't build if `offset` makes the read go out of bounds
+            // (including the type size).
+            unsafe { iopoll::readx_poll_timeout(bindings::$callback_name, cond, sleep_us, timeout_us, ptr as *const _) }
+        }
+
+        /// Polls i/o data from the given offset known, at compile time.
+        ///
+        /// The i/o data is polled until it matches specific condition or fails
+        /// at timeout.
+        ///
+        /// It fails if/when the offset (plus the type size) is out of bounds.
+        $(#[$attr])*
+        pub fn $try_name<F: Fn(&$type_name) -> bool>(
+            &self,
+            offset: usize,
+            cond: F,
+            sleep_us: usize,
+            timeout_us: u64,
+        ) -> Result<$type_name> {
+            if !Self::offset_ok::<$type_name>(offset) {
+                return Err(Error::EINVAL);
+            }
+            let ptr = self.ptr.wrapping_add(offset);
+            // SAFETY: The type invariants guarantee that `ptr` is a valid pointer. The check above
+            // guarantees that the code won't build if `offset` makes the read go out of bounds
+            // (including the type size).
+            unsafe { iopoll::readx_poll_timeout(bindings::$callback_name, cond, sleep_us, timeout_us, ptr as *const _) }
+        }
+    };
+}
+
 impl<const SIZE: usize> IoMem<SIZE> {
     /// Tries to create a new instance of a memory block.
     ///
@@ -186,6 +236,17 @@ impl<const SIZE: usize> IoMem<SIZE> {
     const fn check_offset<T>(offset: usize) {
         crate::build_assert!(Self::offset_ok::<T>(offset), "IoMem offset overflow");
     }
+
+    define_readx_poll_timeout!(readb_poll_timeout, try_readb_poll_timeout, readb, u8);
+    define_readx_poll_timeout!(readw_poll_timeout, try_readw_poll_timeout, readw, u16);
+    define_readx_poll_timeout!(readl_poll_timeout, try_readl_poll_timeout, readl, u32);
+    define_readx_poll_timeout!(
+        #[cfg(CONFIG_64BIT)]
+        readq_poll_timeout,
+        try_readq_poll_timeout,
+        readq,
+        u64
+    );
 
     define_read!(readb, try_readb, u8);
     define_read!(readw, try_readw, u16);

--- a/rust/kernel/iopoll.rs
+++ b/rust/kernel/iopoll.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Helper routines for polling i/o addresses.
+//!
+//! C header: [`include/linux/iopoll.h`](../../../../include/linux/iopoll.h)
+use crate::{
+    c_types, delay,
+    error::{Error, Result},
+    ktime, might_sleep_if,
+};
+
+/// Periodically poll an address until a condition is met or a timeout occurs.
+///
+/// - `op`: poll function, takes `args` as its arguments,
+/// - `cond`: break condition,
+/// - `sleep_us`: maximum time to sleep between reads in us (0
+///    tight-loops). Should be less than ~20ms since usleep_range
+///    is used, see [documentation],
+/// - `timeout_us`: timeout in `us`, 0 means never timeout,
+/// - `sleep_before_read`: when true, sleep for `sleep_us` before read,
+/// - `args`: arguments for `op` poll function.
+///
+/// Returns the last read value or ETIMEDOUT upon a timeout.
+/// Must not be called from atomic context if `sleep_us` or `timeout_us` are used.
+///
+/// [documentation]: [Documentation/timers/timers-howto.rst]
+///
+/// # Safety
+///
+/// `op` must be non-null function pointer or other callable object.
+macro_rules! read_poll_timeout {
+    ($op:ident, $cond:expr, $sleep_us:expr, $timeout_us:expr,
+     $sleep_before_read:literal, $( $args:expr ),*) => {
+        {
+            let sleep_us: usize = $sleep_us;
+            let timeout_us: u64 = $timeout_us;
+            let sleep_before_read: bool = $sleep_before_read;
+            let timeout = ktime::get().add_us(timeout_us);
+            might_sleep_if!(sleep_us != 0);
+
+            if sleep_before_read && sleep_us != 0 {
+                delay::usleep_range((sleep_us >> 2) + 1, sleep_us);
+            }
+
+            let val = loop {
+                // SAFETY: `op` is valid by the safety contract.
+                let val = unsafe { $op($( $args ),*) };
+                if $cond(&val) {
+                    break val;
+                }
+
+                if timeout_us != 0 && ktime::get() > timeout {
+                    // SAFETY: `op` is valid by the safety contract.
+                    break unsafe { $op($( $args ),*) };
+                }
+
+                if sleep_us != 0 {
+                    delay::usleep_range((sleep_us >> 2) + 1, sleep_us);
+                }
+            };
+
+            if $cond(&val) {
+                Ok(val)
+            } else {
+                Err(Error::ETIMEDOUT)
+            }
+        }
+    }
+}
+
+/// Periodically polls an address until a condition is met or a timeout occurs.
+///
+/// - `op`: poll function, takes `args` as its arguments,
+/// - `cond`: break condition,
+/// - `sleep_us`: maximum time to sleep between reads in us (0
+///    tight-loops). Should be less than ~20ms since usleep_range
+///    is used, see [documentation],
+/// - `timeout_us`: timeout in `us`, 0 means never timeout,
+/// - `args`: arguments for `op` poll function.
+///
+/// [documentation]: [Documentation/timers/timers-howto.rst]
+///
+/// # Safety
+///
+/// `op` must be non-null function pointer or other callable object.
+/// `addr` must be non-null i/o address.
+pub unsafe fn readx_poll_timeout<T, F: Fn(&T) -> bool>(
+    op: unsafe extern "C" fn(*const c_types::c_void) -> T,
+    cond: F,
+    sleep_us: usize,
+    timeout_us: u64,
+    addr: *const c_types::c_void,
+) -> Result<T> {
+    // SAFETY: `op` and `addr` are valid by the safety contract.
+    read_poll_timeout!(op, cond, sleep_us, timeout_us, false, addr)
+}

--- a/rust/kernel/ktime.rs
+++ b/rust/kernel/ktime.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Ktime - nanosecond-resolution time format.
+//!
+//! C header: [`include/linux/ktime.h`](../../../../include/linux/ktime.h)
+
+use crate::bindings;
+use core::cmp::Ordering;
+
+/// Represents `ktime_t` type.
+pub struct Ktime(bindings::ktime_t);
+
+/// Get current time value.
+pub fn get() -> Ktime {
+    // SAFETY: FFI call.
+    unsafe { Ktime(bindings::ktime_get()) }
+}
+
+impl Ktime {
+    /// Add microseconds to ktime.
+    pub fn add_us(&self, usec: u64) -> Ktime {
+        // SAFETY: FFI call.
+        unsafe { Ktime(bindings::ktime_add_us(self.0, usec)) }
+    }
+}
+
+impl PartialEq for Ktime {
+    fn eq(&self, other: &Self) -> bool {
+        ktime_compare(self, other) == Ordering::Equal
+    }
+}
+
+impl PartialOrd for Ktime {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(ktime_compare(self, other))
+    }
+}
+
+/// Compare ktime values.
+fn ktime_compare(cmp1: &Ktime, cmp2: &Ktime) -> Ordering {
+    // SAFETY: FFI call.
+    let ret = unsafe { bindings::ktime_compare(cmp1.0, cmp2.0) };
+    ret.cmp(&0)
+}

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -55,6 +55,7 @@ mod error;
 pub mod file;
 pub mod file_operations;
 pub mod gpio;
+pub mod iopoll;
 pub mod irq;
 pub mod ktime;
 pub mod miscdev;
@@ -177,6 +178,17 @@ impl<'a> Drop for KParamGuard<'a> {
         // guarantees that the lock is held.
         unsafe { bindings::kernel_param_unlock(self.this_module.0) }
     }
+}
+
+#[macro_export]
+/// Possible sleep when the provided condition is true.
+macro_rules! might_sleep_if {
+    ($cond:expr) => {
+        if $cond {
+            // SAFETY: FFI call.
+            unsafe { $crate::bindings::might_sleep() };
+        }
+    };
 }
 
 /// Calculates the offset of a field from the beginning of the struct it belongs to.

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -56,6 +56,7 @@ pub mod file;
 pub mod file_operations;
 pub mod gpio;
 pub mod irq;
+pub mod ktime;
 pub mod miscdev;
 pub mod mm;
 pub mod pages;

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -48,6 +48,7 @@ pub mod chrdev;
 #[cfg(CONFIG_COMMON_CLK)]
 pub mod clk;
 pub mod cred;
+pub mod delay;
 pub mod device;
 pub mod driver;
 mod error;


### PR DESCRIPTION
This patch adds `read_poll_timeout()` macro rewritten in Rust.
It is intended for indirect use by wrapping any specialization of
this macro in a concrete function definition such as `readx_poll_timeout()`
for a given `read()` function. This provides additional type-safety for the interface
as well as encapsulates the `read_poll_timeout!()` macro.

This patch is a dependency of a Samsung Exynos trng driver provided initially in https://github.com/Rust-for-Linux/linux/pull/554.

Signed-off-by: Maciej Falkowski <m.falkowski@samsung.com>