### PR TITLE
binder: use `Either` from `kernel` crate

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -14,6 +14,7 @@ use kernel::{
     sync::{Guard, Mutex, Ref, RefBorrow, UniqueRef},
     task::Task,
     user_ptr::{UserSlicePtr, UserSlicePtrReader},
+    Either,
 };
 
 use crate::{
@@ -23,7 +24,7 @@ use crate::{
     node::{Node, NodeDeath, NodeRef},
     range_alloc::RangeAllocator,
     thread::{BinderError, BinderResult, Thread},
-    DeliverToRead, DeliverToReadListAdapter, Either,
+    DeliverToRead, DeliverToReadListAdapter,
 };
 
 // TODO: Review this:

--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -33,11 +33,6 @@ module! {
     license: b"GPL",
 }
 
-enum Either<L, R> {
-    Left(L),
-    Right(R),
-}
-
 trait DeliverToRead {
     /// Performs work. Returns true if remaining work items in the queue should be processed
     /// immediately, or false if it should return to caller before processing additional work

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -14,6 +14,7 @@ use kernel::{
     security,
     sync::{CondVar, Ref, SpinLock, UniqueRef},
     user_ptr::{UserSlicePtr, UserSlicePtrWriter},
+    Either,
 };
 
 use crate::{
@@ -22,7 +23,7 @@ use crate::{
     process::{AllocationInfo, Process},
     ptr_align,
     transaction::{FileInfo, Transaction},
-    DeliverCode, DeliverToRead, DeliverToReadListAdapter, Either,
+    DeliverCode, DeliverToRead, DeliverToReadListAdapter,
 };
 
 pub(crate) type BinderResult<T = ()> = core::result::Result<T, BinderError>;

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -10,7 +10,7 @@ use kernel::{
     prelude::*,
     sync::{Ref, SpinLock, UniqueRef},
     user_ptr::UserSlicePtrWriter,
-    ScopeGuard,
+    Either, ScopeGuard,
 };
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
     process::Process,
     ptr_align,
     thread::{BinderResult, Thread},
-    DeliverToRead, Either,
+    DeliverToRead,
 };
 
 struct TransactionInner {


### PR DESCRIPTION
There is no need to define its own anymore as the kernel crate offers
one.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>