### PR TITLE
Target specification cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -887,6 +887,8 @@ else
 # select FRAME_POINTER.  However, FUNCTION_TRACER adds -pg, and this is
 # incompatible with -fomit-frame-pointer with current GCC, so we don't use
 # -fomit-frame-pointer with FUNCTION_TRACER.
+# In the Rust target specification, "frame-pointer" is set explicitly
+# to "may-omit".
 ifndef CONFIG_FUNCTION_TRACER
 KBUILD_CFLAGS	+= -fomit-frame-pointer
 endif

--- a/Makefile
+++ b/Makefile
@@ -556,6 +556,7 @@ KBUILD_RUSTFLAGS := $(rust_common_flags) \
 		    -Cpanic=abort -Cembed-bitcode=n -Clto=n \
 		    -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		    -Csymbol-mangling-version=v0 \
+		    -Crelocation-model=static \
 		    -Dclippy::float_arithmetic
 
 KBUILD_AFLAGS_KERNEL :=

--- a/Makefile
+++ b/Makefile
@@ -557,6 +557,7 @@ KBUILD_RUSTFLAGS := $(rust_common_flags) \
 		    -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		    -Csymbol-mangling-version=v0 \
 		    -Crelocation-model=static \
+		    -Zfunction-sections=n \
 		    -Dclippy::float_arithmetic
 
 KBUILD_AFLAGS_KERNEL :=

--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 KBUILD_CPPFLAGS := -D__KERNEL__
 KBUILD_RUSTFLAGS := $(rust_common_flags) \
 		    --target=$(objtree)/rust/target.json \
-		    -Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
+		    -Cpanic=abort -Cembed-bitcode=n -Clto=n \
 		    -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		    -Csymbol-mangling-version=v0 \
 		    -Dclippy::float_arithmetic

--- a/Makefile
+++ b/Makefile
@@ -955,8 +955,10 @@ ifdef CONFIG_DEBUG_SECTION_MISMATCH
 KBUILD_CFLAGS += -fno-inline-functions-called-once
 endif
 
+# `rustc`'s `-Zfunction-sections` applies to data too (as of 1.59.0).
 ifdef CONFIG_LD_DEAD_CODE_DATA_ELIMINATION
 KBUILD_CFLAGS_KERNEL += -ffunction-sections -fdata-sections
+KBUILD_RUSTFLAGS_KERNEL += -Zfunction-sections=y
 LDFLAGS_vmlinux += --gc-sections
 endif
 

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -26,6 +26,8 @@ ifeq ($(CONFIG_ARCH_RV64I),y)
 	KBUILD_CFLAGS += -mabi=lp64
 	KBUILD_AFLAGS += -mabi=lp64
 
+	KBUILD_RUSTFLAGS += -Ctarget-cpu=generic-rv64
+
 	KBUILD_LDFLAGS += -melf64lriscv
 else
 	BITS := 32
@@ -33,6 +35,9 @@ else
 
 	KBUILD_CFLAGS += -mabi=ilp32
 	KBUILD_AFLAGS += -mabi=ilp32
+
+	KBUILD_RUSTFLAGS += -Ctarget-cpu=generic-rv32
+
 	KBUILD_LDFLAGS += -melf32lriscv
 endif
 

--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -140,6 +140,13 @@ else
         cflags-$(CONFIG_GENERIC_CPU)	+= -mtune=generic
         KBUILD_CFLAGS += $(cflags-y)
 
+        rustflags-$(CONFIG_MK8)		+= -Ctarget-cpu=k8
+        rustflags-$(CONFIG_MPSC)	+= -Ctarget-cpu=nocona
+        rustflags-$(CONFIG_MCORE2)	+= -Ctarget-cpu=core2
+        rustflags-$(CONFIG_MATOM)	+= -Ctarget-cpu=atom
+        rustflags-$(CONFIG_GENERIC_CPU)	+= -Ztune-cpu=generic
+        KBUILD_RUSTFLAGS += $(rustflags-y)
+
         KBUILD_CFLAGS += -mno-red-zone
         KBUILD_CFLAGS += -mcmodel=kernel
         KBUILD_RUSTFLAGS += -Cno-redzone=y

--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -138,6 +138,7 @@ else
 
         KBUILD_CFLAGS += -mno-red-zone
         KBUILD_CFLAGS += -mcmodel=kernel
+        KBUILD_RUSTFLAGS += -Cno-redzone=y
 endif
 
 ifdef CONFIG_X86_X32

--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -61,6 +61,8 @@ export BITS
 #    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53383
 #
 KBUILD_CFLAGS += -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx
+KBUILD_RUSTFLAGS += -Ctarget-feature=-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2
+KBUILD_RUSTFLAGS += -Ctarget-feature=-3dnow,-3dnowa,-avx,-avx2,+soft-float
 
 # Intel CET isn't enabled in the kernel
 KBUILD_CFLAGS += $(call cc-option,-fcf-protection=none)

--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -139,6 +139,7 @@ else
         KBUILD_CFLAGS += -mno-red-zone
         KBUILD_CFLAGS += -mcmodel=kernel
         KBUILD_RUSTFLAGS += -Cno-redzone=y
+        KBUILD_RUSTFLAGS += -Ccode-model=kernel
 endif
 
 ifdef CONFIG_X86_X32

--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -21,6 +21,8 @@ ifdef CONFIG_CC_IS_CLANG
 RETPOLINE_CFLAGS	:= -mretpoline-external-thunk
 RETPOLINE_VDSO_CFLAGS	:= -mretpoline
 endif
+RETPOLINE_RUSTFLAGS	:= -Ctarget-feature=+retpoline-external-thunk
+
 export RETPOLINE_CFLAGS
 export RETPOLINE_VDSO_CFLAGS
 
@@ -193,6 +195,7 @@ ifdef CONFIG_RETPOLINE
   ifndef CONFIG_CC_IS_CLANG
     KBUILD_CFLAGS += -fno-jump-tables
   endif
+  KBUILD_RUSTFLAGS += $(RETPOLINE_RUSTFLAGS)
 endif
 
 ifdef CONFIG_SLS

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -211,7 +211,6 @@ fn main() {
             "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
         );
         ts.push("disable-redzone", true);
-        ts.push("emit-debug-gdb-scripts", false);
         ts.push("features", "+strict-align,+neon,+fp-armv8");
         ts.push("frame-pointer", "always");
         ts.push("llvm-target", "aarch64-unknown-none");
@@ -254,7 +253,6 @@ fn main() {
         }
         ts.push("code-model", "medium");
         ts.push("disable-redzone", true);
-        ts.push("emit-debug-gdb-scripts", false);
         let mut features = "+m,+a".to_string();
         if cfg.has("RISCV_ISA_C") {
             features += ",+c";
@@ -274,7 +272,6 @@ fn main() {
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
         );
         ts.push("disable-redzone", true);
-        ts.push("emit-debug-gdb-scripts", false);
         ts.push(
             "features",
             "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
@@ -292,6 +289,7 @@ fn main() {
         panic!("Unsupported architecture");
     }
 
+    ts.push("emit-debug-gdb-scripts", false);
     ts.push("env", "gnu");
     ts.push("function-sections", false);
     ts.push("linker-is-gnu", true);

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -170,7 +170,6 @@ fn main() {
         ts.push("features", "+strict-align,+neon,+fp-armv8");
         ts.push("llvm-target", "aarch64-unknown-none");
         ts.push("max-atomic-width", 128);
-        ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
     } else if cfg.has("PPC") {
@@ -206,7 +205,6 @@ fn main() {
             features += ",+c";
         }
         ts.push("features", features);
-        ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
     } else if cfg.has("X86") {
         ts.push("arch", "x86_64");
@@ -217,7 +215,6 @@ fn main() {
         );
         ts.push("llvm-target", "x86_64-elf");
         ts.push("max-atomic-width", 64);
-        ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
     } else {

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -187,14 +187,12 @@ fn main() {
             ts.push("cpu", "generic-rv64");
             ts.push("data-layout", "e-m:e-p:64:64-i64:64-i128:128-n64-S128");
             ts.push("llvm-target", "riscv64");
-            ts.push("max-atomic-width", 64);
             ts.push("target-pointer-width", "64");
         } else {
             ts.push("arch", "riscv32");
             ts.push("cpu", "generic-rv32");
             ts.push("data-layout", "e-m:e-p:32:32-i64:64-n32-S128");
             ts.push("llvm-target", "riscv32");
-            ts.push("max-atomic-width", 32);
             ts.push("target-pointer-width", "32");
         }
         ts.push("code-model", "medium");
@@ -212,7 +210,6 @@ fn main() {
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
         );
         ts.push("llvm-target", "x86_64-elf");
-        ts.push("max-atomic-width", 64);
         ts.push("target-pointer-width", "64");
     } else {
         panic!("Unsupported architecture");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -238,9 +238,5 @@ fn main() {
         ts.push("target-endian", "big");
     }
 
-    if !cfg.has("ARM") {
-        ts.push("relro-level", "full");
-    }
-
     println!("{}", ts);
 }

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -212,7 +212,6 @@ fn main() {
 
     ts.push("emit-debug-gdb-scripts", false);
     ts.push("frame-pointer", "may-omit");
-    ts.push("function-sections", false);
     ts.push(
         "stack-probes",
         vec![("kind".to_string(), Value::String("none".to_string()))],

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -238,7 +238,6 @@ fn main() {
     ts.push("env", "gnu");
     ts.push("frame-pointer", "may-omit");
     ts.push("function-sections", false);
-    ts.push("linker-is-gnu", true);
     ts.push("position-independent-executables", true);
     ts.push("relocation-model", "static");
     ts.push(

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -170,7 +170,6 @@ fn main() {
         ts.push("features", "+strict-align,+neon,+fp-armv8");
         ts.push("llvm-target", "aarch64-unknown-none");
         ts.push("max-atomic-width", 128);
-        ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
     } else if cfg.has("PPC") {
         ts.push("arch", "powerpc64");
@@ -205,7 +204,6 @@ fn main() {
             features += ",+c";
         }
         ts.push("features", features);
-        ts.push("target-c-int-width", "32");
     } else if cfg.has("X86") {
         ts.push("arch", "x86_64");
         ts.push("cpu", "x86-64");
@@ -215,7 +213,6 @@ fn main() {
         );
         ts.push("llvm-target", "x86_64-elf");
         ts.push("max-atomic-width", 64);
-        ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
     } else {
         panic!("Unsupported architecture");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -155,7 +155,6 @@ fn main() {
         ts.push("dynamic-linking", true);
         ts.push("crt-static-respected", true);
         ts.push("features", "+strict-align,+v6");
-        ts.push("has-elf-tls", true);
         ts.push("llvm-target", "arm-linux-gnueabi");
         ts.push("max-atomic-width", 64);
         ts.push("target-mcount", "\\u0001__gnu_mcount_nc");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -36,9 +36,9 @@ impl Display for Value {
                 formatter.write_str("{")?;
                 if let [ref rest @ .., ref last] = object[..] {
                     for (key, value) in rest {
-                        write!(formatter, "\"{}\":{},", key, value)?;
+                        write!(formatter, "\"{}\": {},", key, value)?;
                     }
-                    write!(formatter, "\"{}\":{}", last.0, last.1)?;
+                    write!(formatter, "\"{}\": {}", last.0, last.1)?;
                 }
                 formatter.write_str("}")
             }
@@ -94,9 +94,9 @@ impl Display for TargetSpec {
         formatter.write_str("{\n")?;
         if let [ref rest @ .., ref last] = self.0[..] {
             for (key, value) in rest {
-                write!(formatter, "\"{}\":{},\n", key, value)?;
+                write!(formatter, "    \"{}\": {},\n", key, value)?;
             }
-            write!(formatter, "\"{}\":{}\n", last.0, last.1)?;
+            write!(formatter, "    \"{}\": {}\n", last.0, last.1)?;
         }
         formatter.write_str("}")
     }

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -176,7 +176,6 @@ fn main() {
         ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
-        ts.push("vendor", "");
     } else if cfg.has("PPC") {
         ts.push("arch", "powerpc64");
         ts.push("code-model", "large");
@@ -213,7 +212,6 @@ fn main() {
         ts.push("features", features);
         ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
-        ts.push("vendor", "");
     } else if cfg.has("X86") {
         ts.push("arch", "x86_64");
         ts.push("code-model", "kernel");
@@ -232,7 +230,6 @@ fn main() {
         ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
-        ts.push("vendor", "unknown");
     } else {
         panic!("Unsupported architecture");
     }

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -227,7 +227,6 @@ fn main() {
     ts.push("emit-debug-gdb-scripts", false);
     ts.push("frame-pointer", "may-omit");
     ts.push("function-sections", false);
-    ts.push("position-independent-executables", true);
     ts.push(
         "stack-probes",
         vec![("kind".to_string(), Value::String("none".to_string()))],

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -156,7 +156,6 @@ fn main() {
         ts.push("crt-static-respected", true);
         ts.push("features", "+strict-align,+v6");
         ts.push("has-elf-tls", true);
-        ts.push("has-rpath", true);
         ts.push("llvm-target", "arm-unknown-linux-gnueabi");
         ts.push("max-atomic-width", 64);
         ts.push("target-family", "unix");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -246,16 +246,14 @@ fn main() {
         vec![("kind".to_string(), Value::String("none".to_string()))],
     );
 
+    // Everything else is LE, whether `CPU_LITTLE_ENDIAN`
+    // is declared or not (e.g. x86).
+    if cfg.has("CPU_BIG_ENDIAN") {
+        ts.push("target-endian", "big");
+    }
+
     if !cfg.has("ARM") {
         ts.push("relro-level", "full");
-
-        if cfg.has("CPU_BIG_ENDIAN") {
-            ts.push("target-endian", "big");
-        } else {
-            // Everything else is LE, whether `CPU_LITTLE_ENDIAN`
-            // is declared or not (e.g. x86).
-            ts.push("target-endian", "little");
-        }
     }
 
     println!("{}", ts);

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -158,32 +158,6 @@ fn main() {
     let cfg = KernelConfig::from_stdin();
     let mut ts = TargetSpec::new();
 
-    let pre_link_args = vec![(
-        "gcc".to_string(),
-        Value::Array(vec![
-            Value::String("-Wl,--as-needed".to_string()),
-            Value::String("-Wl,-z,noexecstack".to_string()),
-        ]),
-    )];
-
-    let pre_link_args_32 = vec![(
-        "gcc".to_string(),
-        Value::Array(vec![
-            Value::String("-Wl,--as-needed".to_string()),
-            Value::String("-Wl,-z,noexecstack".to_string()),
-            Value::String("-m32".to_string()),
-        ]),
-    )];
-
-    let pre_link_args_64 = vec![(
-        "gcc".to_string(),
-        Value::Array(vec![
-            Value::String("-Wl,--as-needed".to_string()),
-            Value::String("-Wl,-z,noexecstack".to_string()),
-            Value::String("-m64".to_string()),
-        ]),
-    )];
-
     if cfg.has("ARM") {
         ts.push("arch", "arm");
         ts.push(
@@ -198,7 +172,6 @@ fn main() {
         ts.push("has-rpath", true);
         ts.push("llvm-target", "arm-unknown-linux-gnueabi");
         ts.push("max-atomic-width", 64);
-        ts.push("pre-link-args", pre_link_args);
         ts.push("target-family", "unix");
         ts.push("target-mcount", "\\u0001__gnu_mcount_nc");
         ts.push("target-pointer-width", "32");
@@ -213,7 +186,6 @@ fn main() {
         ts.push("llvm-target", "aarch64-unknown-none");
         ts.push("max-atomic-width", 128);
         ts.push("needs-plt", true);
-        ts.push("pre-link-args", pre_link_args_64);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
         ts.push("vendor", "");
@@ -225,7 +197,6 @@ fn main() {
         ts.push("features", "-altivec,-vsx,-hard-float");
         ts.push("llvm-target", "powerpc64le-elf");
         ts.push("max-atomic-width", 64);
-        ts.push("pre-link-args", pre_link_args_64);
         ts.push("target-family", "unix");
         ts.push("target-mcount", "_mcount");
         ts.push("target-pointer-width", "64");
@@ -236,7 +207,6 @@ fn main() {
             ts.push("data-layout", "e-m:e-p:64:64-i64:64-i128:128-n64-S128");
             ts.push("llvm-target", "riscv64");
             ts.push("max-atomic-width", 64);
-            ts.push("pre-link-args", pre_link_args_64);
             ts.push("target-pointer-width", "64");
         } else {
             ts.push("arch", "riscv32");
@@ -244,7 +214,6 @@ fn main() {
             ts.push("data-layout", "e-m:e-p:32:32-i64:64-n32-S128");
             ts.push("llvm-target", "riscv32");
             ts.push("max-atomic-width", 32);
-            ts.push("pre-link-args", pre_link_args_32);
             ts.push("target-pointer-width", "32");
         }
         ts.push("code-model", "medium");
@@ -273,7 +242,6 @@ fn main() {
         ts.push("llvm-target", "x86_64-elf");
         ts.push("max-atomic-width", 64);
         ts.push("needs-plt", true);
-        ts.push("pre-link-args", pre_link_args_64);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
         ts.push("vendor", "unknown");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -216,7 +216,6 @@ fn main() {
             "data-layout",
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
         );
-        ts.push("disable-redzone", true);
         ts.push(
             "features",
             "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -5,7 +5,8 @@
 //! To configure a target from scratch, a JSON-encoded file has to be passed
 //! to `rustc` (introduced in [RFC 131]). These options and the file itself are
 //! unstable. Eventually, `rustc` should provide a way to do this in a stable
-//! manner. For instance, via command-line arguments.
+//! manner. For instance, via command-line arguments. Therefore, this file
+//! should avoid using keys which can be set via `-C` or `-Z` options.
 //!
 //! [RFC 131]: https://rust-lang.github.io/rfcs/0131-target-specification.html
 
@@ -24,8 +25,8 @@ enum Value {
 
 type Object = Vec<(String, Value)>;
 
-/// Minimal "almost JSON" generator (e.g. no `null`s, no escaping), enough
-/// for this purpose.
+/// Minimal "almost JSON" generator (e.g. no `null`s, no arrays, no escaping),
+/// enough for this purpose.
 impl Display for Value {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
         match self {
@@ -135,7 +136,7 @@ impl KernelConfig {
     ///
     /// The argument must be passed without the `CONFIG_` prefix.
     /// This avoids repetition and it also avoids `fixdep` making us
-    /// depending on it.
+    /// depend on it.
     fn has(&self, option: &str) -> bool {
         let option = "CONFIG_".to_owned() + option;
         self.0.contains_key(&option)
@@ -215,8 +216,8 @@ fn main() {
         vec![("kind".to_string(), Value::String("none".to_string()))],
     );
 
-    // Everything else is LE, whether `CPU_LITTLE_ENDIAN`
-    // is declared or not (e.g. x86).
+    // Everything else is LE, whether `CPU_LITTLE_ENDIAN` is declared or not
+    // (e.g. x86). It is also `rustc`'s default.
     if cfg.has("CPU_BIG_ENDIAN") {
         ts.push("target-endian", "big");
     }

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -156,7 +156,7 @@ fn main() {
         ts.push("crt-static-respected", true);
         ts.push("features", "+strict-align,+v6");
         ts.push("has-elf-tls", true);
-        ts.push("llvm-target", "arm-unknown-linux-gnueabi");
+        ts.push("llvm-target", "arm-linux-gnueabi");
         ts.push("max-atomic-width", 64);
         ts.push("target-mcount", "\\u0001__gnu_mcount_nc");
         ts.push("target-pointer-width", "32");
@@ -168,7 +168,7 @@ fn main() {
         );
         ts.push("disable-redzone", true);
         ts.push("features", "+strict-align,+neon,+fp-armv8");
-        ts.push("llvm-target", "aarch64-unknown-none");
+        ts.push("llvm-target", "aarch64-linux-gnu");
         ts.push("max-atomic-width", 128);
         ts.push("target-pointer-width", "64");
     } else if cfg.has("PPC") {
@@ -177,7 +177,7 @@ fn main() {
         ts.push("cpu", "ppc64le");
         ts.push("data-layout", "e-m:e-i64:64-n32:64");
         ts.push("features", "-altivec,-vsx,-hard-float");
-        ts.push("llvm-target", "powerpc64le-elf");
+        ts.push("llvm-target", "powerpc64le-linux-gnu");
         ts.push("max-atomic-width", 64);
         ts.push("target-mcount", "_mcount");
         ts.push("target-pointer-width", "64");
@@ -186,13 +186,13 @@ fn main() {
             ts.push("arch", "riscv64");
             ts.push("cpu", "generic-rv64");
             ts.push("data-layout", "e-m:e-p:64:64-i64:64-i128:128-n64-S128");
-            ts.push("llvm-target", "riscv64");
+            ts.push("llvm-target", "riscv64-linux-gnu");
             ts.push("target-pointer-width", "64");
         } else {
             ts.push("arch", "riscv32");
             ts.push("cpu", "generic-rv32");
             ts.push("data-layout", "e-m:e-p:32:32-i64:64-n32-S128");
-            ts.push("llvm-target", "riscv32");
+            ts.push("llvm-target", "riscv32-linux-gnu");
             ts.push("target-pointer-width", "32");
         }
         ts.push("code-model", "medium");
@@ -209,7 +209,7 @@ fn main() {
             "data-layout",
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
         );
-        ts.push("llvm-target", "x86_64-elf");
+        ts.push("llvm-target", "x86_64-linux-gnu");
         ts.push("target-pointer-width", "64");
     } else {
         panic!("Unsupported architecture");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -231,7 +231,6 @@ fn main() {
     }
 
     ts.push("emit-debug-gdb-scripts", false);
-    ts.push("env", "gnu");
     ts.push("frame-pointer", "may-omit");
     ts.push("function-sections", false);
     ts.push("position-independent-executables", true);

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -228,7 +228,6 @@ fn main() {
     ts.push("frame-pointer", "may-omit");
     ts.push("function-sections", false);
     ts.push("position-independent-executables", true);
-    ts.push("relocation-model", "static");
     ts.push(
         "stack-probes",
         vec![("kind".to_string(), Value::String("none".to_string()))],

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -215,10 +215,6 @@ fn main() {
             "data-layout",
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
         );
-        ts.push(
-            "features",
-            "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
-        );
         ts.push("llvm-target", "x86_64-elf");
         ts.push("max-atomic-width", 64);
         ts.push("needs-plt", true);

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -239,7 +239,6 @@ fn main() {
     ts.push("frame-pointer", "may-omit");
     ts.push("function-sections", false);
     ts.push("linker-is-gnu", true);
-    ts.push("os", if cfg.has("ARM") { "linux" } else { "none" });
     ts.push("position-independent-executables", true);
     ts.push("relocation-model", "static");
     ts.push(

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -19,11 +19,9 @@ enum Value {
     Boolean(bool),
     Number(i32),
     String(String),
-    Array(Array),
     Object(Object),
 }
 
-type Array = Vec<Value>;
 type Object = Vec<(String, Value)>;
 
 /// Minimal "almost JSON" generator (e.g. no `null`s, no escaping), enough
@@ -34,16 +32,6 @@ impl Display for Value {
             Value::Boolean(boolean) => write!(formatter, "{}", boolean),
             Value::Number(number) => write!(formatter, "{}", number),
             Value::String(string) => write!(formatter, "\"{}\"", string),
-            Value::Array(array) => {
-                formatter.write_str("[")?;
-                if let [ref rest @ .., ref last] = array[..] {
-                    for value in rest {
-                        write!(formatter, "{},", value)?;
-                    }
-                    write!(formatter, "{}", last)?;
-                }
-                formatter.write_str("]")
-            }
             Value::Object(object) => {
                 formatter.write_str("{")?;
                 if let [ref rest @ .., ref last] = object[..] {

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -248,7 +248,6 @@ fn main() {
     );
 
     if !cfg.has("ARM") {
-        ts.push("linker-flavor", "gcc");
         ts.push("relro-level", "full");
 
         if cfg.has("CPU_BIG_ENDIAN") {

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -158,7 +158,6 @@ fn main() {
         ts.push("has-elf-tls", true);
         ts.push("llvm-target", "arm-unknown-linux-gnueabi");
         ts.push("max-atomic-width", 64);
-        ts.push("target-family", "unix");
         ts.push("target-mcount", "\\u0001__gnu_mcount_nc");
         ts.push("target-pointer-width", "32");
     } else if cfg.has("ARM64") {
@@ -182,7 +181,6 @@ fn main() {
         ts.push("features", "-altivec,-vsx,-hard-float");
         ts.push("llvm-target", "powerpc64le-elf");
         ts.push("max-atomic-width", 64);
-        ts.push("target-family", "unix");
         ts.push("target-mcount", "_mcount");
         ts.push("target-pointer-width", "64");
     } else if cfg.has("RISCV") {

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -152,7 +152,6 @@ fn main() {
             "data-layout",
             "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
         );
-        ts.push("dynamic-linking", true);
         ts.push("crt-static-respected", true);
         ts.push("features", "+strict-align,+v6");
         ts.push("llvm-target", "arm-linux-gnueabi");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -249,7 +249,6 @@ fn main() {
 
     if !cfg.has("ARM") {
         ts.push("linker-flavor", "gcc");
-        ts.push("panic-strategy", "abort");
         ts.push("relro-level", "full");
 
         if cfg.has("CPU_BIG_ENDIAN") {

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -173,7 +173,6 @@ fn main() {
     } else if cfg.has("PPC") {
         ts.push("arch", "powerpc64");
         ts.push("code-model", "large");
-        ts.push("cpu", "ppc64le");
         ts.push("data-layout", "e-m:e-i64:64-n32:64");
         ts.push("features", "-altivec,-vsx,-hard-float");
         ts.push("llvm-target", "powerpc64le-linux-gnu");
@@ -183,13 +182,11 @@ fn main() {
     } else if cfg.has("RISCV") {
         if cfg.has("64BIT") {
             ts.push("arch", "riscv64");
-            ts.push("cpu", "generic-rv64");
             ts.push("data-layout", "e-m:e-p:64:64-i64:64-i128:128-n64-S128");
             ts.push("llvm-target", "riscv64-linux-gnu");
             ts.push("target-pointer-width", "64");
         } else {
             ts.push("arch", "riscv32");
-            ts.push("cpu", "generic-rv32");
             ts.push("data-layout", "e-m:e-p:32:32-i64:64-n32-S128");
             ts.push("llvm-target", "riscv32-linux-gnu");
             ts.push("target-pointer-width", "32");
@@ -203,7 +200,6 @@ fn main() {
         ts.push("features", features);
     } else if cfg.has("X86") {
         ts.push("arch", "x86_64");
-        ts.push("cpu", "x86-64");
         ts.push(
             "data-layout",
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -152,7 +152,6 @@ fn main() {
             "data-layout",
             "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
         );
-        ts.push("crt-static-respected", true);
         ts.push("features", "+strict-align,+v6");
         ts.push("llvm-target", "arm-linux-gnueabi");
         ts.push("max-atomic-width", 64);

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -154,7 +154,6 @@ fn main() {
         );
         ts.push("dynamic-linking", true);
         ts.push("crt-static-respected", true);
-        ts.push("executables", true);
         ts.push("features", "+strict-align,+v6");
         ts.push("has-elf-tls", true);
         ts.push("has-rpath", true);

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -184,8 +184,6 @@ fn main() {
         ]),
     )];
 
-    let stack_probes = vec![("kind".to_string(), Value::String("none".to_string()))];
-
     if cfg.has("ARM") {
         ts.push("arch", "arm");
         ts.push(
@@ -217,7 +215,6 @@ fn main() {
         ts.push("max-atomic-width", 128);
         ts.push("needs-plt", true);
         ts.push("pre-link-args", pre_link_args_64);
-        ts.push("stack-probes", stack_probes);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
         ts.push("vendor", "");
@@ -261,7 +258,6 @@ fn main() {
         ts.push("frame-pointer", "always");
         ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
-        ts.push("stack-probes", stack_probes);
         ts.push("vendor", "");
     } else if cfg.has("X86") {
         ts.push("arch", "x86_64");
@@ -281,7 +277,6 @@ fn main() {
         ts.push("max-atomic-width", 64);
         ts.push("needs-plt", true);
         ts.push("pre-link-args", pre_link_args_64);
-        ts.push("stack-probes", stack_probes);
         ts.push("target-c-int-width", "32");
         ts.push("target-pointer-width", "64");
         ts.push("vendor", "unknown");
@@ -296,6 +291,10 @@ fn main() {
     ts.push("os", if cfg.has("ARM") { "linux" } else { "none" });
     ts.push("position-independent-executables", true);
     ts.push("relocation-model", "static");
+    ts.push(
+        "stack-probes",
+        vec![("kind".to_string(), Value::String("none".to_string()))],
+    );
 
     if !cfg.has("ARM") {
         ts.push("linker-flavor", "gcc");

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -210,7 +210,6 @@ fn main() {
         ts.push("target-c-int-width", "32");
     } else if cfg.has("X86") {
         ts.push("arch", "x86_64");
-        ts.push("code-model", "kernel");
         ts.push("cpu", "x86-64");
         ts.push(
             "data-layout",

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -210,7 +210,6 @@ fn main() {
         );
         ts.push("disable-redzone", true);
         ts.push("features", "+strict-align,+neon,+fp-armv8");
-        ts.push("frame-pointer", "always");
         ts.push("llvm-target", "aarch64-unknown-none");
         ts.push("max-atomic-width", 128);
         ts.push("needs-plt", true);
@@ -255,7 +254,6 @@ fn main() {
             features += ",+c";
         }
         ts.push("features", features);
-        ts.push("frame-pointer", "always");
         ts.push("needs-plt", true);
         ts.push("target-c-int-width", "32");
         ts.push("vendor", "");
@@ -272,7 +270,6 @@ fn main() {
             "features",
             "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
         );
-        ts.push("frame-pointer", "always");
         ts.push("llvm-target", "x86_64-elf");
         ts.push("max-atomic-width", 64);
         ts.push("needs-plt", true);
@@ -286,6 +283,7 @@ fn main() {
 
     ts.push("emit-debug-gdb-scripts", false);
     ts.push("env", "gnu");
+    ts.push("frame-pointer", "may-omit");
     ts.push("function-sections", false);
     ts.push("linker-is-gnu", true);
     ts.push("os", if cfg.has("ARM") { "linux" } else { "none" });

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -164,7 +164,7 @@ fn main() {
             "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
         );
         ts.push("disable-redzone", true);
-        ts.push("features", "+strict-align,+neon,+fp-armv8");
+        ts.push("features", "+strict-align,-neon,-fp-armv8");
         ts.push("llvm-target", "aarch64-linux-gnu");
         ts.push("max-atomic-width", 128);
         ts.push("target-pointer-width", "64");


### PR DESCRIPTION
PR #694 introduced `target.json` generation on the fly, intentionally keeping the generated files exactly as the ones we previously had in the repository.

However, those `target.json` files we had were just examples. Now we need to start configuring `rustc`/LLVM properly depending on what the kernel configuration is, which requires first cleaning up the script as much as possible. In particular, this involves:

  - Factoring out things that apply to all architectures to reduce complexity.
  - Removing unused keys (e.g. if they are not needed or if they are already the default).
  - Fixing any wrong value.
  - Moving as much as possible into each architecture via command-line options (`-C` and `-Z`), so that we reduce our dependency on the script (eventually removing it).

This PR leaves x86 "clean", i.e. with only the 4 required keys in the script and everything else in `arch/x86/Makefile` as command-line flags.

The other architectures have been fairly cleaned up as well, though I have avoided moving the options to their `Makefile`s yet (with the exception of RISC-V for a trivial detail), mainly in order to avoid introducing lots of changes upstream before Rust is merged. And, nevertheless, it would be best if arch maintainers take a look at how they exactly want to set it up anyway.

While not strictly part of the cleanup, I added `retpoline-external-thunk` as well as `-Ctarget-cpu`/`-Ztune-cpu` as needed for x86 and `-f{data,function}-sections` for all. This is intended to have x86 as complete as possible.

During this I found a couple of small issues (in LLVM and `rustc`), which I will be filling soon. I will also update the live lists with the few new unstable flags we are depending on. I will also start requesting/adding support upstream for some flags we will need.

There are a lot of small commits in this PR in order to justify each change separately. Please see details in the commit messages.

This partially addresses Russell King's feedback.

@mpe In case you want to consider start moving flags to the arch `Makefile`.
@bjorn3 @nbdd0121 Since you may know some `rustc` details.