### PR TITLE
scripts: rust: Fix version check when CC has multiple arguments

### DIFF
--- a/scripts/rust_is_available.sh
+++ b/scripts/rust_is_available.sh
@@ -126,10 +126,10 @@ fi
 # In the future, we might be able to perform a full version check, see
 # https://github.com/rust-lang/rust-bindgen/issues/2138.
 if [ "$1" = -v ]; then
-	cc_name=$($(dirname $0)/cc-version.sh "$CC" | cut -f1 -d' ')
+	cc_name=$($(dirname $0)/cc-version.sh $CC | cut -f1 -d' ')
 	if [ "$cc_name" = Clang ]; then
 		clang_version=$( \
-			LC_ALL=C "$CC" --version 2>/dev/null \
+			LC_ALL=C $CC --version 2>/dev/null \
 				| sed -nE '1s:.*version ([0-9]+\.[0-9]+\.[0-9]+).*:\1:p'
 		)
 		if [ "$clang_version" != "$bindgen_libclang_version" ]; then


### PR DESCRIPTION
rust_is_available.sh uses cc-version.sh to identify which C compiler is
in use, as scripts/Kconfig.include does.  cc-version.sh isn't designed to be
able to handle multiple arguments in one variable, i.e. "ccache clang".
Its invocation in rust_is_available.sh quotes "$CC", which makes
$1 == "ccache clang" instead of the intended $1 == ccache & $2 == clang.

cc-version.sh could also be changed to handle having "ccache clang" as one
argument, but it only has the one consumer upstream, making it simpler to
fix the caller here.

Signed-off-by: Russell Currey <ruscur@russell.cc>