### PR TITLE
rust: hide `bindings::lock_class_key` from drivers

### DIFF
--- a/rust/kernel/sync.rs
+++ b/rust/kernel/sync.rs
@@ -22,7 +22,7 @@
 //! ```
 
 use crate::{bindings, str::CStr};
-use core::pin::Pin;
+use core::{cell::UnsafeCell, mem::MaybeUninit, pin::Pin};
 
 mod arc;
 mod condvar;
@@ -48,6 +48,25 @@ pub use rwsem::{RevocableRwSemaphore, RevocableRwSemaphoreGuard, RwSemaphore};
 pub use seqlock::{SeqLock, SeqLockReadGuard};
 pub use spinlock::{RawSpinLock, SpinLock};
 
+/// Represents a lockdep class. It's a wrapper around C's `lock_class_key`.
+#[repr(transparent)]
+pub struct LockClassKey(UnsafeCell<MaybeUninit<bindings::lock_class_key>>);
+
+// SAFETY: This is a wrapper around a lock class key, so it is safe to use references to it from
+// any thread.
+unsafe impl Sync for LockClassKey {}
+
+impl LockClassKey {
+    /// Creates a new lock class key.
+    pub const fn new() -> Self {
+        Self(UnsafeCell::new(MaybeUninit::uninit()))
+    }
+
+    fn get(&self) -> *mut bindings::lock_class_key {
+        self.0.get().cast()
+    }
+}
+
 /// Safely initialises an object that has an `init` function that takes a name and a lock class as
 /// arguments, examples of these are [`Mutex`] and [`SpinLock`]. Each of them also provides a more
 /// specialised name that uses this macro.
@@ -55,18 +74,11 @@ pub use spinlock::{RawSpinLock, SpinLock};
 #[macro_export]
 macro_rules! init_with_lockdep {
     ($obj:expr, $name:expr) => {{
-        static mut CLASS1: core::mem::MaybeUninit<$crate::bindings::lock_class_key> =
-            core::mem::MaybeUninit::uninit();
-        static mut CLASS2: core::mem::MaybeUninit<$crate::bindings::lock_class_key> =
-            core::mem::MaybeUninit::uninit();
+        static CLASS1: $crate::sync::LockClassKey = $crate::sync::LockClassKey::new();
+        static CLASS2: $crate::sync::LockClassKey = $crate::sync::LockClassKey::new();
         let obj = $obj;
         let name = $crate::c_str!($name);
-        // SAFETY: `CLASS1` and `CLASS2` are never used by Rust code directly; the C portion of the
-        // kernel may change it though.
-        #[allow(unused_unsafe)]
-        unsafe {
-            $crate::sync::NeedsLockClass::init(obj, name, CLASS1.as_mut_ptr(), CLASS2.as_mut_ptr())
-        };
+        $crate::sync::NeedsLockClass::init(obj, name, &CLASS1, &CLASS2)
     }};
 }
 
@@ -79,16 +91,11 @@ pub trait NeedsLockClass {
     ///
     /// Callers are encouraged to use the [`init_with_lockdep`] macro as it automatically creates a
     /// new lock class on each usage.
-    ///
-    /// # Safety
-    ///
-    /// `key1` and `key2` must point to valid memory locations and remain valid until `self` is
-    /// dropped.
-    unsafe fn init(
+    fn init(
         self: Pin<&mut Self>,
         name: &'static CStr,
-        key1: *mut bindings::lock_class_key,
-        key2: *mut bindings::lock_class_key,
+        key1: &'static LockClassKey,
+        key2: &'static LockClassKey,
     );
 }
 

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -5,7 +5,7 @@
 //! This module allows Rust code to use the kernel's [`struct wait_queue_head`] as a condition
 //! variable.
 
-use super::{Guard, Lock, LockInfo, NeedsLockClass};
+use super::{Guard, Lock, LockClassKey, LockInfo, NeedsLockClass};
 use crate::{bindings, str::CStr, task::Task, Opaque};
 use core::{marker::PhantomPinned, pin::Pin};
 
@@ -127,12 +127,14 @@ impl CondVar {
 }
 
 impl NeedsLockClass for CondVar {
-    unsafe fn init(
+    fn init(
         self: Pin<&mut Self>,
         name: &'static CStr,
-        key: *mut bindings::lock_class_key,
-        _: *mut bindings::lock_class_key,
+        key: &'static LockClassKey,
+        _: &'static LockClassKey,
     ) {
-        unsafe { bindings::__init_waitqueue_head(self.wait_list.get(), name.as_char_ptr(), key) };
+        unsafe {
+            bindings::__init_waitqueue_head(self.wait_list.get(), name.as_char_ptr(), key.get())
+        };
     }
 }

--- a/rust/kernel/sync/guard.rs
+++ b/rust/kernel/sync/guard.rs
@@ -6,8 +6,8 @@
 //! the ([`Lock`]) trait. It also contains the definition of the trait, which can be leveraged by
 //! other constructs to work on generic locking primitives.
 
-use super::NeedsLockClass;
-use crate::{bindings, str::CStr, Bool, False, True};
+use super::{LockClassKey, NeedsLockClass};
+use crate::{str::CStr, Bool, False, True};
 use core::pin::Pin;
 
 /// Allows mutual exclusion primitives that implement the [`Lock`] trait to automatically unlock
@@ -144,26 +144,16 @@ pub trait LockFactory {
 /// A lock that can be initialised with a single lock class key.
 pub trait LockIniter {
     /// Initialises the lock instance so that it can be safely used.
-    ///
-    /// # Safety
-    ///
-    /// `key` must point to a valid memory location that will remain valid until the lock is
-    /// dropped.
-    unsafe fn init_lock(
-        self: Pin<&mut Self>,
-        name: &'static CStr,
-        key: *mut bindings::lock_class_key,
-    );
+    fn init_lock(self: Pin<&mut Self>, name: &'static CStr, key: &'static LockClassKey);
 }
 
 impl<L: LockIniter> NeedsLockClass for L {
-    unsafe fn init(
+    fn init(
         self: Pin<&mut Self>,
         name: &'static CStr,
-        key: *mut bindings::lock_class_key,
-        _: *mut bindings::lock_class_key,
+        key: &'static LockClassKey,
+        _: &'static LockClassKey,
     ) {
-        // SAFETY: The safety requirements of this function satisfy those of `init_lock`.
-        unsafe { self.init_lock(name, key) };
+        self.init_lock(name, key);
     }
 }

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -4,7 +4,7 @@
 //!
 //! This module allows Rust code to use the kernel's [`struct mutex`].
 
-use super::{Guard, Lock, LockFactory, LockIniter, WriteLock};
+use super::{Guard, Lock, LockClassKey, LockFactory, LockIniter, WriteLock};
 use crate::{bindings, str::CStr, Opaque};
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
 
@@ -82,12 +82,8 @@ impl<T> LockFactory for Mutex<T> {
 }
 
 impl<T> LockIniter for Mutex<T> {
-    unsafe fn init_lock(
-        self: Pin<&mut Self>,
-        name: &'static CStr,
-        key: *mut bindings::lock_class_key,
-    ) {
-        unsafe { bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key) };
+    fn init_lock(self: Pin<&mut Self>, name: &'static CStr, key: &'static LockClassKey) {
+        unsafe { bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key.get()) };
     }
 }
 

--- a/rust/kernel/sync/revocable.rs
+++ b/rust/kernel/sync/revocable.rs
@@ -3,9 +3,8 @@
 //! Synchronisation primitives where access to their contents can be revoked at runtime.
 
 use crate::{
-    bindings,
     str::CStr,
-    sync::{Guard, Lock, LockFactory, LockInfo, NeedsLockClass, ReadLock, WriteLock},
+    sync::{Guard, Lock, LockClassKey, LockFactory, LockInfo, NeedsLockClass, ReadLock, WriteLock},
     True,
 };
 use core::{
@@ -130,18 +129,15 @@ impl<F: LockFactory, T> NeedsLockClass for Revocable<F, T>
 where
     F::LockedType<Inner<T>>: NeedsLockClass,
 {
-    unsafe fn init(
+    fn init(
         self: Pin<&mut Self>,
         name: &'static CStr,
-        key1: *mut bindings::lock_class_key,
-        key2: *mut bindings::lock_class_key,
+        key1: &'static LockClassKey,
+        key2: &'static LockClassKey,
     ) {
         // SAFETY: `inner` is pinned when `self` is.
         let inner = unsafe { self.map_unchecked_mut(|r| &mut r.inner) };
-
-        // SAFETY: The safety requirements of this function satisfy the ones for `inner.init`
-        // (they're the same).
-        unsafe { inner.init(name, key1, key2) };
+        inner.init(name, key1, key2);
     }
 }
 

--- a/rust/kernel/sync/rwsem.rs
+++ b/rust/kernel/sync/rwsem.rs
@@ -6,7 +6,10 @@
 //!
 //! C header: [`include/linux/rwsem.h`](../../../../include/linux/rwsem.h)
 
-use super::{mutex::EmptyGuardContext, Guard, Lock, LockFactory, LockIniter, ReadLock, WriteLock};
+use super::{
+    mutex::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockIniter, ReadLock,
+    WriteLock,
+};
 use crate::{bindings, str::CStr, Opaque};
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
 
@@ -95,12 +98,8 @@ impl<T> LockFactory for RwSemaphore<T> {
 }
 
 impl<T> LockIniter for RwSemaphore<T> {
-    unsafe fn init_lock(
-        self: Pin<&mut Self>,
-        name: &'static CStr,
-        key: *mut bindings::lock_class_key,
-    ) {
-        unsafe { bindings::__init_rwsem(self.rwsem.get(), name.as_char_ptr(), key) };
+    fn init_lock(self: Pin<&mut Self>, name: &'static CStr, key: &'static LockClassKey) {
+        unsafe { bindings::__init_rwsem(self.rwsem.get(), name.as_char_ptr(), key.get()) };
     }
 }
 

--- a/rust/kernel/sync/smutex.rs
+++ b/rust/kernel/sync/smutex.rs
@@ -46,7 +46,7 @@
 //! When the waiter queue is non-empty, unlocking the mutex always results in the first waiter being
 //! popped form the queue and awakened.
 
-use super::{mutex::EmptyGuardContext, Guard, Lock, LockFactory, LockIniter};
+use super::{mutex::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockIniter};
 use crate::{bindings, str::CStr, Opaque};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{cell::UnsafeCell, pin::Pin};
@@ -153,12 +153,7 @@ impl<T> LockFactory for Mutex<T> {
 }
 
 impl<T> LockIniter for Mutex<T> {
-    unsafe fn init_lock(
-        self: Pin<&mut Self>,
-        _name: &'static CStr,
-        _key: *mut bindings::lock_class_key,
-    ) {
-    }
+    fn init_lock(self: Pin<&mut Self>, _name: &'static CStr, _key: &'static LockClassKey) {}
 }
 
 // SAFETY: The mutex implementation ensures mutual exclusion.


### PR DESCRIPTION
This is in preparation for using lock classes in gpio drivers and
executors. (Which is a requirement imposed by the C implementation, not
something new to Rust.)

This takes us closer to making the `bindings` module private to the
`kernel` crate.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>