### PR TITLE
Add BINDER_TYPE_PTR support

### DIFF
--- a/drivers/android/defs.rs
+++ b/drivers/android/defs.rs
@@ -35,7 +35,9 @@ pub_no_prefix!(
 pub_no_prefix!(
     binder_driver_command_protocol_,
     BC_TRANSACTION,
+    BC_TRANSACTION_SG,
     BC_REPLY,
+    BC_REPLY_SG,
     BC_FREE_BUFFER,
     BC_INCREFS,
     BC_ACQUIRE,
@@ -54,13 +56,14 @@ pub_no_prefix!(
 pub_no_prefix!(transaction_flags_, TF_ONE_WAY, TF_ACCEPT_FDS);
 
 pub(crate) use bindings::{
-    BINDER_TYPE_BINDER, BINDER_TYPE_FD, BINDER_TYPE_HANDLE, BINDER_TYPE_WEAK_BINDER,
-    BINDER_TYPE_WEAK_HANDLE, FLAT_BINDER_FLAG_ACCEPTS_FDS,
+    BINDER_TYPE_BINDER, BINDER_TYPE_FD, BINDER_TYPE_HANDLE, BINDER_TYPE_PTR,
+    BINDER_TYPE_WEAK_BINDER, BINDER_TYPE_WEAK_HANDLE, FLAT_BINDER_FLAG_ACCEPTS_FDS,
 };
 
 macro_rules! decl_wrapper {
     ($newname:ident, $wrapped:ty) => {
         #[derive(Copy, Clone, Default)]
+        #[repr(transparent)]
         pub(crate) struct $newname($wrapped);
 
         // TODO: This must be justified by inspecting the type, so should live outside the macro or
@@ -87,6 +90,10 @@ decl_wrapper!(BinderNodeDebugInfo, bindings::binder_node_debug_info);
 decl_wrapper!(BinderNodeInfoForRef, bindings::binder_node_info_for_ref);
 decl_wrapper!(FlatBinderObject, bindings::flat_binder_object);
 decl_wrapper!(BinderTransactionData, bindings::binder_transaction_data);
+decl_wrapper!(
+    BinderTransactionDataSg,
+    bindings::binder_transaction_data_sg
+);
 decl_wrapper!(BinderWriteRead, bindings::binder_write_read);
 decl_wrapper!(BinderVersion, bindings::binder_version);
 
@@ -94,6 +101,15 @@ impl BinderVersion {
     pub(crate) fn current() -> Self {
         Self(bindings::binder_version {
             protocol_version: bindings::BINDER_CURRENT_PROTOCOL_VERSION as _,
+        })
+    }
+}
+
+impl BinderTransactionData {
+    pub(crate) fn with_buffers_size(self, buffers_size: u64) -> BinderTransactionDataSg {
+        BinderTransactionDataSg(bindings::binder_transaction_data_sg {
+            transaction_data: self.0,
+            buffers_size,
         })
     }
 }

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -47,8 +47,9 @@ impl Transaction {
         node_ref: NodeRef,
         stack_next: Option<Ref<Transaction>>,
         from: &Ref<Thread>,
-        tr: &BinderTransactionData,
+        tr: &BinderTransactionDataSg,
     ) -> BinderResult<Ref<Self>> {
+        let trd = &tr.transaction_data;
         let allow_fds = node_ref.node.flags & FLAT_BINDER_FLAG_ACCEPTS_FDS != 0;
         let to = node_ref.node.owner.clone();
         let mut alloc = from.copy_transaction_data(&to, tr, allow_fds)?;
@@ -62,11 +63,11 @@ impl Transaction {
             stack_next,
             from: from.clone(),
             to,
-            code: tr.code,
-            flags: tr.flags,
-            data_size: tr.data_size as _,
+            code: trd.code,
+            flags: trd.flags,
+            data_size: trd.data_size as _,
             data_address,
-            offsets_size: tr.offsets_size as _,
+            offsets_size: trd.offsets_size as _,
             links: Links::new(),
             free_allocation: AtomicBool::new(true),
         })?);
@@ -81,9 +82,10 @@ impl Transaction {
     pub(crate) fn new_reply(
         from: &Ref<Thread>,
         to: Ref<Process>,
-        tr: &BinderTransactionData,
+        tr: &BinderTransactionDataSg,
         allow_fds: bool,
     ) -> BinderResult<Ref<Self>> {
+        let trd = &tr.transaction_data;
         let mut alloc = from.copy_transaction_data(&to, tr, allow_fds)?;
         let data_address = alloc.ptr;
         let file_list = alloc.take_file_list();
@@ -95,11 +97,11 @@ impl Transaction {
             stack_next: None,
             from: from.clone(),
             to,
-            code: tr.code,
-            flags: tr.flags,
-            data_size: tr.data_size as _,
+            code: trd.code,
+            flags: trd.flags,
+            data_size: trd.data_size as _,
             data_address,
-            offsets_size: tr.offsets_size as _,
+            offsets_size: trd.offsets_size as _,
             links: Links::new(),
             free_allocation: AtomicBool::new(true),
         })?);


### PR DESCRIPTION
This commit adds support for supplying data stored in additional buffers using binder objects of type `BINDER_TYPE_PTR`.

I've tried to figure out how to test this, but I had some trouble getting [this test][1] to work. I would appreciate some assistance in figuring out how to run those tests.

The current implementation doesn't support `BINDER_BUFFER_FLAG_HAS_PARENT`.

[1]: https://github.com/wedsonaf/linux/blob/tests/tools/testing/selftests/binder/binder_test.c