### PR TITLE
Add support for building under x86_64 User-Mode-Linux (UML)

### DIFF
--- a/arch/um/Kconfig
+++ b/arch/um/Kconfig
@@ -24,6 +24,7 @@ config UML
 	select TRACE_IRQFLAGS_SUPPORT
 	select TTY # Needed for line.c
 	select HAVE_ARCH_VMAP_STACK
+	select HAVE_RUST			if X86_64
 
 config MMU
 	bool

--- a/rust/kernel/irq.rs
+++ b/rust/kernel/irq.rs
@@ -352,10 +352,12 @@ impl Drop for ChainedGuard<'_> {
 /// # Invariants
 ///
 /// The pointer `Domain::ptr` is non-null and valid.
+#[cfg(CONFIG_IRQ_DOMAIN)]
 pub struct Domain {
     ptr: *mut bindings::irq_domain,
 }
 
+#[cfg(CONFIG_IRQ_DOMAIN)]
 impl Domain {
     /// Constructs a new `struct irq_domain` wrapper.
     ///

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -87,6 +87,7 @@ pub mod sync;
 pub mod sysctl;
 
 pub mod io_buffer;
+#[cfg(CONFIG_HAS_IOMEM)]
 pub mod io_mem;
 pub mod iov_iter;
 pub mod of;

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -198,7 +198,7 @@ fn main() {
             features += ",+c";
         }
         ts.push("features", features);
-    } else if cfg.has("X86") {
+    } else if cfg.has("X86_64") {
         ts.push("arch", "x86_64");
         ts.push(
             "data-layout",


### PR DESCRIPTION
[User-Mode-Linux](https://www.kernel.org/doc/html/latest/virt/uml/user_mode_linux_howto_v2.html) is a Linux architecture (``ARCH=um``) which builds the kernel as a normal user-mode binary. It's used, amonst other things, as the default architecture for [KUnit tests](https://kunit.dev/), and acts as a very fast, lightweight platform for running and testing kernel code.

Since Rust-for-Linux already supports x86-64, it's relatively simple to add support for x86-64 UML. Most of the changes are simply excluding code whose dependencies are not met (``CONFIG_IOMEM`` and ``CONFIG_IRQ_DOMAIN`` are not set on default UML configs). In addition, ``CONFIG_HAVE_RUST`` is set for X86_64 UML, and ``generate_rust_target`` is modified to check for ``CONFIG_X86_64`` instead of ``CONFIG_X86``.

With these changes, a UML kernel with ``CONFIG_RUST=y`` builds and runs successfully, and the KUnit tooling can run Rust-based tests as follows:
```
./tools/testing/kunit/kunit.py run --kconfig_add CONFIG_RUST=y --make_options LLVM=1
```

Signed-off-by: David Gow <davidgow@google.com>