### PR TITLE
rust: export PointerWrapper from kernel

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -106,7 +106,7 @@ pub use build_error::build_error;
 pub use crate::error::{to_result, Error, Result};
 pub use crate::types::{
     bit, bits_iter, ARef, AlwaysRefCounted, Bool, Either, Either::Left, Either::Right, False, Mode,
-    Opaque, ScopeGuard, True,
+    Opaque, PointerWrapper, ScopeGuard, True,
 };
 
 use core::marker::PhantomData;

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -40,7 +40,8 @@ impl Mode {
 /// Used to convert an object into a raw pointer that represents it.
 ///
 /// It can eventually be converted back into the object. This is used to store objects as pointers
-/// in kernel data structures, for example, an implementation of [`FileOperations`] in `struct
+/// in kernel data structures, for example, an implementation of
+/// [`Operations`][crate::file::Operations] in `struct
 /// file::private_data`.
 pub trait PointerWrapper {
     /// Type of values borrowed between calls to [`PointerWrapper::into_pointer`] and


### PR DESCRIPTION
Previously, only the concrete type could be specified for the data
parameter of kernel::file::Operations method implementations. Exporting
PointerWrapper now allows specifying the data parameter in terms of the
associated type, Self::Data.

Signed-off-by: John Baublitz <john.m.baublitz@gmail.com>