### PR TITLE
Remove unnecessary param in Module::init

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -9,7 +9,6 @@ use kernel::{
     linked_list::{GetLinks, GetLinksWrapped, Links},
     miscdev::Registration,
     prelude::*,
-    str::CStr,
     sync::Ref,
     user_ptr::UserSlicePtrWriter,
 };
@@ -103,8 +102,9 @@ struct BinderModule {
 }
 
 impl kernel::Module for BinderModule {
-    fn init(name: &'static CStr, _module: &'static kernel::ThisModule) -> Result<Self> {
+    fn init(module: &'static kernel::ThisModule) -> Result<Self> {
         let ctx = Context::new()?;
+        let name = module.name();
         let reg = Registration::new_pinned(fmt!("{name}"), ctx)?;
         Ok(Self { _reg: reg })
     }

--- a/rust/kernel/driver.rs
+++ b/rust/kernel/driver.rs
@@ -418,9 +418,9 @@ pub struct Module<T: DriverOps> {
 }
 
 impl<T: DriverOps> crate::Module for Module<T> {
-    fn init(name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
+    fn init(module: &'static ThisModule) -> Result<Self> {
         Ok(Self {
-            _driver: Registration::new_pinned(name, module)?,
+            _driver: Registration::new_pinned(module.name(), module)?,
         })
     }
 }

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -125,7 +125,7 @@ pub trait Module: Sized + Sync {
     /// should do.
     ///
     /// Equivalent to the `module_init` macro in the C API.
-    fn init(name: &'static str::CStr, module: &'static ThisModule) -> Result<Self>;
+    fn init(module: &'static ThisModule) -> Result<Self>;
 }
 
 /// Equivalent to `THIS_MODULE` in the C API.
@@ -162,6 +162,11 @@ impl ThisModule {
             this_module: self,
             phantom: PhantomData,
         }
+    }
+
+    /// Get name of [`ThisModule`]
+    pub fn name(&self) -> &'static str::CStr {
+        unsafe { str::CStr::from_char_ptr((*self.0).name.as_ptr()) }
     }
 }
 

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -9,7 +9,7 @@
 use crate::bindings;
 use crate::error::{code::*, Error, Result};
 use crate::file;
-use crate::{device, str::CStr, str::CString, ThisModule};
+use crate::{device, str::CString, ThisModule};
 use alloc::boxed::Box;
 use core::marker::PhantomPinned;
 use core::{fmt, mem::MaybeUninit, pin::Pin};
@@ -243,7 +243,8 @@ pub struct Module<T: file::Operations<OpenData = ()>> {
 }
 
 impl<T: file::Operations<OpenData = ()>> crate::Module for Module<T> {
-    fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(module: &'static ThisModule) -> Result<Self> {
+        let name = module.name();
         Ok(Self {
             _dev: Registration::new_pinned(crate::fmt!("{name}"), ())?,
         })

--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -569,7 +569,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             }}
 
             fn __init() -> kernel::c_types::c_int {{
-                match <{type_} as kernel::Module>::init(kernel::c_str!(\"{name}\"), &THIS_MODULE) {{
+                match <{type_} as kernel::Module>::init(&THIS_MODULE) {{
                     Ok(m) => {{
                         unsafe {{
                             __MOD = Some(m);

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -28,10 +28,10 @@ struct RustChrdev {
 }
 
 impl kernel::Module for RustChrdev {
-    fn init(name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
+    fn init(module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust character device sample (init)\n");
 
-        let mut chrdev_reg = chrdev::Registration::new_pinned(name, 0, module)?;
+        let mut chrdev_reg = chrdev::Registration::new_pinned(module.name(), 0, module)?;
 
         // Register the same kind of device twice, we're just demonstrating
         // that you can use multiple minors. There are two minors in this case

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -17,7 +17,7 @@ struct RustMinimal {
 }
 
 impl kernel::Module for RustMinimal {
-    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(_module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust minimal sample (init)\n");
         pr_info!("Am I built-in? {}\n", !cfg!(MODULE));
 

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -125,10 +125,11 @@ struct RustMiscdev {
 }
 
 impl kernel::Module for RustMiscdev {
-    fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust miscellaneous device sample (init)\n");
 
         let state = SharedState::try_new()?;
+        let name = module.name();
 
         Ok(RustMiscdev {
             _dev: miscdev::Registration::new_pinned(fmt!("{name}"), state)?,

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -42,7 +42,7 @@ module! {
 struct RustModuleParameters;
 
 impl kernel::Module for RustModuleParameters {
-    fn init(_name: &'static CStr, module: &'static ThisModule) -> Result<Self> {
+    fn init(module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust module parameters sample (init)\n");
 
         {

--- a/samples/rust/rust_netfilter.rs
+++ b/samples/rust/rust_netfilter.rs
@@ -33,7 +33,7 @@ impl netfilter::Filter for RustNetfilter {
 }
 
 impl kernel::Module for RustNetfilter {
-    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(_module: &'static ThisModule) -> Result<Self> {
         Ok(Self {
             _in: netfilter::Registration::new_pinned(
                 Family::INet(inet::Hook::PreRouting),

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -3,7 +3,7 @@
 //! Rust printing macros sample.
 
 use kernel::prelude::*;
-use kernel::{pr_cont, str::CStr, ThisModule};
+use kernel::{pr_cont, ThisModule};
 
 module! {
     type: RustPrint,
@@ -16,7 +16,7 @@ module! {
 struct RustPrint;
 
 impl kernel::Module for RustPrint {
-    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(_module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust printing macros sample (init)\n");
 
         pr_emerg!("Emergency message (level 0) without args\n");

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -107,7 +107,7 @@ struct RustSemaphore {
 }
 
 impl kernel::Module for RustSemaphore {
-    fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust semaphore sample (init)\n");
 
         let mut sema = Pin::from(UniqueRef::try_new(Semaphore {
@@ -130,6 +130,8 @@ impl kernel::Module for RustSemaphore {
         // SAFETY: `inner` is pinned when `sema` is.
         let pinned = unsafe { sema.as_mut().map_unchecked_mut(|s| &mut s.inner) };
         mutex_init!(pinned, "Semaphore::inner");
+
+        let name = module.name();
 
         Ok(Self {
             _dev: Registration::new_pinned(fmt!("{name}"), sema.into())?,

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -15,7 +15,7 @@ module! {
 struct RustStackProbing;
 
 impl kernel::Module for RustStackProbing {
-    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(_module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust stack probing sample (init)\n");
 
         // Including this large variable on the stack will trigger

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -24,7 +24,7 @@ kernel::init_static_sync! {
 struct RustSync;
 
 impl kernel::Module for RustSync {
-    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+    fn init(_module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust synchronisation primitives sample (init)\n");
 
         // Test mutexes.


### PR DESCRIPTION
we can get name from `ThisModule`, so `name` param is unnecessary. 
