### PR TITLE
Pass --no-layout-tests to rustc

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -297,7 +297,7 @@ bindgen_c_flags_final = $(bindgen_c_flags_lto)
 quiet_cmd_bindgen = BINDGEN $@
       cmd_bindgen = \
 	$(BINDGEN) $< $(bindgen_target_flags) \
-		--use-core --with-derive-default --ctypes-prefix core::ffi \
+		--use-core --with-derive-default --ctypes-prefix core::ffi --no-layout-tests \
 		--no-debug '.*' \
 		--size_t-is-usize -o $@ -- $(bindgen_c_flags_final) -DMODULE \
 		$(bindgen_target_cflags) $(bindgen_target_extra)


### PR DESCRIPTION
Layout tests are skipped anyway. Not generating them in the first place
makes rust-analyzer significantly faster to run. Previously `rust-analyzer
analysis-stats rust-project.json` would run in ~40s and now it only needs
~15s.

Signed-off-by: Björn Roy Baron <bjorn3_gh@protonmail.com>