### PR TITLE
Implement provided functions on KernelAllocator

### DIFF
--- a/rust/kernel/allocator.rs
+++ b/rust/kernel/allocator.rs
@@ -13,12 +13,38 @@ unsafe impl GlobalAlloc for KernelAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // `krealloc()` is used instead of `kmalloc()` because the latter is
         // an inline function and cannot be bound to as a result.
+        // SAFETY: calling C, layout is non zero as per function
         unsafe { bindings::krealloc(ptr::null(), layout.size(), bindings::GFP_KERNEL) as *mut u8 }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        // SAFETY: calling C, ptr is valid and from `krealloc` or `kmalloc`.
         unsafe {
             bindings::kfree(ptr as *const core::ffi::c_void);
+        }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // `krealloc()` is used instead of `kmalloc()` because the latter is
+        // an inline function and cannot be bound to as a result.
+        // SAFETY: calling C, layout is non zero as per function
+        unsafe {
+            bindings::krealloc(
+                ptr::null(),
+                layout.size(),
+                bindings::GFP_KERNEL | bindings::__GFP_ZERO,
+            ) as *mut u8
+        }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: calling C, new_size is non zero as per function and prt is valid.
+        unsafe {
+            bindings::krealloc(
+                ptr as *const core::ffi::c_void,
+                new_size,
+                bindings::GFP_KERNEL,
+            ) as *mut u8
         }
     }
 }


### PR DESCRIPTION
This tells the kernel allocator to provide a zeroed region, instead of just writing zeroes into the memory.

Noticed this while looking at #807 