### PR TITLE
Small cleanups from v6

### DIFF
--- a/lib/vsprintf.c
+++ b/lib/vsprintf.c
@@ -2271,7 +2271,7 @@ int __init no_hash_pointers_enable(char *str)
 early_param("no_hash_pointers", no_hash_pointers_enable);
 
 /* Used for Rust formatting ('%pA'). */
-char *rust_fmt_argument(char* buf, char* end, void *ptr);
+char *rust_fmt_argument(char *buf, char *end, void *ptr);
 
 /*
  * Show a '%p' thing.  A kernel extension is that the '%p' is followed

--- a/rust/kernel/kasync/net.rs
+++ b/rust/kernel/kasync/net.rs
@@ -183,7 +183,7 @@ impl<'a, Out, F: FnMut() -> Result<Out> + Send + 'a> SocketFuture<'a, Out, F> {
 
     /// Callback called when the socket changes state.
     ///
-    /// If the state matches the one we're waiting on, we wake up the tak so that the future can be
+    /// If the state matches the one we're waiting on, we wake up the task so that the future can be
     /// polled again.
     unsafe extern "C" fn wake_callback(
         wq_entry: *mut bindings::wait_queue_entry,

--- a/rust/kernel/net/filter.rs
+++ b/rust/kernel/net/filter.rs
@@ -70,7 +70,7 @@ pub enum Family {
     /// IPv6 packets.
     Ipv6(ipv6::Hook, ipv6::PriorityBase),
 
-    /// Adress resolution protocol (ARP) packets.
+    /// Address resolution protocol (ARP) packets.
     Arp(arp::Hook),
 }
 
@@ -431,7 +431,7 @@ pub mod inet {
         /// Inbound packets that are meant to be delivered locally.
         LocalIn = bindings::nf_inet_hooks_NF_INET_LOCAL_IN as _,
 
-        /// Inbound pakcets that are meant to be forwarded to another host.
+        /// Inbound packets that are meant to be forwarded to another host.
         Forward = bindings::nf_inet_hooks_NF_INET_FORWARD as _,
 
         /// Outbound packet created by the local networking stack.

--- a/rust/kernel/net/filter.rs
+++ b/rust/kernel/net/filter.rs
@@ -152,7 +152,7 @@ impl<T: Filter> Registration<T> {
     /// registered.
     ///
     /// The priority is relative to the family's base priority. For example, if the base priority
-    /// is `100` and `priority` is -1, the actual priority will be `99`. If a family doesn't
+    /// is `100` and `priority` is `-1`, the actual priority will be `99`. If a family doesn't
     /// explicitly allow a base to be specified, `0` is assumed.
     pub fn register(
         self: Pin<&mut Self>,

--- a/rust/kernel/raw_list.rs
+++ b/rust/kernel/raw_list.rs
@@ -16,7 +16,7 @@ use core::{
 /// It describes the type of list elements and provides a function to determine how to get the
 /// links to be used on a list.
 ///
-/// A type that may be in multiple lists simultaneously neneds to implement one of these for each
+/// A type that may be in multiple lists simultaneously needs to implement one of these for each
 /// simultaneous list.
 pub trait GetLinks {
     /// The type of the entries in the list.

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -249,7 +249,7 @@ impl fmt::Debug for CStr {
     /// let s = CString::try_from_fmt(fmt!("{:?}", penguin)).unwrap();
     /// assert_eq!(s.as_bytes_with_nul(), "\"\\xf0\\x9f\\x90\\xa7\"\0".as_bytes());
     ///
-    /// // embedded double quotes are escaped
+    /// // Embedded double quotes are escaped.
     /// let ascii = c_str!("so \"cool\"");
     /// let s = CString::try_from_fmt(fmt!("{:?}", ascii)).unwrap();
     /// assert_eq!(s.as_bytes_with_nul(), "\"so \\\"cool\\\"\"\0".as_bytes());

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -494,7 +494,7 @@ where
 
 /// A trait for boolean types.
 ///
-/// This is meant to be used in type states to allow booelan constraints in implementation blocks.
+/// This is meant to be used in type states to allow boolean constraints in implementation blocks.
 /// In the example below, the implementation containing `MyType::set_value` could _not_ be
 /// constrained to type states containing `Writable = true` if `Writable` were a constant instead
 /// of a type.

--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0
 """generate_rust_analyzer - Generates the `rust-project.json` file for `rust-analyzer`.
 """
 


### PR DESCRIPTION
A set of typos/cleanups and a missing SPDX identifier I fixed when submitting v6.