### PR TITLE
rust: bindgen: skip `-mindirect-branch-cs-prefix`

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -267,7 +267,7 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-mskip-rax-setup -mgeneral-regs-only -msign-return-address=% \
 	-mindirect-branch=thunk-extern -mindirect-branch-register \
 	-mfunction-return=thunk-extern -mrecord-mcount -mabi=lp64 \
-	-mstack-protector-guard% -mtraceback=no \
+	-mindirect-branch-cs-prefix -mstack-protector-guard% -mtraceback=no \
 	-mno-pointers-to-nested-functions -mno-string \
 	-mno-strict-align -mstrict-align \
 	-fconserve-stack -falign-jumps=% -falign-loops=% \


### PR DESCRIPTION
Link: https://lore.kernel.org/all/20211119165023.249607540@infradead.org/
Reported-by: Boqun Feng <boqun.feng@gmail.com>
Tested-by: Boqun Feng <boqun.feng@gmail.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>

@fbq 