### PR TITLE
Makefile: use `stdout` for `rustavailable`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1807,7 +1807,7 @@ $(DOC_TARGETS):
 # "Is Rust available?" target
 PHONY += rustavailable
 rustavailable:
-	$(Q)$(CONFIG_SHELL) $(srctree)/scripts/rust-is-available.sh -v && echo >&2 "Rust is available!"
+	$(Q)$(CONFIG_SHELL) $(srctree)/scripts/rust-is-available.sh -v && echo "Rust is available!"
 
 # Documentation target
 #


### PR DESCRIPTION
Given the message is the main point of running `rustavailable`
for normal users, and those that just want the status code may
ignore it, change the target to print to `stdout`.

Link: https://lore.kernel.org/lkml/CAK7LNAQZOTjxJyS3WC1sM7LE-An7DL8xoW=-s1ONe7cq4YukNQ@mail.gmail.com/
Suggested-by: Masahiro Yamada <masahiroy@kernel.org>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>