### PR TITLE
Replace &*obj as *const T with addr_of

### DIFF
--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -159,7 +159,7 @@ impl<T: ?Sized> Ref<T> {
     ///
     /// It can be reconstructed once via [`Ref::from_raw`].
     pub fn into_raw(obj: Self) -> *const T {
-        let ret = &*obj as *const T;
+        let ret = core::ptr::addr_of!(*obj);
         core::mem::forget(obj);
         ret
     }


### PR DESCRIPTION
Normally, clippy will find this. However this lint was missing when doing some manual analysis.

This produces the same code in godbolt.