### PR TITLE
rust: bindgen: add `x86_msi_{data,addr_lo}` as opaque types

### DIFF
--- a/rust/bindgen_parameters
+++ b/rust/bindgen_parameters
@@ -5,6 +5,10 @@
 --opaque-type arch_lbr_state
 --opaque-type local_apic
 
+# Packed type cannot transitively contain a `#[repr(align)]` type.
+--opaque-type x86_msi_data
+--opaque-type x86_msi_addr_lo
+
 # `try` is a reserved keyword since Rust 2018; solved in `bindgen` v0.59.2,
 # commit 2aed6b021680 ("context: Escape the try keyword properly").
 --opaque-type kunit_try_catch


### PR DESCRIPTION
Link: https://lore.kernel.org/lkml/e5c7aa10-590d-0d20-dd3b-385bee2377e7@intel.com/
Reported-by: kernel test robot <yujie.liu@intel.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>