### PR TITLE
rust: delay: add `coarse_sleep` examples and tests

### DIFF
--- a/rust/kernel/delay.rs
+++ b/rust/kernel/delay.rs
@@ -9,13 +9,7 @@ use core::{cmp::min, time::Duration};
 
 const MILLIS_PER_SEC: u64 = 1_000;
 
-/// Sleeps safely even with waitqueue interruptions.
-///
-/// This function forwards the call to the C side `msleep` function. As a result,
-/// `duration` will be rounded up to the nearest millisecond if granularity less
-/// than a millisecond is provided. Any [`Duration`] that exceeds
-/// [`c_uint::MAX`][core::ffi::c_uint::MAX] in milliseconds is saturated.
-pub fn coarse_sleep(duration: Duration) {
+fn coarse_sleep_conversion(duration: Duration) -> core::ffi::c_uint {
     let milli_as_nanos = Duration::MILLISECOND.subsec_nanos();
 
     // Rounds the nanosecond component of `duration` up to the nearest millisecond.
@@ -27,6 +21,84 @@ pub fn coarse_sleep(duration: Duration) {
         u64::from(core::ffi::c_uint::MAX),
     ) as core::ffi::c_uint;
 
+    seconds_as_millis.saturating_add(nanos_as_millis)
+}
+
+/// Sleeps safely even with waitqueue interruptions.
+///
+/// This function forwards the call to the C side `msleep` function. As a result,
+/// `duration` will be rounded up to the nearest millisecond if granularity less
+/// than a millisecond is provided. Any [`Duration`] that exceeds
+/// [`c_uint::MAX`][core::ffi::c_uint::MAX] in milliseconds is saturated.
+///
+/// # Examples
+///
+// Keep these in sync with `test_coarse_sleep_examples`.
+/// ```
+/// # use core::time::Duration;
+/// # use kernel::delay::coarse_sleep;
+/// coarse_sleep(Duration::ZERO);                   // Equivalent to `msleep(0)`.
+/// coarse_sleep(Duration::from_nanos(1));          // Equivalent to `msleep(1)`.
+///
+/// coarse_sleep(Duration::from_nanos(1_000_000));  // Equivalent to `msleep(1)`.
+/// coarse_sleep(Duration::from_nanos(1_000_001));  // Equivalent to `msleep(2)`.
+/// coarse_sleep(Duration::from_nanos(1_999_999));  // Equivalent to `msleep(2)`.
+///
+/// coarse_sleep(Duration::from_millis(1));         // Equivalent to `msleep(1)`.
+/// coarse_sleep(Duration::from_millis(2));         // Equivalent to `msleep(2)`.
+///
+/// coarse_sleep(Duration::from_secs(1));           // Equivalent to `msleep(1000)`.
+/// coarse_sleep(Duration::new(1, 1));              // Equivalent to `msleep(1001)`.
+/// coarse_sleep(Duration::new(1, 2));              // Equivalent to `msleep(1001)`.
+/// ```
+pub fn coarse_sleep(duration: Duration) {
     // SAFETY: msleep is safe for all values of an `unsigned int`.
-    unsafe { bindings::msleep(seconds_as_millis.saturating_add(nanos_as_millis)) }
+    unsafe { bindings::msleep(coarse_sleep_conversion(duration)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{coarse_sleep_conversion, MILLIS_PER_SEC};
+    use core::time::Duration;
+
+    #[test]
+    fn test_coarse_sleep_examples() {
+        // Keep these in sync with `coarse_sleep`'s `# Examples` section.
+
+        assert_eq!(coarse_sleep_conversion(Duration::ZERO), 0);
+        assert_eq!(coarse_sleep_conversion(Duration::from_nanos(1)), 1);
+
+        assert_eq!(coarse_sleep_conversion(Duration::from_nanos(1_000_000)), 1);
+        assert_eq!(coarse_sleep_conversion(Duration::from_nanos(1_000_001)), 2);
+        assert_eq!(coarse_sleep_conversion(Duration::from_nanos(1_999_999)), 2);
+
+        assert_eq!(coarse_sleep_conversion(Duration::from_millis(1)), 1);
+        assert_eq!(coarse_sleep_conversion(Duration::from_millis(2)), 2);
+
+        assert_eq!(coarse_sleep_conversion(Duration::from_secs(1)), 1000);
+        assert_eq!(coarse_sleep_conversion(Duration::new(1, 1)), 1001);
+        assert_eq!(coarse_sleep_conversion(Duration::new(1, 2)), 1001);
+    }
+
+    #[test]
+    fn test_coarse_sleep_saturation() {
+        assert!(
+            coarse_sleep_conversion(Duration::new(
+                core::ffi::c_uint::MAX as u64 / MILLIS_PER_SEC,
+                0
+            )) < core::ffi::c_uint::MAX
+        );
+        assert_eq!(
+            coarse_sleep_conversion(Duration::new(
+                core::ffi::c_uint::MAX as u64 / MILLIS_PER_SEC,
+                999_999_999
+            )),
+            core::ffi::c_uint::MAX
+        );
+
+        assert_eq!(
+            coarse_sleep_conversion(Duration::MAX),
+            core::ffi::c_uint::MAX
+        );
+    }
 }


### PR DESCRIPTION
While I was reviewing #823 I wrote a few `assert!`s to double-check I understood the logic, so why not add them as examples and tests?

We could avoid having to keep these in sync by making the conversion function public and moving the tests as `# Examples`, but I am not sure whether we want to expose another function. So, for the moment, at least add them as tests.