### PR TITLE
rust: fix rust-analyzer warning in macro

### DIFF
--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -80,7 +80,7 @@ impl<'a> ModInfoBuilder<'a> {
             } else {
                 "#[cfg(MODULE)]"
             },
-            module = self.module,
+            module = self.module.to_uppercase(),
             counter = self.counter,
             length = string.len(),
             string = Literal::byte_string(string.as_bytes()),


### PR DESCRIPTION
I get the following warning when using rust-analyzer and the `module`
macro:

Static variable `__rust_fs_4` should have UPPER_SNAKE_CASE name, e.g.
`__RUST_FS_4`

This patch emits an uppercase name for the static, which makes the
warning go away.

Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>