### PR TITLE
rust: rename `FileOperations::Wrapper` to `FileOperations::Data`

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -806,16 +806,16 @@ impl IoctlHandler for Process {
 }
 
 impl FileOperations for Process {
-    type Wrapper = Ref<Self>;
+    type Data = Ref<Self>;
     type OpenData = Ref<Context>;
 
     kernel::declare_file_operations!(ioctl, compat_ioctl, mmap, poll);
 
-    fn open(ctx: &Ref<Context>, file: &File) -> Result<Self::Wrapper> {
+    fn open(ctx: &Ref<Context>, file: &File) -> Result<Self::Data> {
         Self::new(ctx.clone(), file.cred().clone())
     }
 
-    fn release(obj: Self::Wrapper, _file: &File) {
+    fn release(obj: Self::Data, _file: &File) {
         // Mark this process as dead. We'll do the same for the threads later.
         obj.inner.lock().is_dead = true;
 

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -53,12 +53,12 @@ impl SharedState {
 
 struct Token;
 impl FileOperations for Token {
-    type Wrapper = Ref<SharedState>;
+    type Data = Ref<SharedState>;
     type OpenData = Ref<SharedState>;
 
     kernel::declare_file_operations!(read, write);
 
-    fn open(shared: &Ref<SharedState>, _file: &File) -> Result<Self::Wrapper> {
+    fn open(shared: &Ref<SharedState>, _file: &File) -> Result<Self::Data> {
         Ok(shared.clone())
     }
 

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -63,7 +63,7 @@ impl FileState {
 }
 
 impl FileOperations for FileState {
-    type Wrapper = Box<Self>;
+    type Data = Box<Self>;
     type OpenData = Ref<Semaphore>;
 
     declare_file_operations!(read, write, ioctl);


### PR DESCRIPTION
This is for the associated type to have a clearer meaning, and to bring
it in line with other traits like `irq::Chip` and `gpio::Chip` where the
context data type is simply `Data`.

This is a pure refactor with no functional changes intended.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>