### PR TITLE
Makefile: strip debug info for Rust host programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,8 +461,8 @@ export rust_common_flags := --edition=2021 \
 
 KBUILD_HOSTCFLAGS   := $(KBUILD_USERCFLAGS) $(HOST_LFS_CFLAGS) $(HOSTCFLAGS)
 KBUILD_HOSTCXXFLAGS := -Wall -O2 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS)
-KBUILD_HOSTRUSTFLAGS := $(rust_common_flags) -O -Zallow-features= \
-			$(HOSTRUSTFLAGS)
+KBUILD_HOSTRUSTFLAGS := $(rust_common_flags) -O -Cstrip=debuginfo \
+			-Zallow-features= $(HOSTRUSTFLAGS)
 KBUILD_HOSTLDFLAGS  := $(HOST_LFS_LDFLAGS) $(HOSTLDFLAGS)
 KBUILD_HOSTLDLIBS   := $(HOST_LFS_LIBS) $(HOSTLDLIBS)
 


### PR DESCRIPTION
This makes `scripts/generate_rust_target.rs` take about 94%
of the original time.

From https://github.com/Rust-for-Linux/linux/pull/692#issuecomment-1067199222:

> This will make the linker skip debuginfo from libstd (which
> is shipped with debuginfo).

...which should be fine -- if somebody really needs to debug
one of the host programs/scripts, they may as well enable
debugging info for the actual code too.

Suggested-by: bjorn3 <bjorn3_gh@protonmail.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>