### PR TITLE
rust: depend on `!DEBUG_INFO_BTF`

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -2063,6 +2063,7 @@ config RUST
 	depends on RUST_IS_AVAILABLE
 	depends on !MODVERSIONS
 	depends on !GCC_PLUGINS
+	depends on !DEBUG_INFO_BTF
 	select CONSTRUCTORS
 	help
 	  Enables Rust support in the kernel.


### PR DESCRIPTION
When `CONFIG_DEBUG_INFO_BTF` is enabled, loading C modules (rather
than just Rust ones) fails with:

    [    0.642535] BPF:     width type_id=54975 bits_offset=0
    [    0.642932] BPF:
    [    0.643100] BPF: Invalid member bits_offset
    [    0.643413] BPF:

This is triggered because the debug info for `vmlinux` is checked too
(base BTF) the first time it is needed, and that means some info
from Rust compilation units is checked, which fails on a couple of
asserts since:
  - Rust struct members may be reordered, unlike C.
  - Rust type names use quite a few more characters.

One simple possibility to solve this is to skip Rust CUs during
the BTF generation by pahole. pahole may gain support for this soon.

Meanwhile, we make the config option exclusive with `CONFIG_RUST`.

Link: https://github.com/Rust-for-Linux/linux/issues/735
Reported-by: Martin Reboredo <yakoyoku@gmail.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>