### PR TITLE
ci: increase timeout a bit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   ci:
     runs-on: ubuntu-20.04
     container: ghcr.io/rust-for-linux/ci:Rust-1.62.0
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     strategy:
       matrix:


### PR DESCRIPTION
Lately I have noticed more CI jobs being slower than usual,
so let's increase a bit the timeout.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>