### PR TITLE
feat: Allow the use of fn bit in a const context

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -109,8 +109,8 @@ pub use build_error::build_error;
 
 pub use crate::error::{to_result, Error, Result};
 pub use crate::types::{
-    bit, bits_iter, ARef, AlwaysRefCounted, Bool, Either, Either::Left, Either::Right, False, Mode,
-    Opaque, PointerWrapper, ScopeGuard, True,
+    bit, bits_iter, ARef, AlwaysRefCounted, Bit, Bool, Either, Either::Left, Either::Right, False,
+    Mode, Opaque, PointerWrapper, ScopeGuard, True,
 };
 
 use core::marker::PhantomData;

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -355,7 +355,7 @@ pub struct Bit<T> {
 ///
 /// assert_eq!(y | bit(35), 0xc00000000);
 /// ```
-pub fn bit<T: Copy>(index: T) -> Bit<T> {
+pub const fn bit<T: Copy>(index: T) -> Bit<T> {
     Bit {
         index,
         inverted: false,


### PR DESCRIPTION
Changes:

- Mark `bit` as a `pub const fn`
- Expose `Bit` struct (needed, because rust doesn't infer global types)

Fixes: people using `const MASK: u64 = 1 << 4;` instead of `const MASK:
Bit<u64> = bit(4);`