### PR TITLE
rust: split `CreatableLock` into `LockFactory` and `LockIniter`

### DIFF
--- a/rust/kernel/sync.rs
+++ b/rust/kernel/sync.rs
@@ -36,7 +36,7 @@ mod spinlock;
 
 pub use arc::{Ref, RefBorrow, UniqueRef};
 pub use condvar::CondVar;
-pub use guard::{CreatableLock, Guard, Lock, LockInfo, ReadLock, WriteLock};
+pub use guard::{Guard, Lock, LockFactory, LockInfo, LockIniter, ReadLock, WriteLock};
 pub use locked_by::LockedBy;
 pub use mutex::Mutex;
 pub use revocable_mutex::{RevocableMutex, RevocableMutexGuard};

--- a/rust/kernel/sync/smutex.rs
+++ b/rust/kernel/sync/smutex.rs
@@ -46,7 +46,7 @@
 //! When the waiter queue is non-empty, unlocking the mutex always results in the first waiter being
 //! popped form the queue and awakened.
 
-use super::{mutex::EmptyGuardContext, CreatableLock, Guard, Lock};
+use super::{mutex::EmptyGuardContext, Guard, Lock, LockFactory, LockIniter};
 use crate::{bindings, str::CStr, Opaque};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{cell::UnsafeCell, pin::Pin};
@@ -134,13 +134,15 @@ impl<T: ?Sized> Mutex<T> {
     }
 }
 
-impl<T> CreatableLock for Mutex<T> {
-    type CreateArgType = T;
+impl<T> LockFactory for Mutex<T> {
+    type LockedType<U> = Mutex<U>;
 
-    unsafe fn new_lock(data: Self::CreateArgType) -> Self {
-        Self::new(data)
+    unsafe fn new_lock<U>(data: U) -> Mutex<U> {
+        Mutex::new(data)
     }
+}
 
+impl<T> LockIniter for Mutex<T> {
     unsafe fn init_lock(
         self: Pin<&mut Self>,
         _name: &'static CStr,


### PR DESCRIPTION
We then make `LockFactory` more generic in the sense that it is
parametrised to create a lock for any wrapped type.

This is in preparation for adding a revocable version of any
synchronisation primitive. Given for example `Mutex<T>`, we really need
a `Mutex<Inner<T>>`, which can be achieved with the new factory.

The separation of the otherwise unrelated functions also slightly
simplifies how sequence locks are implemented, only requiring `Lock` for
the struct itself, with `LockFactory` and `LockIniter` only needed in
specific functions.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>