### PR TITLE
ci: Enable CONFIG_HIGH_RES_TIMERS for ppc64le

### DIFF
--- a/.github/workflows/kernel-ppc64le-release.config
+++ b/.github/workflows/kernel-ppc64le-release.config
@@ -71,7 +71,7 @@ CONFIG_NO_HZ_COMMON=y
 CONFIG_NO_HZ_IDLE=y
 # CONFIG_NO_HZ_FULL is not set
 # CONFIG_NO_HZ is not set
-# CONFIG_HIGH_RES_TIMERS is not set
+CONFIG_HIGH_RES_TIMERS=y
 # end of Timers subsystem
 
 # CONFIG_PREEMPT_NONE is not set


### PR DESCRIPTION
When we originally added Rust support for ppc64le the kernel config was
copied from the x86 version and updated. That meant we got
CONFIG_HIGH_RES_TIMERS=n.

But that's a very uncommon configuration, basically no modern distros or
defconfigs have that disabled. That has meant the Rust CI has hit bugs
that weren't seen elsewhere, eg:

  https://lore.kernel.org/linuxppc-dev/CANiq72k+5Rdj7i3Df2dcE6_OPYPXK3z5EWLKnY56sSMz4G3OvA@mail.gmail.com/

Finding obscure configuration related bugs is not the job of the Rust
CI, so turn HIGH_RES_TIMERS on to bring the kernel config closer to
something standard.

Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>