### PR TITLE
export `build_error` symbol if RUST_BUILD_ASSERT_DENY is not set

### DIFF
--- a/rust/build_error.rs
+++ b/rust/build_error.rs
@@ -17,13 +17,13 @@
 /// Panics if executed in const context, or triggers a build error if not.
 #[inline(never)]
 #[cold]
-#[no_mangle]
+#[export_name = "rust_build_error"]
 #[track_caller]
 pub const fn build_error(msg: &'static str) -> ! {
     panic!("{}", msg);
 }
 
 #[cfg(CONFIG_RUST_BUILD_ASSERT_WARN)]
-#[link_section = ".gnu.warning.build_error"]
+#[link_section = ".gnu.warning.rust_build_error"]
 #[used]
 static BUILD_ERROR_WARNING: [u8; 45] = *b"call to build_error present after compilation";

--- a/rust/kernel/io_mem.rs
+++ b/rust/kernel/io_mem.rs
@@ -68,6 +68,7 @@ macro_rules! define_read {
         ///
         /// If the offset is not known at compile time, the build will fail.
         $(#[$attr])*
+        #[inline]
         pub fn $name(&self, offset: usize) -> $type_name {
             Self::check_offset::<$type_name>(offset);
             let ptr = self.ptr.wrapping_add(offset);
@@ -100,6 +101,7 @@ macro_rules! define_write {
         ///
         /// If the offset is not known at compile time, the build will fail.
         $(#[$attr])*
+        #[inline]
         pub fn $name(&self, value: $type_name, offset: usize) {
             Self::check_offset::<$type_name>(offset);
             let ptr = self.ptr.wrapping_add(offset);
@@ -164,6 +166,7 @@ impl<const SIZE: usize> IoMem<SIZE> {
         }
     }
 
+    #[inline]
     const fn offset_ok<T>(offset: usize) -> bool {
         let type_size = core::mem::size_of::<T>();
         if let Some(end) = offset.checked_add(type_size) {
@@ -183,6 +186,7 @@ impl<const SIZE: usize> IoMem<SIZE> {
         }
     }
 
+    #[inline]
     const fn check_offset<T>(offset: usize) {
         crate::build_assert!(Self::offset_ok::<T>(offset), "IoMem offset overflow");
     }


### PR DESCRIPTION
This ensures that under `RUST_BUILD_ASSERT_WARN` or `RUST_BUILD_ASSERT_ALLOW`, modpost will not reject modules containing call to `rust_build_error`.

Also contains a tweak to ensure that `check_offset` is more likely to be inlined.

Should fix #755. @SocialistDalao can you check if `GPIO_PL061_RUST` build with these changes?