### PR TITLE
rust: take str literal instead bstr literal in `module!` macro

### DIFF
--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -27,10 +27,10 @@ use {context::Context, thread::Thread};
 
 module! {
     type: BinderModule,
-    name: b"rust_binder",
-    author: b"Wedson Almeida Filho",
-    description: b"Android Binder",
-    license: b"GPL",
+    name: "rust_binder",
+    author: "Wedson Almeida Filho",
+    description: "Android Binder",
+    license: "GPL",
 }
 
 trait DeliverToRead {

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -9,10 +9,10 @@ use kernel::{
 
 module_platform_driver! {
     type: RngDriver,
-    name: b"bcm2835_rng_rust",
-    author: b"Rust for Linux Contributors",
-    description: b"BCM2835 Random Number Generator (RNG) driver",
-    license: b"GPL v2",
+    name: "bcm2835_rng_rust",
+    author: "Rust for Linux Contributors",
+    description: "BCM2835 Random Number Generator (RNG) driver",
+    license: "GPL v2",
 }
 
 struct RngDevice;

--- a/drivers/gpio/gpio_pl061_rust.rs
+++ b/drivers/gpio/gpio_pl061_rust.rs
@@ -361,7 +361,7 @@ impl power::Operations for PL061Device {
 
 module_amba_driver! {
     type: PL061Device,
-    name: b"pl061_gpio",
-    author: b"Wedson Almeida Filho",
-    license: b"GPL",
+    name: "pl061_gpio",
+    author: "Wedson Almeida Filho",
+    license: "GPL",
 }

--- a/rust/kernel/amba.rs
+++ b/rust/kernel/amba.rs
@@ -223,9 +223,9 @@ unsafe impl device::RawDevice for Device {
 ///
 /// module_amba_driver! {
 ///     type: MyDriver,
-///     name: b"module_name",
-///     author: b"Author name",
-///     license: b"GPL",
+///     name: "module_name",
+///     author: "Author name",
+///     license: "GPL",
 /// }
 /// ```
 #[macro_export]

--- a/rust/kernel/fs.rs
+++ b/rust/kernel/fs.rs
@@ -799,10 +799,10 @@ impl<T: Type + Sync> crate::Module for Module<T> {
 ///
 /// module_fs! {
 ///     type: MyFs,
-///     name: b"my_fs_kernel_module",
-///     author: b"Rust for Linux Contributors",
-///     description: b"My very own file system kernel module!",
-///     license: b"GPL",
+///     name: "my_fs_kernel_module",
+///     author: "Rust for Linux Contributors",
+///     description: "My very own file system kernel module!",
+///     license: "GPL",
 /// }
 ///
 /// struct MyFs;

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -266,10 +266,10 @@ impl<T: file::Operations<OpenData = ()>> crate::Module for Module<T> {
 ///
 /// module_misc_device! {
 ///     type: MyFile,
-///     name: b"my_miscdev_kernel_module",
-///     author: b"Rust for Linux Contributors",
-///     description: b"My very own misc device kernel module!",
-///     license: b"GPL",
+///     name: "my_miscdev_kernel_module",
+///     author: "Rust for Linux Contributors",
+///     description: "My very own misc device kernel module!",
+///     license: "GPL",
 /// }
 ///
 /// #[derive(Default)]

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -210,9 +210,9 @@ unsafe impl device::RawDevice for Device {
 ///
 /// module_platform_driver! {
 ///     type: MyDriver,
-///     name: b"module_name",
-///     author: b"Author name",
-///     license: b"GPL",
+///     name: "module_name",
+///     author: "Author name",
+///     license: "GPL",
 /// }
 /// ```
 #[macro_export]

--- a/rust/macros/lib.rs
+++ b/rust/macros/lib.rs
@@ -25,20 +25,20 @@ use proc_macro::TokenStream;
 ///
 /// module!{
 ///     type: MyModule,
-///     name: b"my_kernel_module",
-///     author: b"Rust for Linux Contributors",
-///     description: b"My very own kernel module!",
-///     license: b"GPL",
+///     name: "my_kernel_module",
+///     author: "Rust for Linux Contributors",
+///     description: "My very own kernel module!",
+///     license: "GPL",
 ///     params: {
 ///        my_i32: i32 {
 ///            default: 42,
 ///            permissions: 0o000,
-///            description: b"Example of i32",
+///            description: "Example of i32",
 ///        },
 ///        writeable_i32: i32 {
 ///            default: 42,
 ///            permissions: 0o644,
-///            description: b"Example of i32",
+///            description: "Example of i32",
 ///        },
 ///    },
 /// }

--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -256,13 +256,13 @@ impl ModuleInfo {
 
             match key.as_str() {
                 "type" => info.type_ = expect_ident(it),
-                "name" => info.name = expect_byte_string(it),
-                "author" => info.author = Some(expect_byte_string(it)),
-                "description" => info.description = Some(expect_byte_string(it)),
-                "license" => info.license = expect_byte_string(it),
-                "alias" => info.alias = Some(expect_byte_string(it)),
+                "name" => info.name = expect_string_ascii(it),
+                "author" => info.author = Some(expect_string(it)),
+                "description" => info.description = Some(expect_string(it)),
+                "license" => info.license = expect_string_ascii(it),
+                "alias" => info.alias = Some(expect_string_ascii(it)),
                 "alias_rtnl_link" => {
-                    info.alias = Some(format!("rtnl-link-{}", expect_byte_string(it)))
+                    info.alias = Some(format!("rtnl-link-{}", expect_string_ascii(it)))
                 }
                 "params" => info.params = Some(expect_group(it)),
                 _ => panic!(
@@ -347,7 +347,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             let mut param_it = group.stream().into_iter();
             let param_default = get_default(&param_type, &mut param_it);
             let param_permissions = get_literal(&mut param_it, "permissions");
-            let param_description = get_byte_string(&mut param_it, "description");
+            let param_description = get_string(&mut param_it, "description");
             expect_end(&mut param_it);
 
             // TODO: More primitive types.

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -7,10 +7,10 @@ use kernel::{chrdev, file};
 
 module! {
     type: RustChrdev,
-    name: b"rust_chrdev",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust character device sample",
-    license: b"GPL",
+    name: "rust_chrdev",
+    author: "Rust for Linux Contributors",
+    description: "Rust character device sample",
+    license: "GPL",
 }
 
 struct RustFile;

--- a/samples/rust/rust_echo_server.rs
+++ b/samples/rust/rust_echo_server.rs
@@ -53,8 +53,8 @@ impl kernel::Module for RustEchoServer {
 
 module! {
     type: RustEchoServer,
-    name: b"rust_echo_server",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust tcp echo sample",
-    license: b"GPL v2",
+    name: "rust_echo_server",
+    author: "Rust for Linux Contributors",
+    description: "Rust tcp echo sample",
+    license: "GPL v2",
 }

--- a/samples/rust/rust_fs.rs
+++ b/samples/rust/rust_fs.rs
@@ -7,9 +7,9 @@ use kernel::{c_str, fs};
 
 module_fs! {
     type: RustFs,
-    name: b"rust_fs",
-    author: b"Rust for Linux Contributors",
-    license: b"GPL",
+    name: "rust_fs",
+    author: "Rust for Linux Contributors",
+    license: "GPL",
 }
 
 struct RustFs;

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -6,10 +6,10 @@ use kernel::prelude::*;
 
 module! {
     type: RustMinimal,
-    name: b"rust_minimal",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust minimal sample",
-    license: b"GPL",
+    name: "rust_minimal",
+    author: "Rust for Linux Contributors",
+    description: "Rust minimal sample",
+    license: "GPL",
 }
 
 struct RustMinimal {

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -12,10 +12,10 @@ use kernel::{
 
 module! {
     type: RustMiscdev,
-    name: b"rust_miscdev",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust miscellaneous device sample",
-    license: b"GPL",
+    name: "rust_miscdev",
+    author: "Rust for Linux Contributors",
+    description: "Rust miscellaneous device sample",
+    license: "GPL",
 }
 
 const MAX_TOKENS: usize = 3;

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -6,35 +6,35 @@ use kernel::prelude::*;
 
 module! {
     type: RustModuleParameters,
-    name: b"rust_module_parameters",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust module parameters sample",
-    license: b"GPL",
+    name: "rust_module_parameters",
+    author: "Rust for Linux Contributors",
+    description: "Rust module parameters sample",
+    license: "GPL",
     params: {
         my_bool: bool {
             default: true,
             permissions: 0,
-            description: b"Example of bool",
+            description: "Example of bool",
         },
         my_i32: i32 {
             default: 42,
             permissions: 0o644,
-            description: b"Example of i32",
+            description: "Example of i32",
         },
         my_str: str {
             default: b"default str val",
             permissions: 0o644,
-            description: b"Example of a string param",
+            description: "Example of a string param",
         },
         my_usize: usize {
             default: 42,
             permissions: 0o644,
-            description: b"Example of usize",
+            description: "Example of usize",
         },
         my_array: ArrayParam<i32, 3> {
             default: [0, 1],
             permissions: 0,
-            description: b"Example of array",
+            description: "Example of array",
         },
     },
 }

--- a/samples/rust/rust_netfilter.rs
+++ b/samples/rust/rust_netfilter.rs
@@ -8,10 +8,10 @@ use kernel::prelude::*;
 
 module! {
     type: RustNetfilter,
-    name: b"rust_netfilter",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust netfilter sample",
-    license: b"GPL",
+    name: "rust_netfilter",
+    author: "Rust for Linux Contributors",
+    description: "Rust netfilter sample",
+    license: "GPL",
 }
 
 struct RustNetfilter {

--- a/samples/rust/rust_platform.rs
+++ b/samples/rust/rust_platform.rs
@@ -6,8 +6,8 @@ use kernel::{module_platform_driver, of, platform, prelude::*};
 
 module_platform_driver! {
     type: Driver,
-    name: b"rust_platform",
-    license: b"GPL",
+    name: "rust_platform",
+    license: "GPL",
 }
 
 struct Driver;

--- a/samples/rust/rust_print.rs
+++ b/samples/rust/rust_print.rs
@@ -7,10 +7,10 @@ use kernel::{pr_cont, str::CStr, ThisModule};
 
 module! {
     type: RustPrint,
-    name: b"rust_print",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust printing macros sample",
-    license: b"GPL",
+    name: "rust_print",
+    author: "Rust for Linux Contributors",
+    description: "Rust printing macros sample",
+    license: "GPL",
 }
 
 struct RustPrint;

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -13,10 +13,10 @@ use kernel::{
 
 module_misc_device! {
     type: RandomFile,
-    name: b"rust_random",
-    author: b"Rust for Linux Contributors",
-    description: b"Just use /dev/urandom: Now with early-boot safety",
-    license: b"GPL",
+    name: "rust_random",
+    author: "Rust for Linux Contributors",
+    description: "Just use /dev/urandom: Now with early-boot safety",
+    license: "GPL",
 }
 
 struct RandomFile;

--- a/samples/rust/rust_selftests.rs
+++ b/samples/rust/rust_selftests.rs
@@ -8,10 +8,10 @@ use kernel::prelude::*;
 
 module! {
     type: RustSelftests,
-    name: b"rust_selftests",
-    author: b"Rust for Linux Contributors",
-    description: b"Self test cases for Rust",
-    license: b"GPL",
+    name: "rust_selftests",
+    author: "Rust for Linux Contributors",
+    description: "Self test cases for Rust",
+    license: "GPL",
 }
 
 struct RustSelftests;

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -27,10 +27,10 @@ use kernel::{
 
 module! {
     type: RustSemaphore,
-    name: b"rust_semaphore",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust semaphore sample",
-    license: b"GPL",
+    name: "rust_semaphore",
+    author: "Rust for Linux Contributors",
+    description: "Rust semaphore sample",
+    license: "GPL",
 }
 
 struct SemaphoreInner {

--- a/samples/rust/rust_stack_probing.rs
+++ b/samples/rust/rust_stack_probing.rs
@@ -6,10 +6,10 @@ use kernel::prelude::*;
 
 module! {
     type: RustStackProbing,
-    name: b"rust_stack_probing",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust stack probing sample",
-    license: b"GPL",
+    name: "rust_stack_probing",
+    author: "Rust for Linux Contributors",
+    description: "Rust stack probing sample",
+    license: "GPL",
 }
 
 struct RustStackProbing;

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -10,10 +10,10 @@ use kernel::{
 
 module! {
     type: RustSync,
-    name: b"rust_sync",
-    author: b"Rust for Linux Contributors",
-    description: b"Rust synchronisation primitives sample",
-    license: b"GPL",
+    name: "rust_sync",
+    author: "Rust for Linux Contributors",
+    description: "Rust synchronisation primitives sample",
+    license: "GPL",
 }
 
 kernel::init_static_sync! {


### PR DESCRIPTION
Not a complete fix to #252 because only a subset of string literals are accepted: For simplicity (avoid parsing), escape sequences are not yet handled.