### PR TITLE
rust: change `FileFlags` struct to `flags` module

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -4,7 +4,7 @@ use core::{convert::TryFrom, mem::take, ops::Range};
 use kernel::{
     bindings,
     cred::Credential,
-    file::{self, File, FileFlags, IoctlCommand, IoctlHandler, PollTable},
+    file::{self, File, IoctlCommand, IoctlHandler, PollTable},
     io_buffer::{IoBufferReader, IoBufferWriter},
     linked_list::List,
     mm,
@@ -794,7 +794,7 @@ impl IoctlHandler for Process {
         data: UserSlicePtr,
     ) -> Result<i32> {
         let thread = this.get_thread(Task::current().pid())?;
-        let blocking = (file.flags() & FileFlags::O_NONBLOCK) == 0;
+        let blocking = (file.flags() & file::flags::O_NONBLOCK) == 0;
         match cmd {
             bindings::BINDER_WRITE_READ => thread.write_read(data, blocking)?,
             bindings::BINDER_GET_NODE_DEBUG_INFO => this.get_node_debug_info(data)?,

--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -22,12 +22,7 @@ use core::{cell::UnsafeCell, marker, mem, ptr};
 use macros::vtable;
 
 /// Flags associated with a [`File`].
-///
-/// It is tagged with `non_exhaustive` to prevent users from instantiating it.
-#[non_exhaustive]
-pub struct FileFlags;
-
-impl FileFlags {
+pub mod flags {
     /// File is opened in append mode.
     pub const O_APPEND: u32 = bindings::O_APPEND;
 
@@ -46,7 +41,7 @@ impl FileFlags {
     /// File must be a directory.
     pub const O_DIRECTORY: u32 = bindings::O_DIRECTORY;
 
-    /// Like `Self::O_SYNC` except metadata is not synced.
+    /// Like [`O_SYNC`] except metadata is not synced.
     pub const O_DSYNC: u32 = bindings::O_DSYNC;
 
     /// Ensure that this file is created with the `open(2)` call.
@@ -69,7 +64,7 @@ impl FileFlags {
 
     /// Also known as `O_NDELAY`.
     ///
-    /// This is effectively the same flag as [`Self::O_NONBLOCK`] on all architectures
+    /// This is effectively the same flag as [`O_NONBLOCK`] on all architectures
     /// except SPARC64.
     pub const O_NDELAY: u32 = bindings::O_NDELAY;
 
@@ -90,10 +85,10 @@ impl FileFlags {
     /// # Examples
     ///
     /// ```
-    /// use kernel::file::FileFlags;
+    /// use kernel::file;
     /// # fn do_something() {}
     /// # let flags = 0;
-    /// if (flags & FileFlags::O_ACCMODE) == FileFlags::O_RDONLY {
+    /// if (flags & file::flags::O_ACCMODE) == file::flags::O_RDONLY {
     ///     do_something();
     /// }
     /// ```
@@ -163,7 +158,7 @@ impl File {
 
     /// Returns the flags associated with the file.
     ///
-    /// The flags are a combination of the constants in [`FileFlags`].
+    /// The flags are a combination of the constants in [`flags`].
     pub fn flags(&self) -> u32 {
         // SAFETY: The file is valid because the shared reference guarantees a nonzero refcount.
         unsafe { core::ptr::addr_of!((*self.0.get()).f_flags).read() }

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -6,7 +6,7 @@
 //! <https://github.com/alex/just-use/blob/master/src/lib.rs>.
 
 use kernel::{
-    file::{self, File, FileFlags},
+    file::{self, File},
     io_buffer::{IoBufferReader, IoBufferWriter},
     prelude::*,
 };
@@ -34,7 +34,7 @@ impl file::Operations for RandomFile {
         while !buf.is_empty() {
             let len = chunkbuf.len().min(buf.len());
             let chunk = &mut chunkbuf[0..len];
-            let blocking = (file.flags() & FileFlags::O_NONBLOCK) == 0;
+            let blocking = (file.flags() & file::flags::O_NONBLOCK) == 0;
 
             if blocking {
                 kernel::random::getrandom(chunk)?;


### PR DESCRIPTION
This brings it in line with other cases (e.g., `irq::flags`,
`fs::flags`, `mm::virt::flags`) and allows users to `use` all constants
at once, for example, `use kernel::file::flags::*` if they so choose.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>