### PR TITLE
rust: Proper bindgen sources for BTF debug builds

### DIFF
--- a/include/linux/compiler_types.h
+++ b/include/linux/compiler_types.h
@@ -5,7 +5,7 @@
 #ifndef __ASSEMBLY__
 
 #if defined(CONFIG_DEBUG_INFO_BTF) && defined(CONFIG_PAHOLE_HAS_BTF_TAG) && \
-	__has_attribute(btf_type_tag)
+	__has_attribute(btf_type_tag) && !defined(__BINDGEN__)
 # define BTF_TYPE_TAG(value) __attribute__((btf_type_tag(#value)))
 #else
 # define BTF_TYPE_TAG(value) /* nothing */

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -297,7 +297,7 @@ else
 bindgen_c_flags_lto = $(bindgen_c_flags)
 endif
 
-bindgen_c_flags_final = $(bindgen_c_flags_lto)
+bindgen_c_flags_final = $(bindgen_c_flags_lto) -D__BINDGEN__
 
 quiet_cmd_bindgen = BINDGEN $@
       cmd_bindgen = \


### PR DESCRIPTION
I was testing a BTF debug info build while using a patched pahole that supports excluding Rust. I've noticed that Clang 14 introduced support for the `btf_type_tag` attribute, resulting `BTF_TYPE_TAG(value)` to be expanded as so.
This is all cool and dandy, but watch what happens when bindgen is fed with functions that contains attributed const pointers (like `const char __user *`), bindgen discards its constness, causing that some sources that expect the param to be const failing in their compilation.
For example the `write` field in `file_operations` has a const pointer, a vtable in `rust/kernel/file.rs` based on said struct also uses a const pointer, but if bindgen fails to generate a proper binding it results in the failure of the compilation of the `kernel` crate.

See this [Zulip thread](https://rust-for-linux.zulipchat.com/#narrow/stream/291566-Library/topic/file_operations.20Clang.2014/near/289799180) for context.
