### PR TITLE
rust: drop support for different optimization levels than C

### DIFF
--- a/Documentation/rust/arch-support.rst
+++ b/Documentation/rust/arch-support.rst
@@ -15,11 +15,9 @@ support corresponds to ``S`` values in the ``MAINTAINERS`` file.
 ============  ================  ==============================================
 Architecture  Level of support  Constraints
 ============  ================  ==============================================
-``arm``       Maintained        ``armv6`` and compatible only,
-                                ``RUST_OPT_LEVEL >= 2``.
+``arm``       Maintained        ``armv6`` and compatible only.
 ``arm64``     Maintained        None.
-``powerpc``   Maintained        ``ppc64le`` only, ``RUST_OPT_LEVEL < 2``
-                                requires ``CONFIG_THREAD_SHIFT=15``.
+``powerpc``   Maintained        ``ppc64le`` only.
 ``riscv``     Maintained        ``riscv64`` only.
 ``x86``       Maintained        ``x86_64`` only.
 ============  ================  ==============================================

--- a/Makefile
+++ b/Makefile
@@ -819,27 +819,19 @@ KBUILD_CFLAGS	+= $(call cc-disable-warning, address-of-packed-member)
 
 ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
 KBUILD_CFLAGS += -O2
-KBUILD_RUSTFLAGS_OPT_LEVEL_MAP := 2
+KBUILD_RUSTFLAGS += -Copt-level=2
 else ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE_O3
 KBUILD_CFLAGS += -O3
-KBUILD_RUSTFLAGS_OPT_LEVEL_MAP := 3
+KBUILD_RUSTFLAGS += -Copt-level=3
 else ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
 KBUILD_CFLAGS += -Os
-KBUILD_RUSTFLAGS_OPT_LEVEL_MAP := s
+KBUILD_RUSTFLAGS += -Copt-level=s
 endif
 
 # Always set `debug-assertions` and `overflow-checks` because their default
 # depends on `opt-level` and `debug-assertions`, respectively.
 KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
 KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
-KBUILD_RUSTFLAGS += -Copt-level=$\
-	$(if $(CONFIG_RUST_OPT_LEVEL_SIMILAR_AS_CHOSEN_FOR_C),$(KBUILD_RUSTFLAGS_OPT_LEVEL_MAP))$\
-	$(if $(CONFIG_RUST_OPT_LEVEL_0),0)$\
-	$(if $(CONFIG_RUST_OPT_LEVEL_1),1)$\
-	$(if $(CONFIG_RUST_OPT_LEVEL_2),2)$\
-	$(if $(CONFIG_RUST_OPT_LEVEL_3),3)$\
-	$(if $(CONFIG_RUST_OPT_LEVEL_S),s)$\
-	$(if $(CONFIG_RUST_OPT_LEVEL_Z),z)
 
 # Tell gcc to never replace conditional load with a non-conditional one
 ifdef CONFIG_CC_IS_GCC

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -2721,80 +2721,8 @@ config RUST_OVERFLOW_CHECKS
 	  If unsure, say Y.
 
 choice
-	prompt "Optimization level"
-	default RUST_OPT_LEVEL_SIMILAR_AS_CHOSEN_FOR_C
-	depends on RUST
-	help
-	  Controls rustc's `-Copt-level` codegen option.
-
-	  This flag controls the optimization level.
-
-	  If unsure, say "Similar as chosen for C".
-
-config RUST_OPT_LEVEL_SIMILAR_AS_CHOSEN_FOR_C
-	bool "Similar as chosen for C"
-	help
-	  This choice will pick a similar optimization level as chosen in
-	  the "Compiler optimization level" for C:
-
-	      -O2 is currently mapped to -Copt-level=2
-	      -O3 is currently mapped to -Copt-level=3
-	      -Os is currently mapped to -Copt-level=s
-
-	  The mapping may change over time to follow the intended semantics
-	  of the choice for C as sensibly as possible.
-
-	  This is the default.
-
-config RUST_OPT_LEVEL_0
-	bool "No optimizations (-Copt-level=0)"
-	help
-	  Not recommended for most purposes. It may come in handy for debugging
-	  suspected optimizer bugs, unexpected undefined behavior, etc.
-
-	  Note that this level will *not* enable debug assertions nor overflow
-	  checks on its own (like it happens when interacting with rustc
-	  directly). Use the corresponding configuration options to control
-	  that instead, orthogonally.
-
-	  Note this level may cause excessive stack usage, which can lead to stack
-	  overflow and subsequent crashes.
-
-config RUST_OPT_LEVEL_1
-	bool "Basic optimizations (-Copt-level=1)"
-	help
-	  Useful for debugging without getting too lost, but without
-	  the overhead and boilerplate of no optimizations at all.
-
-	  Note this level may cause excessive stack usage, which can lead to stack
-	  overflow and subsequent crashes.
-
-config RUST_OPT_LEVEL_2
-	bool "Some optimizations (-Copt-level=2)"
-	help
-	  The sensible choice in most cases.
-
-config RUST_OPT_LEVEL_3
-	bool "All optimizations (-Copt-level=3)"
-	help
-	  Yet more performance (hopefully).
-
-config RUST_OPT_LEVEL_S
-	bool "Optimize for size (-Copt-level=s)"
-	help
-	  Smaller kernel, ideally without too much performance loss.
-
-config RUST_OPT_LEVEL_Z
-	bool "Optimize for size, no loop vectorization (-Copt-level=z)"
-	help
-	  Like the previous level, but also turn off loop vectorization.
-
-endchoice
-
-choice
 	prompt "Build-time assertions"
-	default RUST_BUILD_ASSERT_ALLOW if RUST_OPT_LEVEL_0
-	default RUST_BUILD_ASSERT_DENY if !RUST_OPT_LEVEL_0
+	default RUST_BUILD_ASSERT_DENY
 	depends on RUST
 	help
 	  Controls how are `build_error!` and `build_assert!` handled during build.
@@ -2822,7 +2750,6 @@ config RUST_BUILD_ASSERT_WARN
 
 config RUST_BUILD_ASSERT_DENY
 	bool "Deny"
-	depends on !RUST_OPT_LEVEL_0
 	help
 	  Unoptimized calls to `build_error!` will abort compilation.
 


### PR DESCRIPTION
Since the C side only supports `-O2` or higher, we can also remove a few other bits too.

Link: https://lore.kernel.org/lkml/CAKwvOdkjttdX83tL4pw+J5EnHM1MgEYDPp=YTpEagV4RrhdxwA@mail.gmail.com/
Link: https://lore.kernel.org/lkml/CAKwvOd=7QTUH69+ZbT7e8einvgcosTbDkyohmPaUBv6_y8RfrQ@mail.gmail.com/
Link: https://lore.kernel.org/lkml/CANiq72kySVvOQ7eqwe0Jzz3V0JTtrcqODHR9Ty4-sfDMdzP6XQ@mail.gmail.com/
Link: https://lore.kernel.org/lkml/CAKwvOdn+9qORm8UpDGnPXxiK7B7P_TW5CtXv1+8qkv7UvQr3hQ@mail.gmail.com/
Link: https://lore.kernel.org/lkml/CAKwvOdkTjxNEmCTnuH5f41WB50ef6ErBM2Kp2zJ-t9q_5U8rBA@mail.gmail.com/
Suggested-by: Nick Desaulniers <ndesaulniers@google.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>