### PR TITLE
Use rust::bool_to_option

### DIFF
--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -358,12 +358,10 @@ impl Error {
     pub fn name(&self) -> Option<&'static CStr> {
         // SAFETY: Just an FFI call, there are no extra safety requirements.
         let ptr = unsafe { bindings::errname(-self.0) };
-        if ptr.is_null() {
-            None
-        } else {
+        ptr.is_null().then_some({
             // SAFETY: The string returned by `errname` is static and `NUL`-terminated.
-            Some(unsafe { CStr::from_char_ptr(ptr) })
-        }
+            unsafe { CStr::from_char_ptr(ptr) }
+        })
     }
 
     /// Returns a string representing the error, if one exists.

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -27,6 +27,7 @@
 #![feature(coerce_unsized)]
 #![feature(dispatch_from_dyn)]
 #![feature(unsize)]
+#![feature(bool_to_option)]
 
 // Ensure conditional compilation based on the kernel configuration works;
 // otherwise we may silently break things like initcall handling.

--- a/rust/kernel/module_param.rs
+++ b/rust/kernel/module_param.rs
@@ -69,11 +69,9 @@ pub trait ModuleParam: core::fmt::Display + core::marker::Sized {
         val: *const crate::c_types::c_char,
         param: *const crate::bindings::kernel_param,
     ) -> crate::c_types::c_int {
-        let arg = if val.is_null() {
-            None
-        } else {
-            Some(unsafe { CStr::from_char_ptr(val).as_bytes() })
-        };
+        let arg = val
+            .is_null()
+            .then_some( unsafe { CStr::from_char_ptr(val).as_bytes() });
         match Self::try_from_param_arg(arg) {
             Some(new_value) => {
                 let old_value = unsafe { (*param).__bindgen_anon_1.arg as *mut Self };

--- a/rust/kernel/pages.rs
+++ b/rust/kernel/pages.rs
@@ -110,14 +110,12 @@ impl<const ORDER: u32> Pages<ORDER> {
 
         // SAFETY: `page` is valid based on the checks above.
         let ptr = unsafe { bindings::kmap(page) };
-        if ptr.is_null() {
-            return None;
-        }
-
-        Some(PageMapping {
-            page,
-            ptr,
-            _phantom: PhantomData,
+        ptr.is_null().then_some({
+            PageMapping {
+                page,
+                ptr,
+                _phantom: PhantomData,
+            }
         })
     }
 }


### PR DESCRIPTION
Add feature currently on nightly: bool_to_option.

Cleans up uses of is_null when we either return just None or a
Some(T).