### PR TITLE
samples: add Rust GPL access test sample

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -387,6 +387,15 @@ jobs:
             ${{ env.BUILD_DIR }}rust/*.o \
             ${{ env.BUILD_DIR }}vmlinux
 
+      # GPL access test
+      - run: |
+          CONFIG_SAMPLE_RUST_GPL_ACCESS_TEST=m \
+            make ${{ env.MAKE_ARCH }} ${{ env.MAKE_CROSS_COMPILE }} ${{ env.MAKE_LLVM_IAS }} ${{ env.MAKE_TOOLCHAIN }} ${{ env.MAKE_OUTPUT }} ${{ env.MAKE_SYSROOT }} -j3 2>&1 \
+            | grep "^ERROR: modpost: GPL-incompatible module rust_gpl_access_test\.ko uses GPL-only symbol '_R.*printk'$"
+          CONFIG_SAMPLE_RUST_GPL_ACCESS_TEST=m \
+            make ${{ env.MAKE_ARCH }} ${{ env.MAKE_CROSS_COMPILE }} ${{ env.MAKE_LLVM_IAS }} ${{ env.MAKE_TOOLCHAIN }} ${{ env.MAKE_OUTPUT }} ${{ env.MAKE_SYSROOT }} -j3 2>&1 \
+            | grep "^ERROR: modpost: GPL-incompatible module rust_gpl_access_test\.ko uses GPL-only symbol 'kernel_halt'$"
+
       # Clippy
       - run: make ${{ env.MAKE_ARCH }} ${{ env.MAKE_CROSS_COMPILE }} ${{ env.MAKE_LLVM_IAS }} ${{ env.MAKE_TOOLCHAIN }} ${{ env.MAKE_OUTPUT }} ${{ env.MAKE_SYSROOT }} -j3 CLIPPY=1
 

--- a/samples/rust/Kconfig
+++ b/samples/rust/Kconfig
@@ -163,4 +163,18 @@ config SAMPLE_RUST_SELFTESTS
 
 	  If unsure, say N.
 
+config SAMPLE_RUST_GPL_ACCESS_TEST
+	tristate "GPL access test"
+	depends on BROKEN
+	depends on PRINTK
+	help
+	  This option builds the Rust GPL access test.
+
+	  This module should fail to pass modpost.
+
+	  To compile this as a module, choose M here:
+	  the module will be called rust_gpl_access_test.
+
+	  If unsure, say N.
+
 endif # SAMPLES_RUST

--- a/samples/rust/Makefile
+++ b/samples/rust/Makefile
@@ -14,6 +14,8 @@ obj-$(CONFIG_SAMPLE_RUST_PLATFORM)		+= rust_platform.o
 obj-$(CONFIG_SAMPLE_RUST_NETFILTER)		+= rust_netfilter.o
 obj-$(CONFIG_SAMPLE_RUST_ECHO_SERVER)		+= rust_echo_server.o
 obj-$(CONFIG_SAMPLE_RUST_FS)			+= rust_fs.o
+
 obj-$(CONFIG_SAMPLE_RUST_SELFTESTS)		+= rust_selftests.o
+obj-$(CONFIG_SAMPLE_RUST_GPL_ACCESS_TEST)	+= rust_gpl_access_test.o
 
 subdir-$(CONFIG_SAMPLE_RUST_HOSTPROGS)		+= hostprogs

--- a/samples/rust/rust_gpl_access_test.rs
+++ b/samples/rust/rust_gpl_access_test.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Rust GPL access test.
+//!
+//! This module should fail to pass `modpost`.
+
+use kernel::prelude::*;
+
+// This module is licensed as GPL as the SPDX license identifier above mentions.
+// However, the value of the `license` field below is different in order to
+// ensure that `modpost` catches innocent mistakes when a non-GPL compatible
+// module tries to use GPL-only symbols in Rust.
+module! {
+    type: RustGplAccessTest,
+    name: "rust_gpl_access_test",
+    author: "Rust for Linux Contributors",
+    description: "Rust GPL access test",
+    license: "Happy Little Accidents License",
+}
+
+/// Function in a non-GPL compatible module that uses a Rust symbol exported
+/// using `EXPORT_SYMBOL_GPL()`.
+///
+/// This is __not__ OK, and should be detected by `modpost`.
+fn happy_little_accident() {
+    pr_info!("...and in our world, we can do anything that we want to do here\n");
+}
+
+/// Function in a non-GPL compatible module that uses a C symbol exported
+/// using `EXPORT_SYMBOL_GPL()`.
+///
+/// This is __not__ OK, and should be detected by `modpost`.
+fn this_little_rascal_here() {
+    extern "C" {
+        fn kernel_halt();
+    }
+
+    // SAFETY: FFI call with no safety preconditions.
+    unsafe {
+        kernel_halt();
+    }
+}
+
+struct RustGplAccessTest;
+
+impl kernel::Module for RustGplAccessTest {
+    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+        happy_little_accident();
+        this_little_rascal_here();
+
+        Ok(RustGplAccessTest)
+    }
+}


### PR DESCRIPTION
Greg asked me to double-check whether we could use GPL symbols from
non-GPL compatible Rust kernel modules.

So I decided to ensure this in the CI via this sample.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>