### PR TITLE
scripts: Take only first line of clang version.

### DIFF
--- a/scripts/rust-is-available.sh
+++ b/scripts/rust-is-available.sh
@@ -104,6 +104,7 @@ bindgen_libclang_version=$( \
 	LC_ALL=C "$BINDGEN" $(dirname $0)/rust-is-available-bindgen-libclang.h 2>&1 >/dev/null \
 		| grep -F 'clang version ' \
 		| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+		| head -n 1 \
 )
 bindgen_libclang_min_version=$($min_tool_version llvm)
 bindgen_libclang_cversion=$(get_canonical_version $bindgen_libclang_version)


### PR DESCRIPTION
Using the line below to compile with Clang:
```
$make ARCH=x86_64 CC=clang -j9
```

Emits the following warning:
```
*** libclang (used by the Rust bindings generator 'bindgen') version does not match Clang's. This may be a problem.
***   libclang version: 13.0.0
13.0.0                                                                                                                                                        
***   Clang version:    13.0.0
***
```

This is a result of `$LC_ALL=C bindgen scripts/rust-is-available-bindgen-libclang.h`, which gets called from `scripts/rust-is-available.sh`, producing two matches against the grep'ed pattern `[0-9]+\.[0-9]+\.[0-9]+`:
```
scripts/rust-is-available-bindgen-libclang.h:2:9: warning: clang version 13.0.0 (Fedora 13.0.0-3.fc35) [-W#pragma-messages], err: false
```
This fixes the issue by pipe'ing the matching result to a `head` call,
getting the first result one.

Signed-off-by: Tiago Lam <tiagolam@gmail.com>