### PR TITLE
kallsyms: provide a bigger buffer to report the real length

### DIFF
--- a/scripts/kallsyms.c
+++ b/scripts/kallsyms.c
@@ -32,6 +32,13 @@
 
 #define KSYM_NAME_LEN		512
 
+/* A substantially bigger size than the current maximum. */
+#define KSYM_NAME_LEN_BUFFER   2048
+_Static_assert(
+	KSYM_NAME_LEN_BUFFER == KSYM_NAME_LEN * 4,
+	"Please keep KSYM_NAME_LEN_BUFFER in sync with KSYM_NAME_LEN"
+);
+
 struct sym_entry {
 	unsigned long long addr;
 	unsigned int len;
@@ -200,15 +207,15 @@ static void check_symbol_range(const char *sym, unsigned long long addr,
 
 static struct sym_entry *read_symbol(FILE *in)
 {
-	char name[KSYM_NAME_LEN+1], type;
+	char name[KSYM_NAME_LEN_BUFFER+1], type;
 	unsigned long long addr;
 	unsigned int len;
 	struct sym_entry *sym;
 	int rc;
 
-	rc = fscanf(in, "%llx %c %" _stringify(KSYM_NAME_LEN) "s\n", &addr, &type, name);
+	rc = fscanf(in, "%llx %c %" _stringify(KSYM_NAME_LEN_BUFFER) "s\n", &addr, &type, name);
 	if (rc != 3) {
-		if (rc != EOF && fgets(name, KSYM_NAME_LEN + 1, in) == NULL)
+		if (rc != EOF && fgets(name, KSYM_NAME_LEN_BUFFER + 1, in) == NULL)
 			fprintf(stderr, "Read error or end of file.\n");
 		return NULL;
 	}


### PR DESCRIPTION
With a buffer size close to `KSYM_NAME_LEN`, the "symbol too big"
report in `read_symbol` does not really provide information
to the user. Therefore, use a bigger buffer.

Furthermore, add a static assert to keep things matched.

This will be rebased/reorganized in `rust-next` as a new set
of kallsyms patches that makes more sense (instead of putting Boqun's
patch last of the three, it will go first in the series as
an improvement to the mainline kernel). This commit synchronizes
with those changes.

Fixes: d89543615548 ("script: kallsyms: Use the correct buffer size for symbols")
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>