### PR TITLE
rust: `to_result` only needs the return code

### DIFF
--- a/rust/kernel/amba.rs
+++ b/rust/kernel/amba.rs
@@ -95,7 +95,7 @@ impl<T: Driver> driver::DriverOps for Adapter<T> {
         }
         // SAFETY: By the safety requirements of this function, `reg` is valid and fully
         // initialised.
-        to_result(|| unsafe { bindings::amba_driver_register(reg) })
+        to_result(unsafe { bindings::amba_driver_register(reg) })
     }
 
     unsafe fn unregister(reg: *mut bindings::amba_driver) {

--- a/rust/kernel/clk.rs
+++ b/rust/kernel/clk.rs
@@ -35,7 +35,7 @@ impl Clk {
     /// This function should not be called in atomic context.
     pub fn prepare_enable(self) -> Result<EnabledClk> {
         // SAFETY: The pointer is valid by the type invariant.
-        to_result(|| unsafe { bindings::clk_prepare_enable(self.0) })?;
+        to_result(unsafe { bindings::clk_prepare_enable(self.0) })?;
         Ok(EnabledClk(self))
     }
 }

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -551,10 +551,9 @@ pub(crate) fn from_kernel_err_ptr<T>(ptr: *mut T) -> Result<*mut T> {
     Ok(ptr)
 }
 
-/// Calls a kernel function that returns an integer error code on failure and converts the result
-/// to a [`Result`].
-pub fn to_result(func: impl FnOnce() -> core::ffi::c_int) -> Result {
-    let err = func();
+/// Converts an integer as returned by a C kernel function to an error if it's negative, and
+/// `Ok(())` otherwise.
+pub fn to_result(err: core::ffi::c_int) -> Result {
     if err < 0 {
         Err(Error::from_kernel_errno(err))
     } else {

--- a/rust/kernel/hwrng.rs
+++ b/rust/kernel/hwrng.rs
@@ -106,7 +106,7 @@ impl<T: Operations> Registration<T> {
         );
 
         // SAFETY: `bindings::hwrng` is initialized above which guarantees safety.
-        to_result(|| unsafe { bindings::hwrng_register(this.hwrng.get()) })?;
+        to_result(unsafe { bindings::hwrng_register(this.hwrng.get()) })?;
 
         this.registered = true;
         this.name = Some(name);

--- a/rust/kernel/irq.rs
+++ b/rust/kernel/irq.rs
@@ -366,7 +366,7 @@ impl<T: PointerWrapper> InternalRegistration<T> {
             unsafe { T::from_pointer(ptr) };
         });
         // SAFETY: `name` and `ptr` remain valid as long as the registration is alive.
-        to_result(|| unsafe {
+        to_result(unsafe {
             bindings::request_threaded_irq(
                 irq,
                 handler,

--- a/rust/kernel/mm.rs
+++ b/rust/kernel/mm.rs
@@ -66,7 +66,7 @@ pub mod virt {
             // SAFETY: The page is guaranteed to be order 0 by the type system. The range of
             // `address` is already checked by `vm_insert_page`. `self.vma` and `page.pages` are
             // guaranteed by their repective type invariants to be valid.
-            to_result(|| unsafe { bindings::vm_insert_page(self.vma, address as _, page.pages) })
+            to_result(unsafe { bindings::vm_insert_page(self.vma, address as _, page.pages) })
         }
     }
 

--- a/rust/kernel/net.rs
+++ b/rust/kernel/net.rs
@@ -260,7 +260,7 @@ impl TcpListener {
         };
 
         // SAFETY: The namespace is valid and the output socket pointer is valid for write.
-        to_result(|| unsafe {
+        to_result(unsafe {
             bindings::sock_create_kern(
                 ns.0.get(),
                 pf as _,
@@ -275,10 +275,10 @@ impl TcpListener {
 
         // SAFETY: The type invariant guarantees that the socket is valid, and `addr` and `addrlen`
         // were initialised based on valid values provided in the address enum.
-        to_result(|| unsafe { bindings::kernel_bind(socket, addr, addrlen as _) })?;
+        to_result(unsafe { bindings::kernel_bind(socket, addr, addrlen as _) })?;
 
         // SAFETY: The socket is valid per the type invariant.
-        to_result(|| unsafe { bindings::kernel_listen(socket, bindings::SOMAXCONN as _) })?;
+        to_result(unsafe { bindings::kernel_listen(socket, bindings::SOMAXCONN as _) })?;
 
         Ok(listener)
     }
@@ -295,7 +295,7 @@ impl TcpListener {
         let flags = if block { 0 } else { bindings::O_NONBLOCK };
         // SAFETY: The type invariant guarantees that the socket is valid, and the output argument
         // is also valid for write.
-        to_result(|| unsafe { bindings::kernel_accept(self.sock, &mut new, flags as _) })?;
+        to_result(unsafe { bindings::kernel_accept(self.sock, &mut new, flags as _) })?;
         Ok(TcpStream { sock: new })
     }
 }

--- a/rust/kernel/net/filter.rs
+++ b/rust/kernel/net/filter.rs
@@ -213,7 +213,7 @@ impl<T: Filter> Registration<T> {
 
         // SAFETY: `ns` has a valid reference to the namespace, and `this.hook` was just
         // initialised above, so they're both valid.
-        to_result(|| unsafe { bindings::nf_register_net_hook(ns.0.get(), &this.hook) })?;
+        to_result(unsafe { bindings::nf_register_net_hook(ns.0.get(), &this.hook) })?;
 
         this.dev = dev;
         this.ns = Some(ns);

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -49,7 +49,7 @@ impl<T: Driver> driver::DriverOps for Adapter<T> {
         //   - `probe()` and `remove()` are static functions.
         //   - `of_match_table` is either a raw pointer with static lifetime,
         //      as guaranteed by the [`driver::IdTable`] type, or null.
-        to_result(|| unsafe { bindings::__platform_driver_register(reg, module.0) })
+        to_result(unsafe { bindings::__platform_driver_register(reg, module.0) })
     }
 
     unsafe fn unregister(reg: *mut bindings::platform_driver) {

--- a/rust/kernel/security.rs
+++ b/rust/kernel/security.rs
@@ -10,21 +10,21 @@ use crate::{bindings, cred::Credential, file::File, to_result, Result};
 /// context.
 pub fn binder_set_context_mgr(mgr: &Credential) -> Result {
     // SAFETY: `mrg.0` is valid because the shared reference guarantees a nonzero refcount.
-    to_result(|| unsafe { bindings::security_binder_set_context_mgr(mgr.0.get()) })
+    to_result(unsafe { bindings::security_binder_set_context_mgr(mgr.0.get()) })
 }
 
 /// Calls the security modules to determine if binder transactions are allowed from task `from` to
 /// task `to`.
 pub fn binder_transaction(from: &Credential, to: &Credential) -> Result {
     // SAFETY: `from` and `to` are valid because the shared references guarantee nonzero refcounts.
-    to_result(|| unsafe { bindings::security_binder_transaction(from.0.get(), to.0.get()) })
+    to_result(unsafe { bindings::security_binder_transaction(from.0.get(), to.0.get()) })
 }
 
 /// Calls the security modules to determine if task `from` is allowed to send binder objects
 /// (owned by itself or other processes) to task `to` through a binder transaction.
 pub fn binder_transfer_binder(from: &Credential, to: &Credential) -> Result {
     // SAFETY: `from` and `to` are valid because the shared references guarantee nonzero refcounts.
-    to_result(|| unsafe { bindings::security_binder_transfer_binder(from.0.get(), to.0.get()) })
+    to_result(unsafe { bindings::security_binder_transfer_binder(from.0.get(), to.0.get()) })
 }
 
 /// Calls the security modules to determine if task `from` is allowed to send the given file to
@@ -32,7 +32,7 @@ pub fn binder_transfer_binder(from: &Credential, to: &Credential) -> Result {
 pub fn binder_transfer_file(from: &Credential, to: &Credential, file: &File) -> Result {
     // SAFETY: `from`, `to` and `file` are valid because the shared references guarantee nonzero
     // refcounts.
-    to_result(|| unsafe {
+    to_result(unsafe {
         bindings::security_binder_transfer_file(from.0.get(), to.0.get(), file.0.get())
     })
 }


### PR DESCRIPTION
There is no need for it to take a closure as argument as it just calls
it. Removing the closure simplifies the callers.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>