### PR TITLE
Change libmacros compiler plugin path on macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.dtbo
 *.dtb.S
 *.dwo
+*.dylib
 *.elf
 *.gcno
 *.gz

--- a/Makefile
+++ b/Makefile
@@ -1588,7 +1588,8 @@ MRPROPER_FILES += include/config include/generated          \
 		  certs/x509.genkey \
 		  vmlinux-gdb.py \
 		  *.spec \
-		  rust/target.json rust/libmacros.so
+		  rust/target.json \
+		  rust/libmacros.so rust/libmacros.dylib
 
 # clean - Delete most, but leave enough to build external modules
 #

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -11,9 +11,6 @@ always-$(CONFIG_RUST) += exports_core_generated.h
 obj-$(CONFIG_RUST) += helpers.o
 CFLAGS_REMOVE_helpers.o = -Wmissing-prototypes -Wmissing-declarations
 
-always-$(CONFIG_RUST) += libmacros.so
-no-clean-files += libmacros.so
-
 always-$(CONFIG_RUST) += bindings/bindings_generated.rs bindings/bindings_helpers_generated.rs
 obj-$(CONFIG_RUST) += alloc.o bindings.o kernel.o
 always-$(CONFIG_RUST) += exports_alloc_generated.h exports_bindings_generated.h \
@@ -30,8 +27,14 @@ obj-$(CONFIG_RUST) += exports.o
 obj-$(CONFIG_RUST_KERNEL_KUNIT_TEST) += doctests_kernel_generated.o
 obj-$(CONFIG_RUST_KERNEL_KUNIT_TEST) += doctests_kernel_generated_kunit.o
 
-# Avoids running `$(RUSTC)` for the sysroot when it may not be available.
+# Avoids running `$(RUSTC)` for the sysroot and macros extensions when it may not be available.
 ifdef CONFIG_RUST
+
+libmacros_path := $(shell echo | $(RUSTC) --print file-names --crate-name macros --crate-type proc-macro -)
+libmacros_extension := $(patsubst libmacros.%,%,$(libmacros_path))
+
+always-$(CONFIG_RUST) += $(libmacros_path)
+no-clean-files += $(libmacros_path)
 
 # `$(rust_flags)` is passed in case the user added `--sysroot`.
 rustc_sysroot := $(shell $(RUSTC) $(rust_flags) --print sysroot)
@@ -114,10 +117,10 @@ rustdoc-alloc: $(src)/alloc/lib.rs rustdoc-core rustdoc-compiler_builtins FORCE
 	$(call if_changed,rustdoc)
 
 rustdoc-kernel: private rustc_target_flags = --extern alloc \
-    --extern build_error --extern macros=$(objtree)/$(obj)/libmacros.so \
+    --extern build_error --extern macros=$(objtree)/$(obj)/$(libmacros_path) \
     --extern bindings
 rustdoc-kernel: $(src)/kernel/lib.rs rustdoc-core rustdoc-macros \
-    rustdoc-compiler_builtins rustdoc-alloc $(obj)/libmacros.so \
+    rustdoc-compiler_builtins rustdoc-alloc $(obj)/$(libmacros_path) \
     $(obj)/bindings.o FORCE
 	$(call if_changed,rustdoc)
 
@@ -355,14 +358,14 @@ quiet_cmd_rustc_procmacro = $(RUSTC_OR_CLIPPY_QUIET) P $@
 	$(RUSTC_OR_CLIPPY) $(rust_common_flags) \
 		--emit=dep-info,link --extern proc_macro \
 		--crate-type proc-macro --out-dir $(objtree)/$(obj) \
-		--crate-name $(patsubst lib%.so,%,$(notdir $@)) $<; \
-	mv $(objtree)/$(obj)/$(patsubst lib%.so,%,$(notdir $@)).d $(depfile); \
+		--crate-name $(patsubst lib%.$(libmacros_extension),%,$(notdir $@)) $<; \
+	mv $(objtree)/$(obj)/$(patsubst lib%.$(libmacros_extension),%,$(notdir $@)).d $(depfile); \
 	sed -i '/^\#/d' $(depfile)
 
 # Procedural macros can only be used with the `rustc` that compiled it.
 # Therefore, to get `libmacros.so` automatically recompiled when the compiler
 # version changes, we add `core.o` as a dependency (even if it is not needed).
-$(obj)/libmacros.so: $(src)/macros/lib.rs $(obj)/core.o FORCE
+$(obj)/$(libmacros_path): $(src)/macros/lib.rs $(obj)/core.o FORCE
 	$(call if_changed_dep,rustc_procmacro)
 
 quiet_cmd_rustc_library = $(if $(skip_clippy),RUSTC,$(RUSTC_OR_CLIPPY_QUIET)) L $@
@@ -409,7 +412,7 @@ $(obj)/bindings.o: $(src)/bindings/lib.rs \
 $(obj)/kernel.o: private rustc_target_flags = --extern alloc \
     --extern build_error --extern macros --extern bindings
 $(obj)/kernel.o: $(src)/kernel/lib.rs $(obj)/alloc.o $(obj)/build_error.o \
-    $(obj)/libmacros.so $(obj)/bindings.o FORCE
+    $(obj)/$(libmacros_path) $(obj)/bindings.o FORCE
 	$(call if_changed_dep,rustc_library)
 
 endif # CONFIG_RUST

--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -8,6 +8,7 @@ import json
 import logging
 import pathlib
 import sys
+import subprocess
 
 def generate_crates(srctree, objtree, sysroot_src):
     # Generate the configuration list.
@@ -65,7 +66,14 @@ def generate_crates(srctree, objtree, sysroot_src):
         [],
         is_proc_macro=True,
     )
-    crates[-1]["proc_macro_dylib_path"] = "rust/libmacros.so"
+
+    libmacros_path = subprocess.run(
+        ["rustc", "--print", "file-names", "--crate-name", "macros", "--crate-type", "proc-macro", "-"],
+        stdin=subprocess.DEVNULL,
+        capture_output=True
+    ).stdout.decode().strip()
+    libmacros_path = f"rust/{libmacros_path}"
+    crates[-1]["proc_macro_dylib_path"] = libmacros_path
 
     append_crate(
         "build_error",

--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -8,6 +8,7 @@ import json
 import logging
 import pathlib
 import sys
+import os
 import subprocess
 
 def generate_crates(srctree, objtree, sysroot_src):
@@ -68,7 +69,7 @@ def generate_crates(srctree, objtree, sysroot_src):
     )
 
     libmacros_path = subprocess.run(
-        ["rustc", "--print", "file-names", "--crate-name", "macros", "--crate-type", "proc-macro", "-"],
+        [os.environ["RUSTC"], "--print", "file-names", "--crate-name", "macros", "--crate-type", "proc-macro", "-"],
         stdin=subprocess.DEVNULL,
         capture_output=True
     ).stdout.decode().strip()


### PR DESCRIPTION
Change the path to the resulting libmacros compiler plugin to a dylib
extension when building on macos in the rust-project definition file

CC: @ojeda 