### PR TITLE
scripts: generate_rust_analyzer: Handle sub-modules with no Makefile

### DIFF
--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -104,7 +104,10 @@ def generate_crates(srctree, objtree, sysroot_src):
             name = path.name.replace(".rs", "")
 
             # Skip those that are not crate roots.
-            if f"{name}.o" not in open(path.parent / "Makefile").read():
+            try:
+                if f"{name}.o" not in open(path.parent / "Makefile").read():
+                    continue
+            except FileNotFoundError:
                 continue
 
             logging.info("Adding %s", name)


### PR DESCRIPTION
More complex drivers might want to use modules to organize their Rust code, but those module folders do not need a Makefile. generate_rust_analyzer.py currently crashes on those. Fix it so that a missing Makefile is silently ignored.

Signed-off-by: Asahi Lina <lina@asahilina.net>