### PR TITLE
rust: rename `KernelModule` to `Module`

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -102,7 +102,7 @@ struct BinderModule {
     _reg: Pin<Box<Registration<process::Process>>>,
 }
 
-impl KernelModule for BinderModule {
+impl kernel::Module for BinderModule {
     fn init(name: &'static CStr, _module: &'static kernel::ThisModule) -> Result<Self> {
         let ctx = Context::new()?;
         let reg = Registration::new_pinned(fmt!("{name}"), ctx)?;

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -100,7 +100,7 @@ impl<const N: usize> Registration<{ N }> {
     ///
     /// This associated function is intended to be used when you need to avoid
     /// a memory allocation, e.g. when the [`Registration`] is a member of
-    /// a bigger structure inside your [`crate::KernelModule`] instance. If you
+    /// a bigger structure inside your [`crate::Module`] instance. If you
     /// are going to pin the registration right away, call
     /// [`Self::new_pinned()`] instead.
     pub fn new(

--- a/rust/kernel/driver.rs
+++ b/rust/kernel/driver.rs
@@ -5,7 +5,7 @@
 //! Each bus/subsystem is expected to implement [`DriverOps`], which allows drivers to register
 //! using the [`Registration`] class.
 
-use crate::{error::code::*, str::CStr, sync::Ref, KernelModule, Result, ThisModule};
+use crate::{error::code::*, str::CStr, sync::Ref, Result, ThisModule};
 use alloc::boxed::Box;
 use core::{cell::UnsafeCell, marker::PhantomData, ops::Deref, pin::Pin};
 
@@ -415,7 +415,7 @@ pub struct Module<T: DriverOps> {
     _driver: Pin<Box<Registration<T>>>,
 }
 
-impl<T: DriverOps> KernelModule for Module<T> {
+impl<T: DriverOps> crate::Module for Module<T> {
     fn init(name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
         Ok(Self {
             _driver: Registration::new_pinned(name, module)?,

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -115,7 +115,7 @@ const __LOG_PREFIX: &[u8] = b"rust_kernel\0";
 /// The top level entrypoint to implementing a kernel module.
 ///
 /// For any teardown or cleanup operations, your type may implement [`Drop`].
-pub trait KernelModule: Sized + Sync {
+pub trait Module: Sized + Sync {
     /// Called at module initialization time.
     ///
     /// Use this method to perform whatever setup or registration your module

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -9,7 +9,7 @@
 use crate::bindings;
 use crate::error::{code::*, Error, Result};
 use crate::file;
-use crate::{device, str::CStr, str::CString, KernelModule, ThisModule};
+use crate::{device, str::CStr, str::CString, ThisModule};
 use alloc::boxed::Box;
 use core::marker::PhantomPinned;
 use core::{fmt, mem::MaybeUninit, pin::Pin};
@@ -242,7 +242,7 @@ pub struct Module<T: file::Operations<OpenData = ()>> {
     _dev: Pin<Box<Registration<T>>>,
 }
 
-impl<T: file::Operations<OpenData = ()>> KernelModule for Module<T> {
+impl<T: file::Operations<OpenData = ()>> crate::Module for Module<T> {
     fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         Ok(Self {
             _dev: Registration::new_pinned(crate::fmt!("{name}"), ())?,

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -31,6 +31,6 @@ pub use super::module_amba_driver;
 
 pub use super::static_assert;
 
-pub use super::{error::code::*, Error, KernelModule, Result};
+pub use super::{error::code::*, Error, Result};
 
 pub use super::{str::CStr, ARef, ThisModule};

--- a/rust/macros/lib.rs
+++ b/rust/macros/lib.rs
@@ -9,12 +9,12 @@ use proc_macro::TokenStream;
 
 /// Declares a kernel module.
 ///
-/// The `type` argument should be a type which implements the [`KernelModule`]
+/// The `type` argument should be a type which implements the [`Module`]
 /// trait. Also accepts various forms of kernel metadata.
 ///
 /// C header: [`include/linux/moduleparam.h`](../../../include/linux/moduleparam.h)
 ///
-/// [`KernelModule`]: ../kernel/trait.KernelModule.html
+/// [`Module`]: ../kernel/trait.Module.html
 ///
 /// # Examples
 ///
@@ -22,7 +22,7 @@ use proc_macro::TokenStream;
 /// use kernel::prelude::*;
 ///
 /// module!{
-///     type: MyKernelModule,
+///     type: MyModule,
 ///     name: b"my_kernel_module",
 ///     author: b"Rust for Linux Contributors",
 ///     description: b"My very own kernel module!",
@@ -41,9 +41,9 @@ use proc_macro::TokenStream;
 ///    },
 /// }
 ///
-/// struct MyKernelModule;
+/// struct MyModule;
 ///
-/// impl KernelModule for MyKernelModule {
+/// impl kernel::Module for MyModule {
 ///     fn init() -> Result<Self> {
 ///         // If the parameter is writeable, then the kparam lock must be
 ///         // taken to read the parameter:
@@ -54,13 +54,13 @@ use proc_macro::TokenStream;
 ///         // If the parameter is read only, it can be read without locking
 ///         // the kernel parameters:
 ///         pr_info!("i32 param is:  {}\n", my_i32.read());
-///         Ok(MyKernelModule)
+///         Ok(Self)
 ///     }
 /// }
 /// ```
 ///
 /// # Supported argument types
-///   - `type`: type which implements the [`KernelModule`] trait (required).
+///   - `type`: type which implements the [`Module`] trait (required).
 ///   - `name`: byte array of the name of the kernel module (required).
 ///   - `author`: byte array of the author of the kernel module.
 ///   - `description`: byte array of the description of the kernel module.

--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -569,7 +569,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             }}
 
             fn __init() -> kernel::c_types::c_int {{
-                match <{type_} as kernel::KernelModule>::init(kernel::c_str!(\"{name}\"), &THIS_MODULE) {{
+                match <{type_} as kernel::Module>::init(kernel::c_str!(\"{name}\"), &THIS_MODULE) {{
                     Ok(m) => {{
                         unsafe {{
                             __MOD = Some(m);

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -27,7 +27,7 @@ struct RustChrdev {
     _dev: Pin<Box<chrdev::Registration<2>>>,
 }
 
-impl KernelModule for RustChrdev {
+impl kernel::Module for RustChrdev {
     fn init(name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust character device sample (init)\n");
 

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -16,7 +16,7 @@ struct RustMinimal {
     message: String,
 }
 
-impl KernelModule for RustMinimal {
+impl kernel::Module for RustMinimal {
     fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust minimal sample (init)\n");
         pr_info!("Am I built-in? {}\n", !cfg!(MODULE));

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -124,7 +124,7 @@ struct RustMiscdev {
     _dev: Pin<Box<miscdev::Registration<Token>>>,
 }
 
-impl KernelModule for RustMiscdev {
+impl kernel::Module for RustMiscdev {
     fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust miscellaneous device sample (init)\n");
 

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -41,7 +41,7 @@ module! {
 
 struct RustModuleParameters;
 
-impl KernelModule for RustModuleParameters {
+impl kernel::Module for RustModuleParameters {
     fn init(_name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust module parameters sample (init)\n");
 

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -15,7 +15,7 @@ module! {
 
 struct RustPrint;
 
-impl KernelModule for RustPrint {
+impl kernel::Module for RustPrint {
     fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust printing macros sample (init)\n");
 

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -106,7 +106,7 @@ struct RustSemaphore {
     _dev: Pin<Box<Registration<FileState>>>,
 }
 
-impl KernelModule for RustSemaphore {
+impl kernel::Module for RustSemaphore {
     fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust semaphore sample (init)\n");
 

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -14,7 +14,7 @@ module! {
 
 struct RustStackProbing;
 
-impl KernelModule for RustStackProbing {
+impl kernel::Module for RustStackProbing {
     fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust stack probing sample (init)\n");
 

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -23,7 +23,7 @@ kernel::init_static_sync! {
 
 struct RustSync;
 
-impl KernelModule for RustSync {
+impl kernel::Module for RustSync {
     fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust synchronisation primitives sample (init)\n");
 


### PR DESCRIPTION
Since it's already in the `kernel` crate, prefixing it with `Kernel` is
redundant. This is also for consistency with other types (e.g., we
renamed `KernelResult` to `Result`).

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>