### PR TITLE
Makefile: export `KBUILD_CLIPPY`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,8 @@ ifeq ("$(origin CLIPPY)", "command line")
   KBUILD_CLIPPY := $(CLIPPY)
 endif
 
+export KBUILD_CLIPPY
+
 # Use make M=dir or set the environment variable KBUILD_EXTMOD to specify the
 # directory of external module to build. Setting M= takes precedence.
 ifeq ("$(origin M)", "command line")


### PR DESCRIPTION
Otherwise, for `O=` builds `CLIPPY=1` does nothing since
the `Makefile` invokes a second `make` in the output directory.

Reported-by: Andreas Hindborg <andreas.hindborg@wdc.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>