### PR TITLE
Fix building under UML

### DIFF
--- a/arch/um/Makefile
+++ b/arch/um/Makefile
@@ -68,6 +68,8 @@ KBUILD_CFLAGS += $(CFLAGS) $(CFLAGS-y) -D__arch_um__ \
 	-Din6addr_loopback=kernel_in6addr_loopback \
 	-Din6addr_any=kernel_in6addr_any -Dstrrchr=kernel_strrchr
 
+KBUILD_RUSTFLAGS += -Crelocation-model=pie
+
 KBUILD_AFLAGS += $(ARCH_INCLUDE)
 
 USER_CFLAGS = $(patsubst $(KERNEL_DEFINES),,$(patsubst -I%,,$(KBUILD_CFLAGS))) \

--- a/arch/x86/Makefile.um
+++ b/arch/x86/Makefile.um
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0
 core-y += arch/x86/crypto/
 
+#
+# Disable SSE and other FP/SIMD instructions to match normal x86
+#
+KBUILD_CFLAGS += -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx
+KBUILD_RUSTFLAGS += -Ctarget-feature=-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2
+
 ifeq ($(CONFIG_X86_32),y)
 START := 0x8048000
 


### PR DESCRIPTION
At some point, UML (arch/um) support got broken.

We were able to work out the two causes of this at Kangrejos:
- A [strange SSE2-related SIGTRAP](https://bestrustcrates.com/p/this-small-project-iliakonnovrust-crash/index.html) in rustc.
- The relocation model needs to be PIE for some reason on UML builds. Maybe this is something better fixed in UML, but it was easier to change here. This is basically a revert of [this commit](https://github.com/Rust-for-Linux/linux/commit/883b79d78b25d3fb9c57a47a89b90a67885cf9e2) in PR #706 — despite the comment there, I couldn't override the command-line version in a per-architecture way.

There's almost definitely a better way of fixing these, and even these fixes would need to be better understood and documented, but I'm putting this out there so we have some documentation of the problems, and something we can apply to test against.