### PR TITLE
Kbuild: rust: remove `rust_cross_flags`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,19 +445,19 @@ export KBUILD_USERLDFLAGS :=
 
 # These flags apply to all Rust code in the tree, including the kernel and
 # host programs.
-rust_common_flags := --edition=2021 \
-		     -Zbinary_dep_depinfo=y \
-		     -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
-		     -Dunreachable_pub -Dnon_ascii_idents \
-		     -Wmissing_docs \
-		     -Drustdoc::missing_crate_level_docs \
-		     -Dclippy::correctness -Dclippy::style \
-		     -Dclippy::suspicious -Dclippy::complexity \
-		     -Dclippy::perf \
-		     -Dclippy::let_unit_value -Dclippy::mut_mut \
-		     -Dclippy::needless_bitwise_bool \
-		     -Dclippy::needless_continue \
-		     -Wclippy::dbg_macro
+export rust_common_flags := --edition=2021 \
+			    -Zbinary_dep_depinfo=y \
+			    -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
+			    -Dunreachable_pub -Dnon_ascii_idents \
+			    -Wmissing_docs \
+			    -Drustdoc::missing_crate_level_docs \
+			    -Dclippy::correctness -Dclippy::style \
+			    -Dclippy::suspicious -Dclippy::complexity \
+			    -Dclippy::perf \
+			    -Dclippy::let_unit_value -Dclippy::mut_mut \
+			    -Dclippy::needless_bitwise_bool \
+			    -Dclippy::needless_continue \
+			    -Wclippy::dbg_macro
 
 KBUILD_HOSTCFLAGS   := $(KBUILD_USERCFLAGS) $(HOST_LFS_CFLAGS) $(HOSTCFLAGS)
 KBUILD_HOSTCXXFLAGS := -Wall -O2 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS)
@@ -552,6 +552,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -std=gnu89
 KBUILD_CPPFLAGS := -D__KERNEL__
 KBUILD_RUSTFLAGS := $(rust_common_flags) \
+		    --target=$(objtree)/rust/target.json \
 		    -Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
 		    -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		    -Csymbol-mangling-version=v0 \

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -51,8 +51,7 @@ alloc-cfgs = \
 quiet_cmd_rustdoc = RUSTDOC $(if $(rustdoc_host),H, ) $<
       cmd_rustdoc = \
 	OBJTREE=$(abspath $(objtree)) \
-	$(RUSTDOC) $(if $(rustdoc_host),,$(rust_cross_flags)) \
-		$(filter-out -Cpanic=abort, $(rust_flags)) \
+	$(RUSTDOC) $(if $(rustdoc_host),$(rust_common_flags),$(rust_flags)) \
 		$(rustc_target_flags) -L $(objtree)/rust \
 		--output $(objtree)/rust/doc --crate-name $(subst rustdoc-,,$@) \
 		@$(objtree)/include/generated/rustc_cfg $<
@@ -106,7 +105,8 @@ rustdoc-kernel: $(srctree)/rust/kernel/lib.rs rustdoc-core \
 quiet_cmd_rustc_test_library = RUSTC TL $<
       cmd_rustc_test_library = \
 	OBJTREE=$(abspath $(objtree)) \
-	$(RUSTC) $(filter-out --sysroot=%, $(filter-out -Cpanic=abort, $(rust_flags))) \
+	$(RUSTC) $(rust_common_flags) \
+		@$(objtree)/include/generated/rustc_cfg \
 		$(rustc_target_flags) --crate-type $(if $(rustc_test_library_proc),proc-macro,rlib) \
 		--out-dir $(objtree)/rust/test/ --cfg testlib \
 		--sysroot $(objtree)/rust/test/sysroot \
@@ -123,7 +123,8 @@ rusttestlib-macros: $(srctree)/rust/macros/lib.rs rusttest-prepare FORCE
 quiet_cmd_rustdoc_test = RUSTDOC T $<
       cmd_rustdoc_test = \
 	OBJTREE=$(abspath $(objtree)) \
-	$(RUSTDOC) --test $(filter-out --sysroot=%, $(filter-out -Cpanic=abort, $(rust_flags))) \
+	$(RUSTDOC) --test $(rust_common_flags) \
+		@$(objtree)/include/generated/rustc_cfg \
 		$(rustc_target_flags) $(rustdoc_test_target_flags) \
 		--sysroot $(objtree)/rust/test/sysroot $(rustdoc_test_quiet) \
 		-L $(objtree)/rust/test \
@@ -135,7 +136,8 @@ quiet_cmd_rustdoc_test = RUSTDOC T $<
 quiet_cmd_rustc_test = RUSTC T  $<
       cmd_rustc_test = \
 	OBJTREE=$(abspath $(objtree)) \
-	$(RUSTC) --test $(filter-out --sysroot=%, $(filter-out -Cpanic=abort, $(rust_flags))) \
+	$(RUSTC) --test $(rust_common_flags) \
+		@$(objtree)/include/generated/rustc_cfg \
 		$(rustc_target_flags) --out-dir $(objtree)/rust/test \
 		--sysroot $(objtree)/rust/test/sysroot \
 		-L $(objtree)/rust/test/ --crate-name $(subst rusttest-,,$@) $<; \
@@ -305,13 +307,10 @@ $(objtree)/rust/exports_alloc_generated.h: $(objtree)/rust/alloc.o FORCE
 $(objtree)/rust/exports_kernel_generated.h: $(objtree)/rust/kernel.o FORCE
 	$(call if_changed,exports)
 
-# `-Cpanic=unwind -Cforce-unwind-tables=y` overrides `rust_flags` in order to
-# avoid the https://github.com/rust-lang/rust/issues/82320 rustc crash.
 quiet_cmd_rustc_procmacro = $(RUSTC_OR_CLIPPY_QUIET) P $@
       cmd_rustc_procmacro = \
-	$(RUSTC_OR_CLIPPY) $(rust_flags) \
+	$(RUSTC_OR_CLIPPY) $(rust_common_flags) \
 		--emit=dep-info,link --extern proc_macro \
-		-Cpanic=unwind -Cforce-unwind-tables=y \
 		--crate-type proc-macro --out-dir $(objtree)/rust/ \
 		--crate-name $(patsubst lib%.so,%,$(notdir $@)) $<; \
 	mv $(objtree)/rust/$(patsubst lib%.so,%,$(notdir $@)).d $(depfile); \
@@ -328,7 +327,7 @@ quiet_cmd_rustc_library = $(if $(skip_clippy),RUSTC,$(RUSTC_OR_CLIPPY_QUIET)) L 
       cmd_rustc_library = \
 	OBJTREE=$(abspath $(objtree)) \
 	$(if $(skip_clippy),$(RUSTC),$(RUSTC_OR_CLIPPY)) \
-		$(filter-out $(skip_flags),$(rust_flags) $(rust_cross_flags) $(rustc_target_flags)) \
+		$(filter-out $(skip_flags),$(rust_flags) $(rustc_target_flags)) \
 		--emit=dep-info,obj,metadata \
 		--crate-type rlib --out-dir $(objtree)/rust/ -L $(objtree)/rust/ \
 		--crate-name $(patsubst %.o,%,$(notdir $@)) $<; \

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -328,12 +328,10 @@ $(obj)/%.lst: $(src)/%.c FORCE
 # Compile Rust sources (.rs)
 # ---------------------------------------------------------------------------
 
-rust_cross_flags := --target=$(objtree)/rust/target.json
 rust_allowed_features := allocator_api,bench_black_box,concat_idents,generic_associated_types
 
 rust_common_cmd = \
-	RUST_MODFILE=$(modfile) $(RUSTC_OR_CLIPPY) \
-	$(rust_flags) $(rust_cross_flags) \
+	RUST_MODFILE=$(modfile) $(RUSTC_OR_CLIPPY) $(rust_flags) \
 	-Zallow-features=$(rust_allowed_features) \
 	-Zcrate-attr=no_std \
 	-Zcrate-attr='feature($(rust_allowed_features))' \


### PR DESCRIPTION
Export the `rust_common_flags` and use those for proc macros and test targets,
instead of tweaking `rust_flags` and having a `rust_cross_flags`.
This simplifies things a bit and avoids later having to tweak
the flags further during the `target.json` cleanups.

Since now we use "standard" flags (i.e. no `-Cpanic=abort` etc.) for
compiling the proc macros, we do not need the comment on proc macros
breaking under non-`panic=unwind` builds (we still track it in the
GitHub list in any case).

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>