### PR TITLE
rust: take lock class keys when registering gpio chips

### DIFF
--- a/drivers/gpio/gpio_pl061_rust.rs
+++ b/drivers/gpio/gpio_pl061_rust.rs
@@ -297,10 +297,15 @@ impl amba::Driver for PL061Device {
 
         data.resources().ok_or(ENXIO)?.base.writeb(0, GPIOIE); // disable irqs
 
-        data.registrations()
-            .ok_or(ENXIO)?
-            .as_pinned_mut()
-            .register::<Self>(PL061_GPIO_NR, None, dev, data.clone(), irq)?;
+        kernel::gpio_irq_chip_register!(
+            data.registrations().ok_or(ENXIO)?.as_pinned_mut(),
+            Self,
+            PL061_GPIO_NR,
+            None,
+            dev,
+            data.clone(),
+            irq
+        )?;
 
         dev_info!(data.dev, "PL061 GPIO chip registered\n");
 

--- a/rust/kernel/sync.rs
+++ b/rust/kernel/sync.rs
@@ -62,7 +62,7 @@ impl LockClassKey {
         Self(UnsafeCell::new(MaybeUninit::uninit()))
     }
 
-    fn get(&self) -> *mut bindings::lock_class_key {
+    pub(crate) fn get(&self) -> *mut bindings::lock_class_key {
         self.0.get().cast()
     }
 }


### PR DESCRIPTION
We also define macros to automatically define the keys.

This fixes the following warning when booting with lockdep enabled:

[    1.100169] DEBUG_LOCKS_WARN_ON(!key)
[    1.100752] WARNING: CPU: 0 PID: 1 at kernel/locking/lockdep.c:4831 lockdep_init_map_type+0x238/0x288

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>