### PR TITLE
rust: convert `File` to use `ARef`

### DIFF
--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -297,7 +297,7 @@ pub(crate) struct FileInfo {
     links: Links<FileInfo>,
 
     /// The file for which a descriptor will be created in the recipient process.
-    file: Option<File>,
+    file: Option<ARef<File>>,
 
     /// The file descriptor reservation on the recipient process.
     reservation: Option<FileDescriptorReservation>,
@@ -307,7 +307,7 @@ pub(crate) struct FileInfo {
 }
 
 impl FileInfo {
-    pub(crate) fn new(file: File, buffer_offset: usize) -> Self {
+    pub(crate) fn new(file: ARef<File>, buffer_offset: usize) -> Self {
         Self {
             file: Some(file),
             reservation: None,

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -398,6 +398,12 @@ int rust_helper_security_binder_transfer_file(const struct cred *from,
 }
 EXPORT_SYMBOL_GPL(rust_helper_security_binder_transfer_file);
 
+struct file *rust_helper_get_file(struct file *f)
+{
+	return get_file(f);
+}
+EXPORT_SYMBOL_GPL(rust_helper_get_file);
+
 void rust_helper_rcu_read_lock(void)
 {
 	rcu_read_lock();

--- a/rust/kernel/security.rs
+++ b/rust/kernel/security.rs
@@ -32,5 +32,5 @@ pub fn binder_transfer_binder(from: &Credential, to: &Credential) -> Result {
 pub fn binder_transfer_file(from: &Credential, to: &Credential, file: &File) -> Result {
     // SAFETY: By the `Credential` invariants, `from.ptr` and `to.ptr` are valid. Similarly, by the
     // `File` invariants, `file.ptr` is also valid.
-    to_result(|| unsafe { bindings::security_binder_transfer_file(from.ptr, to.ptr, file.ptr) })
+    to_result(|| unsafe { bindings::security_binder_transfer_file(from.ptr, to.ptr, file.0.get()) })
 }


### PR DESCRIPTION
This is to unify the usage of all ref-counted C structures.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>