### PR TITLE
Remove panicking stub for `__mulodi4`

### DIFF
--- a/rust/compiler_builtins.rs
+++ b/rust/compiler_builtins.rs
@@ -53,5 +53,4 @@ define_panicking_intrinsics!("`u128` should not be used", {
 #[cfg(target_arch = "arm")]
 define_panicking_intrinsics!("`u64` division/modulo should not be used", {
     __aeabi_uldivmod,
-    __mulodi4,
 });


### PR DESCRIPTION
Since Rust 1.60, LLVM is upgraded to LLVM 14 and it will no longer generate `__mulodi4` calls (https://godbolt.org/z/cWhE718rM), so this stub can be removed.