### PR TITLE
Fix latent entropy GCC plugin and disable all GCC plugins

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -2058,7 +2058,7 @@ config RUST
 	depends on HAVE_RUST
 	depends on RUST_IS_AVAILABLE
 	depends on !MODVERSIONS
-	depends on !GCC_PLUGIN_RANDSTRUCT
+	depends on !GCC_PLUGINS
 	select CONSTRUCTORS
 	help
 	  Enables Rust support in the kernel.

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -245,8 +245,7 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-fno-reorder-blocks -fno-allow-store-data-races -fasan-shadow-offset=% \
 	-fzero-call-used-regs=% -fno-stack-clash-protection \
 	-fno-inline-functions-called-once \
-	--param=% --param asan-% \
-	$(GCC_PLUGINS_CFLAGS)
+	--param=% --param asan-%
 
 # Derived from `scripts/Makefile.clang`.
 BINDGEN_TARGET_arm	:= arm-linux-gnueabi

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -245,7 +245,8 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-fno-reorder-blocks -fno-allow-store-data-races -fasan-shadow-offset=% \
 	-fzero-call-used-regs=% -fno-stack-clash-protection \
 	-fno-inline-functions-called-once \
-	--param=% --param asan-%
+	--param=% --param asan-% \
+	$(GCC_PLUGINS_CFLAGS)
 
 # Derived from `scripts/Makefile.clang`.
 BINDGEN_TARGET_arm	:= arm-linux-gnueabi


### PR DESCRIPTION
The latent entropy GCC plugin adds a `latent_entropy` `extern`
declaration. An static inline function in `include/linux/random.h`
uses the variable, thus `bindgen`'s `clang` fails since it does
not recognize the identifier.

One way to avoid this is using the `GCC_PLUGINS_CFLAGS`
to skip those flags for `bindgen`. I do this in the first commit to
keep a possible solution in the repo.

However, while we can keep support for some of the GCC plugins,
it is simpler and safer to just disable GCC plugin support since they
will be going away anyway. Furthermore, if they are kept, new
or future ones could also break Rust support in subtle ways. And,
in any case, Rust support with GCC-built kernels is very experimental.
So I disable them in the second commit.