### PR TITLE
configs: add `rust` config

### DIFF
--- a/kernel/configs/rust.config
+++ b/kernel/configs/rust.config
@@ -1,0 +1,1 @@
+CONFIG_RUST=y


### PR DESCRIPTION
This allows us to enable Rust while creating a configuration file, for
example, we can run `make defconfig rust.config` from the command line
to create the default configuration plus enable Rust.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>