### PR TITLE
rust: depend on `!RANDSTRUCT`

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1916,6 +1916,7 @@ config RUST
 	depends on RUST_IS_AVAILABLE
 	depends on !MODVERSIONS
 	depends on !GCC_PLUGINS
+	depends on !RANDSTRUCT
 	depends on !DEBUG_INFO_BTF
 	select CONSTRUCTORS
 	help


### PR DESCRIPTION
Clang 15 will support structure layout randomization, and the kernel
has reorganized the Kconfig options in preparation, see commit
595b893e2087 ("randstruct: Reorganize Kconfigs and attribute macros").

Thus depend ourselves on `!RANDSTRUCT` until we figure out a way
to handle it in `bindgen` (or go through a C function etc.). Some
of the Rust code we have in the `kernel` crate does not support it
in any case.

Link: https://lore.kernel.org/lkml/383b1045-94c5-c2b0-57db-9f4f4760206c@intel.com/
Reported-by: kernel test robot <yujie.liu@intel.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>