### PR TITLE
rust: macros: allow overriding the name of module param constants

### DIFF
--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -329,6 +329,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
         assert_eq!(params.delimiter(), Delimiter::Brace);
 
         let mut it = params.stream().into_iter();
+        let mut read_funcs = Vec::new();
 
         loop {
             let param_name = match it.next() {
@@ -388,7 +389,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             let read_func = if permissions_are_readonly(&param_permissions) {
                 format!(
                     "
-                        fn read(&self)
+                        fn {param_name}(&self)
                             -> &<{param_type_internal} as kernel::module_param::ModuleParam>::Value {{
                             // SAFETY: Parameters do not need to be locked because they are
                             // read only or sysfs is not enabled.
@@ -406,7 +407,7 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             } else {
                 format!(
                     "
-                        fn read<'lck>(&self, lock: &'lck kernel::KParamGuard)
+                        fn {param_name}<'lck>(&self, lock: &'lck kernel::KParamGuard)
                             -> &'lck <{param_type_internal} as kernel::module_param::ModuleParam>::Value {{
                             // SAFETY: Parameters are locked by `KParamGuard`.
                             unsafe {{
@@ -421,6 +422,8 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
                     param_type_internal = param_type_internal,
                 )
             };
+            read_funcs.push(read_func);
+
             let kparam = format!(
                 "
                     kernel::bindings::kernel_param__bindgen_ty_1 {{
@@ -435,12 +438,6 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
                 modinfo.buffer,
                 "
                 static mut __{name}_{param_name}_value: {param_type_internal} = {param_default};
-
-                struct __{name}_{param_name};
-
-                impl __{name}_{param_name} {{ {read_func} }}
-
-                const {param_name}: __{name}_{param_name} = __{name}_{param_name};
 
                 // Note: the C macro that generates the static structs for the `__param` section
                 // asks for them to be `aligned(sizeof(void *))`. However, that was put in place
@@ -483,7 +480,6 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
                 ",
                 name = info.name,
                 param_type_internal = param_type_internal,
-                read_func = read_func,
                 param_default = param_default,
                 param_name = param_name,
                 ops = ops,
@@ -492,6 +488,29 @@ pub(crate) fn module(ts: TokenStream) -> TokenStream {
             )
             .unwrap();
         }
+
+        write!(
+            modinfo.buffer,
+            "
+            struct __MODPARAM;
+
+            impl __MODPARAM {{
+            "
+        )
+        .unwrap();
+
+        read_funcs.iter().for_each(|read_func| {
+            writeln!(modinfo.buffer, "{}", read_func).unwrap();
+        });
+
+        write!(
+            modinfo.buffer,
+            "}}
+
+            const MODPARAM: __MODPARAM = __MODPARAM;
+            "
+        )
+        .unwrap();
     }
 
     let mut generated_array_types = String::new();

--- a/samples/rust/rust_module_parameters.rs
+++ b/samples/rust/rust_module_parameters.rs
@@ -48,14 +48,14 @@ impl kernel::Module for RustModuleParameters {
         {
             let lock = module.kernel_param_lock();
             pr_info!("Parameters:\n");
-            pr_info!("  my_bool:    {}\n", my_bool.read());
-            pr_info!("  my_i32:     {}\n", my_i32.read(&lock));
+            pr_info!("  my_bool:    {}\n", MODPARAM.my_bool());
+            pr_info!("  my_i32:     {}\n", MODPARAM.my_i32(&lock));
             pr_info!(
                 "  my_str:     {}\n",
-                core::str::from_utf8(my_str.read(&lock))?
+                core::str::from_utf8(MODPARAM.my_str(&lock))?
             );
-            pr_info!("  my_usize:   {}\n", my_usize.read(&lock));
-            pr_info!("  my_array:   {:?}\n", my_array.read());
+            pr_info!("  my_usize:   {}\n", MODPARAM.my_usize(&lock));
+            pr_info!("  my_array:   {:?}\n", MODPARAM.my_array());
         }
 
         Ok(RustModuleParameters)


### PR DESCRIPTION
Currently, ``module!`` emits constants to access module parameters
with the same name as the parameter:

    const {param_name}: __{name}_{param_name} = __{name}_{param_name};

Since a ``const`` is visible throughout the file it is defined in,
this can cause clashes with ``let`` bindings, e. g. when trying to
create a binding ``let foobar = 42`` in a module with a parameter
of the same name:

        10 | / module! {
        11 | |     type: ParamName,
        12 | |     name: "param_name",
        13 | |     author: "A. U. Thor",
        ...  |
        21 | |     },
        22 | | }
           | |_- constant defined here
        ...
        25 |       let foobar = 42;
           |           ^^^^^^   -- this expression has type `{integer}`
           |           |
           |           expected integer, found struct `__param_name_foobar`
           |           `foobar` is interpreted as a constant, not a new binding
           |           help: introduce a new binding instead: `other_foobar`
Likewise when binding to ``foobar`` in a ``match`` pattern.

This PR proposes to extend ``module!`` to allow specifying a distinct
name for the constant:

    module! {
        type: ParamName,
        name: "param_name",
        author: "A. U. Thor",
        license: "GPL",
        params: {
            foobar = MODPARAM_FOO_BAR : bool {
                default: true,
                permissions: 0o644,
                description: "distinct const name",
            },
        },
    }

So when loading the module one would still pass ``foobar=0`` but in the
module code the parameter would be accessible as ``MODPARAM_FOO_BAR``.
That would avoid the identifier clashing with pattern matching while
at the same time being [more idiomatic Rust](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#non-upper-case-globals).

The ``param = PARAM : type { …`` syntax is just what I came up with
without giving it much thought. It might as well be a ``key: value``
setting though then we’d have to find a name for the key, ``const``
perhaps?

I’m aware of #423 and from a casual glance at the changes (@nbdd0121
please correct me if I’m wrong) it doesn’t appear to address this
issue.
