### PR TITLE
Shrink list of allowed unstable features for drivers

### DIFF
--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -275,7 +275,7 @@ $(obj)/%.lst: $(src)/%.c FORCE
 # Compile Rust sources (.rs)
 # ---------------------------------------------------------------------------
 
-rust_allowed_features := allocator_api,bench_black_box,core_ffi_c,generic_associated_types,const_ptr_offset_from,const_refs_to_cell
+rust_allowed_features := allocator_api,bench_black_box,const_ptr_offset_from,core_ffi_c,generic_associated_types
 
 rust_common_cmd = \
 	RUST_MODFILE=$(modfile) $(RUSTC_OR_CLIPPY) $(rust_flags) \


### PR DESCRIPTION
const_ptr_offset_from and const_refs_to_cell aren't used by any driver
at all.

Signed-off-by: Björn Roy Baron <bjorn3_gh@protonmail.com>