### PR TITLE
rust: move `retpoline-external-thunk` back to the target spec file

### DIFF
--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -21,7 +21,6 @@ ifdef CONFIG_CC_IS_CLANG
 RETPOLINE_CFLAGS	:= -mretpoline-external-thunk
 RETPOLINE_VDSO_CFLAGS	:= -mretpoline
 endif
-RETPOLINE_RUSTFLAGS	:= -Ctarget-feature=+retpoline-external-thunk
 
 ifdef CONFIG_RETHUNK
 RETHUNK_CFLAGS		:= -mfunction-return=thunk-extern
@@ -203,7 +202,6 @@ ifdef CONFIG_RETPOLINE
   ifndef CONFIG_CC_IS_CLANG
     KBUILD_CFLAGS += -fno-jump-tables
   endif
-  KBUILD_RUSTFLAGS += $(RETPOLINE_RUSTFLAGS)
 endif
 
 ifdef CONFIG_SLS

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -266,9 +266,10 @@ else
 bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-mskip-rax-setup -mgeneral-regs-only -msign-return-address=% \
 	-mindirect-branch=thunk-extern -mindirect-branch-register \
-	-mrecord-mcount -mabi=lp64 -mstack-protector-guard% -mtraceback=no \
-	-mno-pointers-to-nested-functions -mno-string -mno-strict-align \
-	-mstrict-align \
+	-mfunction-return=thunk-extern -mrecord-mcount -mabi=lp64 \
+	-mstack-protector-guard% -mtraceback=no \
+	-mno-pointers-to-nested-functions -mno-string \
+	-mno-strict-align -mstrict-align \
 	-fconserve-stack -falign-jumps=% -falign-loops=% \
 	-femit-struct-debug-baseonly -fno-ipa-cp-clone -fno-ipa-sra \
 	-fno-partial-inlining -fplugin-arg-arm_ssp_per_task_plugin-% \

--- a/scripts/generate_rust_target.rs
+++ b/scripts/generate_rust_target.rs
@@ -204,7 +204,11 @@ fn main() {
             "data-layout",
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
         );
-        ts.push("features", "-3dnow,-3dnowa,-mmx,+soft-float");
+        let mut features = "-3dnow,-3dnowa,-mmx,+soft-float".to_string();
+        if cfg.has("RETPOLINE") {
+            features += ",+retpoline-external-thunk";
+        }
+        ts.push("features", features);
         ts.push("llvm-target", "x86_64-linux-gnu");
         ts.push("target-pointer-width", "64");
     } else {


### PR DESCRIPTION
Also skip it for bindgen.

Found compiling `allmodconfig`.