### PR TITLE
rust: add support for USB device drivers

### DIFF
--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -4,7 +4,7 @@ use core::{convert::TryFrom, mem::take, ops::Range};
 use kernel::{
     bindings,
     cred::Credential,
-    file::{self, File, IoctlCommand, IoctlHandler, PollTable},
+    file::{self, File, Inode, IoctlCommand, IoctlHandler, PollTable},
     io_buffer::{IoBufferReader, IoBufferWriter},
     linked_list::List,
     mm,
@@ -813,11 +813,11 @@ impl file::Operations for Process {
     type Data = Arc<Self>;
     type OpenData = Arc<Context>;
 
-    fn open(ctx: &Arc<Context>, file: &File) -> Result<Self::Data> {
+    fn open(ctx: &Arc<Context>, _inode: &Inode, file: &File) -> Result<Self::Data> {
         Self::new(ctx.clone(), file.cred().into())
     }
 
-    fn release(obj: Self::Data, _file: &File) {
+    fn release(obj: Self::Data, _inode: &Inode, _file: &File) {
         // Mark this process as dead. We'll do the same for the threads later.
         obj.inner.lock().is_dead = true;
 

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -3,8 +3,12 @@
 //! Broadcom BCM2835 Random Number Generator support.
 
 use kernel::{
-    device, file, file::File, io_buffer::IoBufferWriter, miscdev, module_platform_driver, of,
-    platform, prelude::*, sync::Arc,
+    device, file,
+    file::{File, Inode},
+    io_buffer::IoBufferWriter,
+    miscdev, module_platform_driver, of, platform,
+    prelude::*,
+    sync::Arc,
 };
 
 module_platform_driver! {
@@ -19,7 +23,7 @@ struct RngDevice;
 
 #[vtable]
 impl file::Operations for RngDevice {
-    fn open(_open_data: &(), _file: &File) -> Result {
+    fn open(_open_data: &(), _inode: &Inode, _file: &File) -> Result {
         Ok(())
     }
 

--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -36,6 +36,7 @@
 #include <linux/sysctl.h>
 #include <linux/uaccess.h>
 #include <linux/uio.h>
+#include <linux/usb.h>
 #include <linux/xarray.h>
 #include <uapi/linux/android/binder.h>
 

--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -36,6 +36,7 @@
 #include <linux/sysctl.h>
 #include <linux/uaccess.h>
 #include <linux/uio.h>
+#include <linux/xarray.h>
 #include <uapi/linux/android/binder.h>
 
 /* `bindgen` gets confused at certain things. */
@@ -49,5 +50,21 @@ const __poll_t BINDINGS_EPOLLIN = EPOLLIN;
 const __poll_t BINDINGS_EPOLLOUT = EPOLLOUT;
 const __poll_t BINDINGS_EPOLLERR = EPOLLERR;
 const __poll_t BINDINGS_EPOLLHUP = EPOLLHUP;
+
+const gfp_t BINDINGS_XA_FLAGS_LOCK_IRQ = XA_FLAGS_LOCK_IRQ;
+const gfp_t BINDINGS_XA_FLAGS_LOCK_BH = XA_FLAGS_LOCK_BH;
+const gfp_t BINDINGS_XA_FLAGS_TRACK_FREE = XA_FLAGS_TRACK_FREE;
+const gfp_t BINDINGS_XA_FLAGS_ZERO_BUSY = XA_FLAGS_ZERO_BUSY;
+const gfp_t BINDINGS_XA_FLAGS_ALLOC_WRAPPED = XA_FLAGS_ALLOC_WRAPPED;
+const gfp_t BINDINGS_XA_FLAGS_ACCOUNT = XA_FLAGS_ACCOUNT;
+const gfp_t BINDINGS_XA_FLAGS_ALLOC = XA_FLAGS_ALLOC;
+const gfp_t BINDINGS_XA_FLAGS_ALLOC1 = XA_FLAGS_ALLOC1;
+
+const xa_mark_t BINDINGS_XA_MARK_0 = XA_MARK_0;
+const xa_mark_t BINDINGS_XA_MARK_1 = XA_MARK_1;
+const xa_mark_t BINDINGS_XA_MARK_2 = XA_MARK_2;
+const xa_mark_t BINDINGS_XA_PRESENT = XA_PRESENT;
+const xa_mark_t BINDINGS_XA_MARK_MAX = XA_MARK_MAX;
+const xa_mark_t BINDINGS_XA_FREE_MARK = XA_FREE_MARK;
 
 const loff_t BINDINGS_MAX_LFS_FILESIZE = MAX_LFS_FILESIZE;

--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -40,7 +40,11 @@
 
 /* `bindgen` gets confused at certain things. */
 const gfp_t BINDINGS_GFP_KERNEL = GFP_KERNEL;
-const gfp_t BINDINGS___GFP_ZERO = __GFP_ZERO;
+const gfp_t BINDINGS_GFP_ATOMIC = GFP_ATOMIC;
+const gfp_t BINDINGS_GFP_NOWAIT = GFP_NOWAIT;
+const gfp_t BINDINGS_GFP_NOIO = GFP_NOIO;
+const gfp_t BINDINGS_GFP_NOFS = GFP_NOFS;
+const gfp_t BINDINGS_GFP_USER = GFP_USER;
 const __poll_t BINDINGS_EPOLLIN = EPOLLIN;
 const __poll_t BINDINGS_EPOLLOUT = EPOLLOUT;
 const __poll_t BINDINGS_EPOLLERR = EPOLLERR;

--- a/rust/bindings/lib.rs
+++ b/rust/bindings/lib.rs
@@ -49,8 +49,17 @@ mod bindings_helper {
 
 pub use bindings_raw::*;
 
+pub const GFP_ATOMIC: gfp_t = BINDINGS_GFP_ATOMIC;
 pub const GFP_KERNEL: gfp_t = BINDINGS_GFP_KERNEL;
-pub const __GFP_ZERO: gfp_t = BINDINGS___GFP_ZERO;
+pub const GFP_NOWAIT: gfp_t = BINDINGS_GFP_NOWAIT;
+pub const GFP_NOIO: gfp_t = BINDINGS_GFP_NOIO;
+pub const GFP_NOFS: gfp_t = BINDINGS_GFP_NOFS;
+pub const GFP_USER: gfp_t = BINDINGS_GFP_USER;
+pub const __GFP_NOFAIL: gfp_t = ___GFP_NOFAIL;
+pub const __GFP_NORETRY: gfp_t = ___GFP_NORETRY;
+pub const __GFP_NOWARN: gfp_t = ___GFP_NOWARN;
+pub const __GFP_COMP: gfp_t = ___GFP_COMP;
+pub const __GFP_ZERO: gfp_t = ___GFP_ZERO;
 pub const __GFP_HIGHMEM: gfp_t = ___GFP_HIGHMEM;
 
 pub const MAX_LFS_FILESIZE: loff_t = BINDINGS_MAX_LFS_FILESIZE;

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -39,6 +39,7 @@
 #include <linux/skbuff.h>
 #include <linux/uaccess.h>
 #include <linux/uio.h>
+#include <linux/xarray.h>
 
 __noreturn void rust_helper_BUG(void)
 {
@@ -349,6 +350,42 @@ void rust_helper_mutex_lock(struct mutex *lock)
 	mutex_lock(lock);
 }
 EXPORT_SYMBOL_GPL(rust_helper_mutex_lock);
+
+void rust_helper_xa_init_flags(struct xarray *xa, gfp_t flags)
+{
+	xa_init_flags(xa, flags);
+}
+EXPORT_SYMBOL_GPL(rust_helper_xa_init_flags);
+
+bool rust_helper_xa_empty(struct xarray *xa)
+{
+	return xa_empty(xa);
+}
+EXPORT_SYMBOL_GPL(rust_helper_xa_empty);
+
+int rust_helper_xa_alloc(struct xarray *xa, u32 *id, void *entry, struct xa_limit limit, gfp_t gfp)
+{
+	return xa_alloc(xa, id, entry, limit, gfp);
+}
+EXPORT_SYMBOL_GPL(rust_helper_xa_alloc);
+
+void rust_helper_xa_lock(struct xarray *xa)
+{
+	xa_lock(xa);
+}
+EXPORT_SYMBOL_GPL(rust_helper_xa_lock);
+
+void rust_helper_xa_unlock(struct xarray *xa)
+{
+	xa_unlock(xa);
+}
+EXPORT_SYMBOL_GPL(rust_helper_xa_unlock);
+
+int rust_helper_xa_err(void *entry)
+{
+	return xa_err(entry);
+}
+EXPORT_SYMBOL_GPL(rust_helper_xa_err);
 
 void rust_helper_amba_set_drvdata(struct amba_device *dev, void *data)
 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -38,6 +38,7 @@
 #include <linux/security.h>
 #include <linux/skbuff.h>
 #include <linux/uaccess.h>
+#include <linux/usb.h>
 #include <linux/uio.h>
 #include <linux/xarray.h>
 
@@ -515,6 +516,12 @@ void *rust_helper_dev_get_drvdata(struct device *dev)
 }
 EXPORT_SYMBOL_GPL(rust_helper_dev_get_drvdata);
 
+void rust_helper_dev_set_drvdata(struct device *dev, void *data)
+{
+	dev_set_drvdata(dev, data);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dev_set_drvdata);
+
 const char *rust_helper_dev_name(const struct device *dev)
 {
 	return dev_name(dev);
@@ -691,6 +698,16 @@ int rust_helper_fs_parse(struct fs_context *fc,
 	return fs_parse(fc, desc, param, result);
 }
 EXPORT_SYMBOL_GPL(rust_helper_fs_parse);
+
+void *rust_helper_usb_get_intfdata(struct usb_interface *intf) {
+	return usb_get_intfdata(intf);
+}
+EXPORT_SYMBOL_GPL(rust_helper_usb_get_intfdata);
+
+void rust_helper_usb_set_intfdata(struct usb_interface *intf, void *data) {
+	usb_set_intfdata(intf, data);
+}
+EXPORT_SYMBOL_GPL(rust_helper_usb_set_intfdata);
 
 /*
  * We use `bindgen`'s `--size_t-is-usize` option to bind the C `size_t` type

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -421,6 +421,12 @@ refcount_t rust_helper_REFCOUNT_INIT(int n)
 }
 EXPORT_SYMBOL_GPL(rust_helper_REFCOUNT_INIT);
 
+unsigned int rust_helper_refcount_read(refcount_t *r)
+{
+	return refcount_read(r);
+}
+EXPORT_SYMBOL_GPL(rust_helper_refcount_read);
+
 void rust_helper_refcount_inc(refcount_t *r)
 {
 	refcount_inc(r);
@@ -708,6 +714,43 @@ void rust_helper_usb_set_intfdata(struct usb_interface *intf, void *data) {
 	usb_set_intfdata(intf, data);
 }
 EXPORT_SYMBOL_GPL(rust_helper_usb_set_intfdata);
+
+struct usb_device *rust_helper_interface_to_usbdev(struct usb_interface *intf)
+{
+	return interface_to_usbdev(intf);
+}
+EXPORT_SYMBOL_GPL(rust_helper_interface_to_usbdev);
+
+void rust_helper_usb_fill_control_urb(struct urb *urb, struct usb_device *dev,
+		unsigned int pipe,
+		unsigned char *setup_packet,
+		void *transfer_buffer, int buffer_length,
+		usb_complete_t complete_fn, void *context)
+{
+	usb_fill_control_urb(urb, dev, pipe, setup_packet, transfer_buffer,
+		buffer_length, complete_fn, context);
+}
+EXPORT_SYMBOL_GPL(rust_helper_usb_fill_control_urb);
+
+void rust_helper_usb_fill_bulk_urb(struct urb *urb, struct usb_device *dev,
+		unsigned int pipe, void *transfer_buffer,
+		int buffer_length,
+		usb_complete_t complete_fn, void *context)
+{
+	usb_fill_bulk_urb(urb, dev, pipe, transfer_buffer, buffer_length,
+		complete_fn, context);
+}
+EXPORT_SYMBOL_GPL(rust_helper_usb_fill_bulk_urb);
+
+void rust_helper_usb_fill_int_urb(struct urb *urb, struct usb_device *dev,
+		unsigned int pipe, void *transfer_buffer,
+		int buffer_length, usb_complete_t complete_fn,
+		void *context, int interval)
+{
+	usb_fill_int_urb(urb, dev, pipe, transfer_buffer, buffer_length,
+		complete_fn, context, interval);
+}
+EXPORT_SYMBOL_GPL(rust_helper_usb_fill_int_urb);
 
 /*
  * We use `bindgen`'s `--size_t-is-usize` option to bind the C `size_t` type

--- a/rust/kernel/allocator.rs
+++ b/rust/kernel/allocator.rs
@@ -6,6 +6,7 @@ use core::alloc::{GlobalAlloc, Layout};
 use core::ptr;
 
 use crate::bindings;
+use crate::{GFP_KERNEL, __GFP_ZERO};
 
 struct KernelAllocator;
 
@@ -13,7 +14,7 @@ unsafe impl GlobalAlloc for KernelAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // `krealloc()` is used instead of `kmalloc()` because the latter is
         // an inline function and cannot be bound to as a result.
-        unsafe { bindings::krealloc(ptr::null(), layout.size(), bindings::GFP_KERNEL) as *mut u8 }
+        unsafe { bindings::krealloc(ptr::null(), layout.size(), GFP_KERNEL) as *mut u8 }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
@@ -33,7 +34,7 @@ static ALLOCATOR: KernelAllocator = KernelAllocator;
 // Note that `#[no_mangle]` implies exported too, nowadays.
 #[no_mangle]
 fn __rust_alloc(size: usize, _align: usize) -> *mut u8 {
-    unsafe { bindings::krealloc(core::ptr::null(), size, bindings::GFP_KERNEL) as *mut u8 }
+    unsafe { bindings::krealloc(core::ptr::null(), size, GFP_KERNEL) as *mut u8 }
 }
 
 #[no_mangle]
@@ -43,22 +44,10 @@ fn __rust_dealloc(ptr: *mut u8, _size: usize, _align: usize) {
 
 #[no_mangle]
 fn __rust_realloc(ptr: *mut u8, _old_size: usize, _align: usize, new_size: usize) -> *mut u8 {
-    unsafe {
-        bindings::krealloc(
-            ptr as *const core::ffi::c_void,
-            new_size,
-            bindings::GFP_KERNEL,
-        ) as *mut u8
-    }
+    unsafe { bindings::krealloc(ptr as *const core::ffi::c_void, new_size, GFP_KERNEL) as *mut u8 }
 }
 
 #[no_mangle]
 fn __rust_alloc_zeroed(size: usize, _align: usize) -> *mut u8 {
-    unsafe {
-        bindings::krealloc(
-            core::ptr::null(),
-            size,
-            bindings::GFP_KERNEL | bindings::__GFP_ZERO,
-        ) as *mut u8
-    }
+    unsafe { bindings::krealloc(core::ptr::null(), size, GFP_KERNEL | __GFP_ZERO) as *mut u8 }
 }

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -23,6 +23,74 @@ use core::{
 #[cfg(CONFIG_PRINTK)]
 use crate::c_str;
 
+/// Device number which 12 bits are used to store a major and another 20 a minor.
+#[derive(Clone, Copy, Default, PartialEq)]
+#[repr(transparent)]
+pub struct Dev(pub bindings::dev_t);
+
+impl Dev {
+    /// Creates a new device number from a major and a minor.
+    pub const fn new(major: u32, minor: u32) -> Self {
+        Self((major << bindings::MINORBITS) | minor)
+    }
+
+    /// Creates a new device number from a major.
+    pub const fn from_major(major: u32) -> Self {
+        Self(major << bindings::MINORBITS)
+    }
+
+    /// Creates a new device number from a minor.
+    pub const fn from_minor(minor: u32) -> Self {
+        Self(minor & bindings::MINORMASK)
+    }
+
+    /// Returns the major of the device number.
+    pub const fn major(self) -> u32 {
+        self.0 >> bindings::MINORBITS
+    }
+
+    /// Returns the minor of the device number.
+    pub const fn minor(self) -> u32 {
+        self.0 & bindings::MINORMASK
+    }
+}
+
+impl const From<u32> for Dev {
+    fn from(item: u32) -> Self {
+        Self(item)
+    }
+}
+
+impl const From<Dev> for u32 {
+    fn from(dev: Dev) -> Self {
+        dev.0
+    }
+}
+
+impl const From<u64> for Dev {
+    fn from(item: u64) -> Self {
+        Self(item as u32)
+    }
+}
+
+impl const From<Dev> for u64 {
+    fn from(dev: Dev) -> Self {
+        dev.0 as u64
+    }
+}
+
+impl const From<i64> for Dev {
+    fn from(item: i64) -> Self {
+        Self(item as u32)
+    }
+}
+
+impl const From<Dev> for i64 {
+    fn from(dev: Dev) -> Self {
+        dev.0 as i64
+    }
+}
+
 /// A raw device.
 ///
 /// # Safety

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -97,6 +97,7 @@ pub mod of;
 pub mod platform;
 mod types;
 pub mod user_ptr;
+pub mod xarray;
 
 #[cfg(CONFIG_KUNIT)]
 pub mod kunit;

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -66,6 +66,8 @@ pub mod revocable;
 pub mod security;
 pub mod str;
 pub mod task;
+#[cfg(CONFIG_USB)]
+pub mod usb;
 pub mod workqueue;
 
 pub mod linked_list;

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -112,6 +112,46 @@ pub use crate::types::{
 
 use core::marker::PhantomData;
 
+/// Memory allocation flags.
+///
+/// GFP flags are commonly used throughout Linux to indicate how memory should be allocated. The
+/// GFP acronym stands for `get_free_pages()`, the underlying memory allocation function. Not every
+/// GFP flag is supported by every function which may allocate memory. Most users will want to use
+/// a plain [`GFP_KERNEL`].
+///
+/// [`gfp_t`]: ../../../include/linux/gfp_types.h
+pub use bindings::gfp_t;
+
+/// Users can not sleep and need the allocation to succeed.
+pub use bindings::GFP_ATOMIC;
+/// Typical for kernel-internal allocations.
+pub use bindings::GFP_KERNEL;
+/// Will use direct reclaim but will not use any filesystem interfaces.
+pub use bindings::GFP_NOFS;
+/// Will use direct reclaim to discard clean pages or slab pages that do not require the starting
+/// of any physical IO.
+pub use bindings::GFP_NOIO;
+/// Is for kernel allocations that should not stall for direct reclaim, start physical IO or use
+/// any filesystem callback.
+pub use bindings::GFP_NOWAIT;
+/// Is for userspace allocations that also need to be directly accessibly by the kernel or
+/// hardware.
+pub use bindings::GFP_USER;
+/// Address compound page metadata.
+pub use bindings::__GFP_COMP;
+/// A memory area that is only addressable by the kernel through mapping portions into its own
+/// address space.
+pub use bindings::__GFP_HIGHMEM;
+/// The VM implementation _must_ retry infinitely as the caller cannot handle allocation failures.
+pub use bindings::__GFP_NOFAIL;
+/// The VM implementation will try only very lightweight memory direct reclaim to get some memory
+/// under memory pressure (thus it can sleep).
+pub use bindings::__GFP_NORETRY;
+/// Suppresses allocation failure reports.
+pub use bindings::__GFP_NOWARN;
+/// Returns a zeroed page on success.
+pub use bindings::__GFP_ZERO;
+
 /// Page size defined in terms of the `PAGE_SHIFT` macro from C.
 ///
 /// [`PAGE_SHIFT`]: ../../../include/asm-generic/page.h

--- a/rust/kernel/pages.rs
+++ b/rust/kernel/pages.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     bindings, error::code::*, io_buffer::IoBufferReader, user_ptr::UserSlicePtrReader, Result,
-    PAGE_SIZE,
+    GFP_KERNEL, PAGE_SIZE, __GFP_HIGHMEM, __GFP_ZERO,
 };
 use core::{marker::PhantomData, ptr};
 
@@ -27,12 +27,8 @@ impl<const ORDER: u32> Pages<ORDER> {
     pub fn new() -> Result<Self> {
         // TODO: Consider whether we want to allow callers to specify flags.
         // SAFETY: This only allocates pages. We check that it succeeds in the next statement.
-        let pages = unsafe {
-            bindings::alloc_pages(
-                bindings::GFP_KERNEL | bindings::__GFP_ZERO | bindings::__GFP_HIGHMEM,
-                ORDER,
-            )
-        };
+        let pages =
+            unsafe { bindings::alloc_pages(GFP_KERNEL | __GFP_ZERO | __GFP_HIGHMEM, ORDER) };
         if pages.is_null() {
             return Err(ENOMEM);
         }

--- a/rust/kernel/power.rs
+++ b/rust/kernel/power.rs
@@ -9,6 +9,9 @@
 use crate::{bindings, error::from_kernel_result, types::ForeignOwnable, Result};
 use core::marker::PhantomData;
 
+/// Message from PM subsystem.
+pub type PmMessage = bindings::pm_message;
+
 /// Corresponds to the kernel's `struct dev_pm_ops`.
 ///
 /// It is meant to be implemented by drivers that support power-management operations.

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -70,6 +70,19 @@ impl<T: ?Sized> Mutex<T> {
         // SAFETY: The mutex was just acquired.
         unsafe { Guard::new(self, ctx) }
     }
+
+    /// Tries to acquire the mutex and gives the caller access to the data protected by it. Due to
+    /// only one thread at a time is allowed to access the protected data an optional value will be
+    /// returned.
+    pub fn try_lock(&self) -> Option<Guard<'_, Self>> {
+        // SAFETY: `mutex` points to valid memory.
+        if unsafe { bindings::mutex_trylock(self.mutex.get()) == 1 } {
+            // SAFETY: The mutex was just acquired.
+            unsafe { Some(Guard::new(self, EmptyGuardContext)) }
+        } else {
+            None
+        }
+    }
 }
 
 impl<T> LockFactory for Mutex<T> {

--- a/rust/kernel/usb.rs
+++ b/rust/kernel/usb.rs
@@ -1,0 +1,780 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! USB devices and drivers.
+//!
+//! C header: [`include/linux/usb.h`](../../../../include/linux/usb.h)
+
+use core::num::NonZeroU64;
+
+use crate::{
+    bindings, container_of,
+    device::{self, RawDevice},
+    driver,
+    error::{code::*, from_kernel_result, Result},
+    file::IoctlCommand,
+    macros::vtable,
+    power::PmMessage,
+    str::CStr,
+    to_result,
+    types::ForeignOwnable,
+    ThisModule,
+};
+
+/// USB device ID macros reexports and casted to [`u16`] intended for the
+/// [`match_flags`](DeviceId::match_flags) field of [`DeviceId`].
+pub mod id_match {
+    #![allow(missing_docs)]
+    pub const USB_DEVICE_ID_MATCH_VENDOR: u16 = bindings::USB_DEVICE_ID_MATCH_VENDOR as u16;
+    pub const USB_DEVICE_ID_MATCH_PRODUCT: u16 = bindings::USB_DEVICE_ID_MATCH_PRODUCT as u16;
+    pub const USB_DEVICE_ID_MATCH_DEV_LO: u16 = bindings::USB_DEVICE_ID_MATCH_DEV_LO as u16;
+    pub const USB_DEVICE_ID_MATCH_DEV_HI: u16 = bindings::USB_DEVICE_ID_MATCH_DEV_HI as u16;
+    pub const USB_DEVICE_ID_MATCH_DEV_CLASS: u16 = bindings::USB_DEVICE_ID_MATCH_DEV_CLASS as u16;
+    pub const USB_DEVICE_ID_MATCH_DEV_SUBCLASS: u16 =
+        bindings::USB_DEVICE_ID_MATCH_DEV_SUBCLASS as u16;
+    pub const USB_DEVICE_ID_MATCH_DEV_PROTOCOL: u16 =
+        bindings::USB_DEVICE_ID_MATCH_DEV_PROTOCOL as u16;
+    pub const USB_DEVICE_ID_MATCH_INT_CLASS: u16 = bindings::USB_DEVICE_ID_MATCH_INT_CLASS as u16;
+    pub const USB_DEVICE_ID_MATCH_INT_SUBCLASS: u16 =
+        bindings::USB_DEVICE_ID_MATCH_INT_SUBCLASS as u16;
+    pub const USB_DEVICE_ID_MATCH_INT_PROTOCOL: u16 =
+        bindings::USB_DEVICE_ID_MATCH_INT_PROTOCOL as u16;
+    pub const USB_DEVICE_ID_MATCH_INT_NUMBER: u16 = bindings::USB_DEVICE_ID_MATCH_INT_NUMBER as u16;
+    pub const USB_DEVICE_ID_MATCH_DEVICE: u16 = bindings::USB_DEVICE_ID_MATCH_DEVICE as u16;
+    pub const USB_DEVICE_ID_MATCH_DEV_RANGE: u16 = bindings::USB_DEVICE_ID_MATCH_DEV_RANGE as u16;
+    pub const USB_DEVICE_ID_MATCH_DEVICE_AND_VERSION: u16 =
+        bindings::USB_DEVICE_ID_MATCH_DEVICE_AND_VERSION as u16;
+    pub const USB_DEVICE_ID_MATCH_DEV_INFO: u16 = bindings::USB_DEVICE_ID_MATCH_DEV_INFO as u16;
+    pub const USB_DEVICE_ID_MATCH_INT_INFO: u16 = bindings::USB_DEVICE_ID_MATCH_INT_INFO as u16;
+}
+
+use id_match::*;
+
+/// Check if USB is disabled.
+pub fn disabled() -> bool {
+    // SAFETY: FFI call.
+    unsafe { bindings::usb_disabled() != 0 }
+}
+
+/// Registration of an USB interface driver.
+pub type Registration<T> = driver::Registration<Adapter<T>>;
+
+/// An adapter for the registration of USB interface drivers.
+pub struct Adapter<T: Driver>(T);
+
+impl<T: Driver> driver::DriverOps for Adapter<T> {
+    type RegType = bindings::usb_driver;
+
+    unsafe fn register(
+        reg: *mut bindings::usb_driver,
+        name: &'static CStr,
+        module: &'static ThisModule,
+    ) -> Result {
+        // SAFETY: the driver to register `reg` points to valid, initialized and writable memory.
+        let pdrv = unsafe { &mut *reg };
+
+        pdrv.name = name.as_char_ptr();
+        pdrv.probe = Some(Self::probe_callback);
+        pdrv.disconnect = Some(Self::disconnect_callback);
+        if let Some(t) = T::ID_TABLE {
+            pdrv.id_table = t.as_ref();
+        }
+        if T::HAS_IOCTL {
+            pdrv.unlocked_ioctl = Some(Self::unlocked_ioctl_callback);
+        }
+        if T::HAS_SUSPEND {
+            pdrv.suspend = Some(Self::suspend_callback);
+        }
+        if T::HAS_RESUME {
+            pdrv.resume = Some(Self::resume_callback);
+        }
+        if T::HAS_RESET_RESUME {
+            pdrv.reset_resume = Some(Self::reset_resume_callback);
+        }
+        if T::HAS_PRE_RESET {
+            pdrv.pre_reset = Some(Self::pre_reset_callback);
+        }
+        if T::HAS_POST_RESET {
+            pdrv.post_reset = Some(Self::post_reset_callback);
+        }
+        if let Some(t) = T::ID_TABLE {
+            pdrv.id_table = t.as_ref();
+        }
+        // SAFETY: `reg`, `module.0` and `name.as_char_ptr()` all point to valid data.
+        to_result(unsafe { bindings::usb_register_driver(reg, module.0, name.as_char_ptr()) })
+    }
+
+    unsafe fn unregister(reg: *mut bindings::usb_driver) {
+        // SAFETY: the driver to unregister `reg` points to valid, initialized and writable memory.
+        unsafe { bindings::usb_deregister(reg) }
+    }
+}
+
+impl<T: Driver> Adapter<T> {
+    extern "C" fn probe_callback(
+        intf: *mut bindings::usb_interface,
+        id: *const bindings::usb_device_id,
+    ) -> core::ffi::c_int {
+        from_kernel_result! {
+            // SAFETY: `intf` is always a valid pointer passed from the caller.
+            let mut dev = unsafe { Interface::from_ptr(intf) };
+            // SAFETY: `id` is a pointer within the static table, so it's always valid.
+            let info = unsafe {
+                NonZeroU64::new((*id).driver_info).map(|o| &*(id.cast::<u8>().offset(o.get() as _).cast::<T::IdInfo>()))
+            };
+            let data = T::probe(&mut dev, info)?;
+            let ptr = T::Data::into_foreign(data);
+            // SAFETY: `ptr` must either be null or valid.
+            unsafe { bindings::usb_set_intfdata(intf, ptr as _) };
+            Ok(0)
+        }
+    }
+
+    extern "C" fn disconnect_callback(intf: *mut bindings::usb_interface) {
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let ptr = unsafe { bindings::usb_get_intfdata(intf) };
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let mut intf = unsafe { Interface::from_ptr(intf) };
+        // SAFETY: `ptr` can be null or must be valid.
+        let data = unsafe { T::Data::from_foreign(ptr) };
+        T::disconnect(&mut intf, &data);
+        <T::Data as driver::DeviceRemoval>::device_remove(&data);
+        // SAFETY: passing null clears the interface data.
+        unsafe { bindings::usb_set_intfdata(intf.ptr, core::ptr::null_mut()) };
+    }
+
+    extern "C" fn unlocked_ioctl_callback(
+        intf: *mut bindings::usb_interface,
+        code: u32,
+        buf: *mut core::ffi::c_void,
+    ) -> i32 {
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let mut intf = unsafe { Interface::from_ptr(intf) };
+        let mut cmd = IoctlCommand::new(code, buf as usize);
+        from_kernel_result! {
+            let res = T::ioctl(&mut intf, &mut cmd)?;
+            Ok(res)
+        }
+    }
+
+    extern "C" fn suspend_callback(intf: *mut bindings::usb_interface, message: PmMessage) -> i32 {
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let mut intf = unsafe { Interface::from_ptr(intf) };
+        from_kernel_result! {
+            T::suspend(&mut intf, message)?;
+            Ok(0)
+        }
+    }
+
+    extern "C" fn resume_callback(intf: *mut bindings::usb_interface) -> i32 {
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let mut intf = unsafe { Interface::from_ptr(intf) };
+        from_kernel_result! {
+            T::resume(&mut intf)?;
+            Ok(0)
+        }
+    }
+
+    extern "C" fn reset_resume_callback(intf: *mut bindings::usb_interface) -> i32 {
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let mut intf = unsafe { Interface::from_ptr(intf) };
+        from_kernel_result! {
+            T::reset_resume(&mut intf)?;
+            Ok(0)
+        }
+    }
+
+    extern "C" fn pre_reset_callback(intf: *mut bindings::usb_interface) -> i32 {
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let mut intf = unsafe { Interface::from_ptr(intf) };
+        from_kernel_result! {
+            T::pre_reset(&mut intf)?;
+            Ok(0)
+        }
+    }
+
+    extern "C" fn post_reset_callback(intf: *mut bindings::usb_interface) -> i32 {
+        // SAFETY: `intf` is always a valid pointer passed from the caller.
+        let mut intf = unsafe { Interface::from_ptr(intf) };
+        from_kernel_result! {
+            T::post_reset(&mut intf)?;
+            Ok(0)
+        }
+    }
+}
+
+/// Device table entry for table-driven USB drivers.
+#[derive(Clone, Copy, Default, PartialEq)]
+#[repr(C)]
+pub struct DeviceId {
+    /// Mask used to match against new devices.
+    pub match_flags: u16,
+    /// USB vendor ID for a device.
+    pub id_vendor: u16,
+    /// Vendor-assigned product ID.
+    pub id_product: u16,
+    /// Low end of range of vendor-assigned product version numbers.
+    pub bcd_device_lo: u16,
+    /// High end of version number range.
+    pub bcd_device_hi: u16,
+    /// Class of device.
+    pub b_device_class: u8,
+    /// Subclass of device.
+    pub b_device_subclass: u8,
+    /// Protocol of device.
+    pub b_device_protocol: u8,
+    /// Class of interface.
+    pub b_interface_class: u8,
+    /// Subclass of interface.
+    pub b_interface_subclass: u8,
+    /// Protocol of interface.
+    pub b_interface_protocol: u8,
+    /// Number of interface.
+    pub b_interface_number: u8,
+}
+
+impl DeviceId {
+    /// `USB_DEVICE` macro.
+    pub const fn new(id_vendor: u16, id_product: u16) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_DEVICE,
+            id_vendor,
+            id_product,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_DEVICE_VER` macro.
+    pub const fn with_version(
+        id_vendor: u16,
+        id_product: u16,
+        bcd_device_lo: u16,
+        bcd_device_hi: u16,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_DEVICE_AND_VERSION,
+            id_vendor,
+            id_product,
+            bcd_device_lo,
+            bcd_device_hi,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_DEVICE_INTERFACE_CLASS` macro.
+    pub const fn with_interface_class(
+        id_vendor: u16,
+        id_product: u16,
+        b_interface_class: u8,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_DEVICE | USB_DEVICE_ID_MATCH_INT_CLASS,
+            id_vendor,
+            id_product,
+            b_interface_class,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_DEVICE_INTERFACE_PROTOCOL` macro.
+    pub const fn with_interface_protocol(
+        id_vendor: u16,
+        id_product: u16,
+        b_interface_protocol: u8,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_DEVICE | USB_DEVICE_ID_MATCH_INT_PROTOCOL,
+            id_vendor,
+            id_product,
+            b_interface_protocol,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_DEVICE_INTERFACE_NUMBER` macro.
+    pub const fn with_interface_number(
+        id_vendor: u16,
+        id_product: u16,
+        b_interface_number: u8,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_DEVICE | USB_DEVICE_ID_MATCH_INT_NUMBER,
+            id_vendor,
+            id_product,
+            b_interface_number,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_DEVICE_INFO` macro.
+    pub const fn with_info(
+        b_device_class: u8,
+        b_device_subclass: u8,
+        b_device_protocol: u8,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_DEV_INFO,
+            b_device_class,
+            b_device_subclass,
+            b_device_protocol,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_INTERFACE_INFO` macro.
+    pub const fn with_interface_info(
+        b_interface_class: u8,
+        b_interface_subclass: u8,
+        b_interface_protocol: u8,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_INT_INFO,
+            b_interface_class,
+            b_interface_subclass,
+            b_interface_protocol,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_DEVICE_AND_INTERFACE_INFO` macro.
+    pub const fn with_device_and_interface_info(
+        id_vendor: u16,
+        id_product: u16,
+        b_interface_class: u8,
+        b_interface_subclass: u8,
+        b_interface_protocol: u8,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_INT_INFO | USB_DEVICE_ID_MATCH_DEVICE,
+            id_vendor,
+            id_product,
+            b_interface_class,
+            b_interface_subclass,
+            b_interface_protocol,
+            ..Self::default()
+        }
+    }
+
+    /// `USB_VENDOR_AND_INTERFACE_INFO` macro.
+    pub const fn with_vendor_and_interface_info(
+        id_vendor: u16,
+        b_interface_class: u8,
+        b_interface_subclass: u8,
+        b_interface_protocol: u8,
+    ) -> Self {
+        Self {
+            match_flags: USB_DEVICE_ID_MATCH_INT_INFO | USB_DEVICE_ID_MATCH_VENDOR,
+            id_vendor,
+            b_interface_class,
+            b_interface_subclass,
+            b_interface_protocol,
+            ..Self::default()
+        }
+    }
+
+    /// Constructor that sets every field to `0`.
+    pub const fn default() -> Self {
+        Self {
+            match_flags: 0,
+            id_vendor: 0,
+            id_product: 0,
+            bcd_device_lo: 0,
+            bcd_device_hi: 0,
+            b_device_class: 0,
+            b_device_subclass: 0,
+            b_device_protocol: 0,
+            b_interface_class: 0,
+            b_interface_subclass: 0,
+            b_interface_protocol: 0,
+            b_interface_number: 0,
+        }
+    }
+}
+
+// SAFETY: `ZERO` is all zeroed-out and `to_rawid` stores `info` in `usb_device_id::driver_info`.
+unsafe impl const driver::RawDeviceId for DeviceId {
+    type RawType = bindings::usb_device_id;
+
+    const ZERO: Self::RawType = bindings::usb_device_id {
+        match_flags: 0,
+        idVendor: 0,
+        idProduct: 0,
+        bcdDevice_lo: 0,
+        bcdDevice_hi: 0,
+        bDeviceClass: 0,
+        bDeviceSubClass: 0,
+        bDeviceProtocol: 0,
+        bInterfaceClass: 0,
+        bInterfaceSubClass: 0,
+        bInterfaceProtocol: 0,
+        bInterfaceNumber: 0,
+        driver_info: 0,
+    };
+
+    fn to_rawid(&self, info: isize) -> Self::RawType {
+        bindings::usb_device_id {
+            match_flags: self.match_flags,
+            idVendor: self.id_vendor,
+            idProduct: self.id_product,
+            bcdDevice_lo: self.bcd_device_lo,
+            bcdDevice_hi: self.bcd_device_hi,
+            bDeviceClass: self.b_device_class,
+            bDeviceSubClass: self.b_device_subclass,
+            bDeviceProtocol: self.b_device_protocol,
+            bInterfaceClass: self.b_interface_class,
+            bInterfaceSubClass: self.b_interface_subclass,
+            bInterfaceProtocol: self.b_interface_protocol,
+            bInterfaceNumber: self.b_interface_number,
+            driver_info: info as _,
+        }
+    }
+}
+
+/// Define a const USB device id table.
+///
+/// # Examples
+///
+/// ```
+/// use kernel::{usb, define_usb_id_table};
+///
+/// struct MyDriver;
+/// impl usb::Driver for MyDriver {
+///     // [...]
+///     fn probe(_dev: &mut usb::Interface, _id_info: Option<&Self::IdInfo>) -> Result {
+///         Ok(())
+///     }
+///     define_usb_id_table! {u64, [
+///         (usb::DeviceId::new(0xbee7, 0xffff), None),
+///         (usb::DeviceId::with_class(0xbee7, 0xff1d), Some(0x40)),
+///     ]}
+/// }
+/// ```
+#[macro_export]
+macro_rules! define_usb_id_table {
+    ($data_type:ty, $($t:tt)*) => {
+        type IdInfo = $data_type;
+        $crate::define_id_table!(ID_TABLE, $crate::usb::DeviceId, $data_type, $($t)*);
+    };
+}
+
+/// Declares a kernel module that exposes a single USB driver.
+///
+/// # Examples
+///
+/// ```ignore
+/// use kernel::{usb, define_usb_id_table, module_usb_driver};
+///
+/// struct MyDriver;
+/// impl usb::Driver for MyDriver {
+///     // [...]
+///     fn probe(_dev: &mut usb::Device, _id: Option<&Self::IdInfo>) -> Result {
+///         Ok(())
+///     }
+///     define_usb_id_table! {(), [
+///         ({ id: 0xfff0, mask: 0xfff0 }, None),
+///     ]}
+/// }
+///
+/// module_usb_driver! {
+///     type: MyDriver,
+///     name: "module_name",
+///     author: "Author name",
+///     license: "GPL",
+/// }
+/// ```
+#[macro_export]
+macro_rules! module_usb_driver {
+    ($($f:tt)*) => {
+        $crate::module_driver!(<T>, $crate::usb::Adapter<T>, { $($f)* });
+    };
+}
+
+/// An USB interface driver.
+#[vtable]
+pub trait Driver {
+    /// Data stored on device interface by driver.
+    ///
+    /// Corresponds to the data set or retrieved via the kernel's
+    /// `usb_{set,get}_intfdata()` functions.
+    ///
+    /// Require that `Data` implements `ForeignOwnable`. We guarantee to
+    /// never move the underlying wrapped data structure.
+    type Data: ForeignOwnable + Send + Sync + driver::DeviceRemoval = ();
+
+    /// The type holding information about each device id supported by the driver.
+    type IdInfo: 'static = ();
+
+    /// The table of device ids supported by the driver.
+    const ID_TABLE: Option<driver::IdTable<'static, DeviceId, Self::IdInfo>> = None;
+
+    /// USB driver probe.
+    ///
+    /// Called to see if the driver can manage a device interface.
+    /// Implementer should attempt to initialize the interface here.
+    fn probe(dev: &mut Interface, id: Option<&Self::IdInfo>) -> Result<Self::Data>;
+
+    /// USB driver disconnect.
+    ///
+    /// Called when a device interface is removed.
+    /// Implementer should prepare the interface for removal here.
+    fn disconnect(_intf: &mut Interface, _data: &Self::Data) {}
+
+    /// USB driver ioctl.
+    ///
+    /// Used for drivers that want to talk to userspace through the `usbfs` filesystem.
+    fn ioctl(_intf: &mut Interface, _cmd: &mut IoctlCommand) -> Result<i32> {
+        Err(EINVAL)
+    }
+
+    /// USB driver suspend.
+    ///
+    /// Called when the device is going to be suspended by the system either from system sleep or
+    /// runtime suspend context. The return value will be ignored in system sleep context, so do
+    /// NOT try to continue using the device if suspend fails in this case. Instead, let the resume
+    /// or reset-resume routine recover from the failure.
+    fn suspend(_intf: &mut Interface, _message: PmMessage) -> Result {
+        Ok(())
+    }
+
+    /// USB driver resume.
+    ///
+    /// Called when the device is being resumed by the system.
+    fn resume(_intf: &mut Interface) -> Result {
+        Ok(())
+    }
+
+    /// USB driver reset-resume.
+    ///
+    /// Called when the suspended device has been reset instead of being resumed.
+    fn reset_resume(_intf: &mut Interface) -> Result {
+        Ok(())
+    }
+
+    /// USB driver pre-reset.
+    ///
+    /// Called by `usb_reset_device()` when the device is about to be reset. This routine must not
+    /// return until the driver has no active URBs for the device, and no more URBs may be
+    /// submitted until the [`post_reset`] method is called.
+    fn pre_reset(_intf: &mut Interface) -> Result {
+        Ok(())
+    }
+
+    /// USB driver post-reset.
+    ///
+    /// Called by `usb_reset_device()` after the device has been reset.
+    fn post_reset(_intf: &mut Interface) -> Result {
+        Ok(())
+    }
+}
+
+/// An USB device.
+///
+/// # Invariants
+///
+/// The field `ptr` is non-null and valid for the lifetime of the object.
+pub struct Device {
+    ptr: *mut bindings::usb_device,
+}
+
+impl Device {
+    /// Creates a device from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// It requires that a non-null and valid pointer to [`bindings::usb_device`] has to be passed.
+    /// Must remain as valid during the life time of the instance as well.
+    #[inline]
+    unsafe fn from_ptr(ptr: *mut bindings::usb_device) -> Self {
+        Self { ptr }
+    }
+
+    /// Returns the raw `struct usb_device` related to `self`.
+    #[inline]
+    pub fn raw(&self) -> *mut bindings::usb_device {
+        self.ptr
+    }
+
+    /// Gets the generic interface of this device.
+    #[inline]
+    pub fn to_device(&self) -> device::Device {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { device::Device::new(self.raw_device()) }
+    }
+
+    /// Increments the reference count of the device.
+    ///
+    /// # Safety
+    ///
+    /// The device must not be released prior to calling this function.
+    #[inline]
+    pub fn get(&mut self) {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            self.ptr = bindings::usb_get_dev(self.ptr);
+        }
+    }
+
+    /// Decrements the reference count of the device.
+    ///
+    /// # Safety
+    ///
+    /// The reference count must be greater than zero.
+    #[inline]
+    pub fn put(&self) {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { bindings::usb_put_dev(self.ptr) }
+    }
+
+    #[inline]
+    fn create_pipe(&self, endpoint: u32) -> u32 {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { (((*self.ptr).devnum as u32) << 8) | (endpoint << 15) }
+    }
+
+    /// Gets the send control pipe of an endpoint.
+    #[inline]
+    pub fn sndctrlpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_CONTROL << 30) | self.create_pipe(endpoint)
+    }
+
+    /// Gets the receive control pipe of an endpoint.
+    #[inline]
+    pub fn rcvctrlpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_CONTROL << 30) | self.create_pipe(endpoint) | bindings::USB_DIR_IN
+    }
+
+    /// Gets the send isochronous pipe of an endpoint.
+    #[inline]
+    pub fn sndisocpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_ISOCHRONOUS << 30) | self.create_pipe(endpoint)
+    }
+
+    /// Gets the receive isochronous pipe of an endpoint.
+    #[inline]
+    pub fn rcvisocpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_ISOCHRONOUS << 30) | self.create_pipe(endpoint) | bindings::USB_DIR_IN
+    }
+
+    /// Gets the send bulk pipe of an endpoint.
+    #[inline]
+    pub fn sndbulkpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_BULK << 30) | self.create_pipe(endpoint)
+    }
+
+    /// Gets the receive bulk pipe of an endpoint.
+    #[inline]
+    pub fn rcvbulkpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_BULK << 30) | self.create_pipe(endpoint) | bindings::USB_DIR_IN
+    }
+
+    /// Gets the send interrupt pipe of an endpoint.
+    #[inline]
+    pub fn sndintpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_INTERRUPT << 30) | self.create_pipe(endpoint)
+    }
+
+    /// Gets the receive interrupt pipe of an endpoint.
+    #[inline]
+    pub fn rcvintpipe(&self, endpoint: u32) -> u32 {
+        (bindings::PIPE_INTERRUPT << 30) | self.create_pipe(endpoint) | bindings::USB_DIR_IN
+    }
+}
+
+// SAFETY: The device returned by `raw_device` is the raw USB device.
+unsafe impl device::RawDevice for Device {
+    fn raw_device(&self) -> *mut bindings::device {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { &mut (*self.ptr).dev }
+    }
+}
+
+// SAFETY: `Device` only holds a pointer to an USB device, which is safe to be used from any thread.
+unsafe impl Send for Device {}
+
+// SAFETY: `Device` only holds a pointer to an USB device, references to which are safe to be used
+// from any thread.
+unsafe impl Sync for Device {}
+
+/// An USB device interface.
+///
+/// # Invariants
+///
+/// The field `ptr` is non-null and valid for the lifetime of the object.
+pub struct Interface {
+    ptr: *mut bindings::usb_interface,
+}
+
+impl Interface {
+    /// Creates an interface from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// It requires that a valid pointer to [`bindings::usb_interface`] has to be passed.
+    /// Must remain as valid during the life time of the instance as well.
+    #[inline]
+    unsafe fn from_ptr(ptr: *mut bindings::usb_interface) -> Self {
+        Self { ptr }
+    }
+
+    /// Returns the raw `struct usb_interface` related to `self`.
+    pub fn raw(&self) -> *mut bindings::usb_interface {
+        self.ptr
+    }
+
+    /// Gets the generic interface of this device.
+    #[inline]
+    pub fn to_device(&self) -> device::Device {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { device::Device::new(self.raw_device()) }
+    }
+
+    /// Returns the USB hub with its lifetime managed by the interface.
+    #[inline]
+    pub fn to_usb_device(&self) -> Device {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            Device::from_ptr(
+                container_of!((*self.ptr).dev.parent, bindings::usb_device, dev).cast_mut(),
+            )
+        }
+    }
+
+    /// Increments the reference count of the interface.
+    ///
+    /// # Safety
+    ///
+    /// The interface must not be released prior to calling this function.
+    #[inline]
+    pub fn get(&mut self) {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            self.ptr = bindings::usb_get_intf(self.ptr);
+        }
+    }
+
+    /// Decrements the reference count of the interface.
+    ///
+    /// # Safety
+    ///
+    /// The reference count must be greater than zero.
+    #[inline]
+    pub fn put(&self) {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { bindings::usb_put_intf(self.ptr) }
+    }
+}
+
+// SAFETY: The device returned by `raw_device` is the raw USB interface.
+unsafe impl device::RawDevice for Interface {
+    fn raw_device(&self) -> *mut bindings::device {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { &mut (*self.ptr).dev }
+    }
+}
+
+// SAFETY: `Interface` only holds a pointer to an USB interface, which is safe to be used from any
+// thread.
+unsafe impl Send for Interface {}
+
+// SAFETY: `Interface` only holds a pointer to an USB interface, references to which are safe to be
+// used from any thread.
+unsafe impl Sync for Interface {}

--- a/rust/kernel/usb.rs
+++ b/rust/kernel/usb.rs
@@ -20,6 +20,10 @@ use crate::{
     ThisModule,
 };
 
+mod urb;
+
+pub use urb::{transfer_flags, Completion, ControlRequest, Transfer, Urb};
+
 /// USB device ID macros reexports and casted to [`u16`] intended for the
 /// [`match_flags`](DeviceId::match_flags) field of [`DeviceId`].
 pub mod id_match {

--- a/rust/kernel/usb/descriptors.rs
+++ b/rust/kernel/usb/descriptors.rs
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use crate::bindings;
+use crate::error::{to_result, Result};
+
+#[cfg(doc)]
+use crate::error::code::ENXIO;
+
+/// An USB endpoint descriptor.
+#[derive(Default, Copy, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct EndpointDescriptor {
+    /// Size of descriptor.
+    pub b_length: u8,
+    /// Descriptor type.
+    pub b_descriptor_type: u8,
+    /// Address of the endpoint on the USB device described by this descriptor.
+    pub b_endpoint_address: u8,
+    /// Endpoint attribute when configured through bConfigurationValue.
+    pub bm_attributes: u8,
+    /// Maximum packet size of this endpoint.
+    pub w_max_packet_size: bindings::__le16,
+    /// Interval for polling endpoint for data transfers.
+    pub b_interval: u8,
+    /// Rate at which synchronization feedback is provide, only in audio endpoints.
+    pub b_refresh: u8,
+    /// Address of the synchronization endpoint, only in audio endpoints.
+    pub b_synch_address: u8,
+}
+
+impl EndpointDescriptor {
+    /// Get the endpoint's number (`0..=15`).
+    #[inline]
+    pub const fn num(&self) -> u8 {
+        self.b_endpoint_address & bindings::USB_ENDPOINT_NUMBER_MASK as u8
+    }
+
+    /// Get the endpoint's transfer type.
+    #[inline]
+    pub const fn xfer_type(&self) -> u8 {
+        self.bm_attributes & bindings::USB_ENDPOINT_XFERTYPE_MASK as u8
+    }
+
+    /// Check if the endpoint has IN direction.
+    #[inline]
+    pub const fn dir_in(&self) -> bool {
+        (self.b_endpoint_address & bindings::USB_ENDPOINT_DIR_MASK as u8)
+            == bindings::USB_DIR_IN as u8
+    }
+
+    /// Check if the endpoint has OUT direction.
+    #[inline]
+    pub const fn dir_out(&self) -> bool {
+        (self.b_endpoint_address & bindings::USB_ENDPOINT_DIR_MASK as u8)
+            == bindings::USB_DIR_OUT as u8
+    }
+
+    /// Check if the endpoint has bulk transfer type.
+    #[inline]
+    pub const fn xfer_bulk(&self) -> bool {
+        (self.bm_attributes & bindings::USB_ENDPOINT_XFERTYPE_MASK as u8)
+            == bindings::USB_ENDPOINT_XFER_BULK as u8
+    }
+
+    /// Check if the endpoint has control transfer type.
+    #[inline]
+    pub const fn xfer_control(&self) -> bool {
+        (self.bm_attributes & bindings::USB_ENDPOINT_XFERTYPE_MASK as u8)
+            == bindings::USB_ENDPOINT_XFER_CONTROL as u8
+    }
+
+    /// Check if the endpoint has interrupt transfer type.
+    #[inline]
+    pub const fn xfer_int(&self) -> bool {
+        (self.bm_attributes & bindings::USB_ENDPOINT_XFERTYPE_MASK as u8)
+            == bindings::USB_ENDPOINT_XFER_INT as u8
+    }
+
+    /// Check if the endpoint has isochronous transfer type.
+    #[inline]
+    pub const fn xfer_isoc(&self) -> bool {
+        (self.bm_attributes & bindings::USB_ENDPOINT_XFERTYPE_MASK as u8)
+            == bindings::USB_ENDPOINT_XFER_ISOC as u8
+    }
+
+    /// Check if the endpoint is bulk IN.
+    #[inline]
+    pub const fn is_bulk_in(&self) -> bool {
+        self.dir_in() && self.xfer_bulk()
+    }
+
+    /// Check if the endpoint is bulk OUT.
+    #[inline]
+    pub const fn is_bulk_out(&self) -> bool {
+        self.dir_out() && self.xfer_bulk()
+    }
+
+    /// Check if the endpoint is interrupt IN.
+    #[inline]
+    pub const fn is_int_in(&self) -> bool {
+        self.dir_in() && self.xfer_int()
+    }
+
+    /// Check if the endpoint is interrupt OUT.
+    #[inline]
+    pub const fn is_int_out(&self) -> bool {
+        self.dir_out() && self.xfer_int()
+    }
+
+    /// Check if the endpoint is isochronous IN.
+    #[inline]
+    pub const fn is_isoc_in(&self) -> bool {
+        self.dir_in() && self.xfer_isoc()
+    }
+
+    /// Check if the endpoint is isochronous OUT.
+    #[inline]
+    pub const fn is_isoc_out(&self) -> bool {
+        self.dir_out() && self.xfer_isoc()
+    }
+
+    /// Get endpoint's max packet size.
+    #[inline]
+    pub const fn maxp(&self) -> u16 {
+        u16::from_le(self.w_max_packet_size) & bindings::USB_ENDPOINT_MAXP_MASK as u16
+    }
+
+    /// Get endpoint's transactional opportunities.
+    #[inline]
+    pub const fn maxp_mult(&self) -> u16 {
+        (u16::from_le(self.w_max_packet_size) & bindings::USB_EP_MAXP_MULT_MASK as u16)
+            >> bindings::USB_EP_MAXP_MULT_SHIFT
+    }
+}
+
+/// An USB device descriptor.
+#[derive(Default, Copy, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct DeviceDescriptor {
+    /// Size of descriptor.
+    pub b_length: u8,
+    /// Descriptor type.
+    pub b_descriptor_type: u8,
+    /// USB specification release number in Binary Coded Decimal.
+    pub bcd_usb: bindings::__le16,
+    /// Class of device.
+    pub b_device_class: u8,
+    /// Subclass of device.
+    pub b_device_subclass: u8,
+    /// Protocol of device.
+    pub b_device_protocol: u8,
+    /// Maximum packet size for Endpoint zero (only 8, 16, 32, or 64 are valid).
+    pub b_max_packet_size0: u8,
+    /// USB vendor ID for a device.
+    pub id_vendor: bindings::__le16,
+    /// Vendor-assigned product ID.
+    pub id_product: bindings::__le16,
+    /// Device release number in Binary Coded Decimal.
+    pub bcd_device: bindings::__le16,
+    /// Index of string descriptor describing manufacturer.
+    pub i_manufacturer: u8,
+    /// Index of string descriptor describing product.
+    pub i_product: u8,
+    /// Index of string descriptor describing the device's serial number.
+    pub i_serial_number: u8,
+    /// Number of possible configurations.
+    pub b_num_configurations: u8,
+}
+
+/// An USB interface descriptor.
+#[derive(Default, Copy, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct InterfaceDescriptor {
+    /// Size of descriptor.
+    pub b_length: u8,
+    /// Descriptor type.
+    pub b_descriptor_type: u8,
+    /// Number of interface.
+    pub b_interface_number: u8,
+    /// Alternate setting.
+    pub b_alternate_setting: u8,
+    /// Number of endpoints.
+    pub b_num_endpoints: u8,
+    /// Class of interface.
+    pub b_interface_class: u8,
+    /// Subclass of interface.
+    pub b_interface_subclass: u8,
+    /// Protocol of interface.
+    pub b_interface_protocol: u8,
+    /// Index of string descriptor.
+    pub i_interface: u8,
+}
+
+/// An USB host-side interface wrapper.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct HostInterface {
+    /// Interface descriptor of the host interface.
+    pub desc: InterfaceDescriptor,
+    extralen: i32,
+    extra: *mut u8,
+    endpoint: *mut bindings::usb_host_endpoint,
+    string: *mut i8,
+}
+
+impl<'a> HostInterface {
+    /// Search the alternate setting's endpoint descriptors for the first bulk-in, bulk-out,
+    /// interrupt-in and interrupt-out endpoints and return them in the provided references (unless
+    /// they are [`None`]).
+    ///
+    /// If a requested endpoint is not found, the corresponding reference is set to `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ENXIO`] if none of the requested descriptors were found.
+    #[inline]
+    pub fn find_common_endpoints(
+        &'a self,
+        bulk_in: Option<&mut Option<&'a EndpointDescriptor>>,
+        bulk_out: Option<&mut Option<&'a EndpointDescriptor>>,
+        int_in: Option<&mut Option<&'a EndpointDescriptor>>,
+        int_out: Option<&mut Option<&'a EndpointDescriptor>>,
+    ) -> Result {
+        // SAFETY: FFI call.
+        to_result(unsafe {
+            bindings::usb_find_common_endpoints(
+                self as *const Self as *mut _,
+                bulk_in
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+                bulk_out
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+                int_in
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+                int_out
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+            )
+        })
+    }
+
+    /// Search the alternate setting's endpoint descriptors for the last bulk-in, bulk-out,
+    /// interrupt-in and interrupt-out endpoints and return them in the provided references (unless
+    /// they are [`None`]).
+    ///
+    /// If a requested endpoint is not found, the corresponding reference is set to `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ENXIO`] if none of the requested descriptors were found.
+    #[inline]
+    pub fn find_common_endpoints_reverse(
+        &'a self,
+        bulk_in: Option<&mut Option<&'a EndpointDescriptor>>,
+        bulk_out: Option<&mut Option<&'a EndpointDescriptor>>,
+        int_in: Option<&mut Option<&'a EndpointDescriptor>>,
+        int_out: Option<&mut Option<&'a EndpointDescriptor>>,
+    ) -> Result {
+        // SAFETY: FFI call.
+        to_result(unsafe {
+            bindings::usb_find_common_endpoints_reverse(
+                self as *const Self as *mut _,
+                bulk_in
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+                bulk_out
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+                int_in
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+                int_out
+                    .map_or(core::ptr::null_mut(), |r| {
+                        r as *mut Option<&'a EndpointDescriptor>
+                    })
+                    .cast(),
+            )
+        })
+    }
+
+    /// Finds the first bulk-in endpoint.
+    ///
+    /// See [`find_common_endpoints`].
+    #[inline]
+    pub fn find_bulk_in_endpoint(&'a self, bulk_in: &mut Option<&'a EndpointDescriptor>) -> Result {
+        self.find_common_endpoints(Some(bulk_in), None, None, None)
+    }
+
+    /// Finds the first bulk-out endpoint.
+    ///
+    /// See [`find_common_endpoints`].
+    #[inline]
+    pub fn find_bulk_out_endpoint(
+        &'a self,
+        bulk_out: &mut Option<&'a EndpointDescriptor>,
+    ) -> Result {
+        self.find_common_endpoints(None, Some(bulk_out), None, None)
+    }
+
+    /// Finds the first interrupt-in endpoint.
+    ///
+    /// See [`find_common_endpoints`].
+    #[inline]
+    pub fn find_int_in_endpoint(&'a self, int_in: &mut Option<&'a EndpointDescriptor>) -> Result {
+        self.find_common_endpoints(None, None, Some(int_in), None)
+    }
+
+    /// Finds the first interrupt-out endpoint.
+    ///
+    /// See [`find_common_endpoints`].
+    #[inline]
+    pub fn find_int_out_endpoint(&'a self, int_out: &mut Option<&'a EndpointDescriptor>) -> Result {
+        self.find_common_endpoints(None, None, None, Some(int_out))
+    }
+
+    /// Finds the last bulk-in endpoint.
+    ///
+    /// See [`find_common_endpoints_reverse`].
+    #[inline]
+    pub fn find_last_bulk_in_endpoint(
+        &'a self,
+        bulk_in: &mut Option<&'a EndpointDescriptor>,
+    ) -> Result {
+        self.find_common_endpoints_reverse(Some(bulk_in), None, None, None)
+    }
+
+    /// Finds the last bulk-out endpoint.
+    ///
+    /// See [`find_common_endpoints_reverse`].
+    #[inline]
+    pub fn find_last_bulk_out_endpoint(
+        &'a self,
+        bulk_out: &mut Option<&'a EndpointDescriptor>,
+    ) -> Result {
+        self.find_common_endpoints_reverse(None, Some(bulk_out), None, None)
+    }
+
+    /// Finds the last interrupt-in endpoint.
+    ///
+    /// See [`find_common_endpoints_reverse`].
+    #[inline]
+    pub fn find_last_int_in_endpoint(
+        &'a self,
+        int_in: &mut Option<&'a EndpointDescriptor>,
+    ) -> Result {
+        self.find_common_endpoints_reverse(None, None, Some(int_in), None)
+    }
+
+    /// Finds the last interrupt-out endpoint.
+    ///
+    /// See [`find_common_endpoints_reverse`].
+    #[inline]
+    pub fn find_last_int_out_endpoint(
+        &'a self,
+        int_out: &mut Option<&'a EndpointDescriptor>,
+    ) -> Result {
+        self.find_common_endpoints_reverse(None, None, None, Some(int_out))
+    }
+
+    /// Provides an slice view to the endpoint descriptors.
+    #[inline]
+    pub fn endpoints(&'a self) -> &'a [EndpointDescriptor] {
+        if self.endpoint.is_null() {
+            &[]
+        } else {
+            // SAFETY: An slice is built out of a valid pointer and `EndpointDescriptor` is an
+            // alias to `usb_endpoint_descriptor`.
+            unsafe {
+                core::slice::from_raw_parts(
+                    (self.endpoint as *const EndpointDescriptor).cast(),
+                    self.desc.b_num_endpoints as usize,
+                )
+            }
+        }
+    }
+
+    /// Provides a mutable slice view to the endpoint descriptors.
+    #[inline]
+    pub fn endpoints_mut(&'a mut self) -> &'a mut [EndpointDescriptor] {
+        if self.endpoint.is_null() {
+            &mut []
+        } else {
+            // SAFETY: An slice is built out of a valid pointer and `EndpointDescriptor` is an
+            // alias to `usb_endpoint_descriptor`.
+            unsafe {
+                core::slice::from_raw_parts_mut(
+                    self.endpoint.cast(),
+                    self.desc.b_num_endpoints as usize,
+                )
+            }
+        }
+    }
+}

--- a/rust/kernel/usb/urb.rs
+++ b/rust/kernel/usb/urb.rs
@@ -1,0 +1,705 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use core::{marker::PhantomData, ops::Deref, pin::Pin, ptr::NonNull};
+
+use crate::{
+    bindings,
+    error::{code::*, Result},
+    gfp_t,
+    sync::{Arc, ArcBorrow},
+    to_result,
+    types::{ForeignOwnable, ScopeGuard},
+    GFP_ATOMIC, GFP_KERNEL,
+};
+
+use super::Device;
+
+/// URB transfer flags macros reexports and casted to [`u32`] intended for the
+/// [`transfer_flags`](Urb::transfer_flags) field of [`Urb`].
+pub mod transfer_flags {
+    #![allow(missing_docs)]
+    pub const URB_SHORT_NOT_OK: u32 = bindings::URB_SHORT_NOT_OK;
+    pub const URB_ISO_ASAP: u32 = bindings::URB_ISO_ASAP;
+    pub const URB_NO_TRANSFER_DMA_MAP: u32 = bindings::URB_NO_TRANSFER_DMA_MAP;
+    pub const URB_ZERO_PACKET: u32 = bindings::URB_ZERO_PACKET;
+    pub const URB_NO_INTERRUPT: u32 = bindings::URB_NO_INTERRUPT;
+    pub const URB_FREE_BUFFER: u32 = bindings::URB_FREE_BUFFER;
+}
+
+/// An URB transfer buffer.
+pub trait Transfer {
+    /// Type of values borrowed between calls to [`Transfer::into_data`] and
+    /// [`Transfer::from_data`].
+    type Borrowed<'a>;
+
+    /// Assembles a transfer buffer from a pointer to data and its size.
+    ///
+    /// # Safety
+    ///
+    /// The passed pointer must come from a previous call to [`Transfer::into_data`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EINVAL`] if either the data was null or the given size does comply with the
+    /// requirements imposed by the type, like being shorter than the type's size.
+    unsafe fn from_data(data: *mut core::ffi::c_void, size: usize) -> Result<Self>
+    where
+        Self: Sized;
+
+    /// Assembles a transfer buffer from a pointer to data and its size.
+    ///
+    /// # Safety
+    ///
+    /// `data` must have been returned by a previous call to [`Transfer::into_data`].
+    /// Additionally, [`Transfer::from_data`] can only be called after *all* values
+    /// returned by [`Transfer::borrow`] have been dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EINVAL`] if either the data was null or the given size does comply with the
+    /// requirements imposed by the type, like being shorter than the type's size.
+    unsafe fn borrow<'a>(data: *mut core::ffi::c_void, size: usize) -> Result<Self::Borrowed<'a>>
+    where
+        Self: Sized;
+
+    /// Returns a mutably borrowed value.
+    ///
+    /// # Safety
+    ///
+    /// The passed pointer must come from a previous to [`Transfer::into_data`], and no
+    /// other concurrent users of the pointer (except the ones derived from the returned value) run
+    /// at least until the returned [`ScopeGuard`] is dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EINVAL`] if either the data was null or the given size does comply with the
+    /// requirements imposed by the type, like being shorter than the type's size.
+    unsafe fn borrow_mut<T: Transfer>(
+        data: *mut core::ffi::c_void,
+        size: usize,
+    ) -> Result<ScopeGuard<T, fn(T)>> {
+        // SAFETY: The safety requirements ensure that `ptr` came from a previous call to
+        // `into_data`.
+        Ok(ScopeGuard::new_with_data(
+            unsafe { T::from_data(data, size)? },
+            |d| {
+                d.into_data();
+            },
+        ))
+    }
+
+    /// Returns the pointer to the underlying buffer data.
+    fn into_data(self) -> *mut core::ffi::c_void;
+
+    /// Returns the buffer length.
+    fn transfer_len(&self) -> usize;
+}
+
+impl<T: 'static> Transfer for &mut [T] {
+    type Borrowed<'a> = &'a [T];
+
+    unsafe fn from_data(data: *mut core::ffi::c_void, size: usize) -> Result<Self> {
+        if data.is_null() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements of this function ensure that `ptr` comes from a previous
+            // call to `Self::into_data`.
+            Ok(unsafe { core::slice::from_raw_parts_mut(data.cast(), size) })
+        }
+    }
+
+    unsafe fn borrow<'a>(data: *mut core::ffi::c_void, size: usize) -> Result<&'a [T]> {
+        if data.is_null() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements for this function ensure that the object is still alive,
+            // so it is safe to build an slice from the raw pointer.
+            // The safety requirements of `from_data` also ensure that the object remains alive for
+            // the lifetime of the returned value.
+            Ok(unsafe { core::slice::from_raw_parts(data as *const _, size) })
+        }
+    }
+
+    fn into_data(self) -> *mut core::ffi::c_void {
+        self.as_mut_ptr().cast()
+    }
+
+    fn transfer_len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: 'static> Transfer for &mut T {
+    type Borrowed<'a> = &'a T;
+
+    unsafe fn from_data(data: *mut core::ffi::c_void, size: usize) -> Result<Self> {
+        if data.is_null() || size < core::mem::size_of::<T>() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements of this function ensure that `ptr` comes from a previous
+            // call to `Self::into_data`.
+            Ok(unsafe { &mut *(data.cast()) })
+        }
+    }
+
+    unsafe fn borrow<'a>(data: *mut core::ffi::c_void, size: usize) -> Result<&'a T> {
+        if data.is_null() || size < core::mem::size_of::<T>() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements for this function ensure that the object is still alive,
+            // so it is safe to dereference the raw pointer.
+            // The safety requirements of `from_data` also ensure that the object remains alive for
+            // the lifetime of the returned value.
+            Ok(unsafe { &*(data as *const _) })
+        }
+    }
+
+    fn into_data(self) -> *mut core::ffi::c_void {
+        (self as *mut T).cast()
+    }
+
+    fn transfer_len(&self) -> usize {
+        core::mem::size_of::<T>()
+    }
+}
+
+impl<T: 'static> Transfer for Vec<T> {
+    type Borrowed<'a> = &'a [T];
+
+    unsafe fn from_data(data: *mut core::ffi::c_void, size: usize) -> Result<Vec<T>> {
+        if data.is_null() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements of this function ensure that `ptr` comes from a previous
+            // call to `Self::into_data`.
+            Ok(unsafe { Vec::from_raw_parts(data.cast(), size, size) })
+        }
+    }
+
+    unsafe fn borrow<'a>(data: *mut core::ffi::c_void, size: usize) -> Result<&'a [T]> {
+        if data.is_null() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements for this function ensure that the object is still alive,
+            // so it is safe to build an slice from the raw pointer.
+            // The safety requirements of `from_data` also ensure that the object remains alive for
+            // the lifetime of the returned value.
+            Ok(unsafe { core::slice::from_raw_parts(data as *const _, size) })
+        }
+    }
+
+    fn into_data(mut self) -> *mut core::ffi::c_void {
+        self.as_mut_ptr().cast()
+    }
+
+    fn transfer_len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: 'static> Transfer for Box<T> {
+    type Borrowed<'a> = &'a T;
+
+    unsafe fn from_data(data: *mut core::ffi::c_void, size: usize) -> Result<Box<T>> {
+        if data.is_null() || size < core::mem::size_of::<T>() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements of this function ensure that `ptr` comes from a previous
+            // call to `Self::into_data`.
+            Ok(unsafe { Box::from_raw(data.cast()) })
+        }
+    }
+
+    unsafe fn borrow<'a>(data: *mut core::ffi::c_void, size: usize) -> Result<&'a T> {
+        if data.is_null() || size < core::mem::size_of::<T>() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements for this function ensure that the object is still alive,
+            // so it is safe to dereference the raw pointer.
+            // The safety requirements of `from_data` also ensure that the object remains alive for
+            // the lifetime of the returned value.
+            Ok(unsafe { &*data.cast() })
+        }
+    }
+
+    fn into_data(self) -> *mut core::ffi::c_void {
+        Box::into_raw(self).cast()
+    }
+
+    fn transfer_len(&self) -> usize {
+        core::mem::size_of::<T>()
+    }
+}
+
+impl<T: 'static> Transfer for Arc<T> {
+    type Borrowed<'a> = ArcBorrow<'a, T>;
+
+    unsafe fn from_data(data: *mut core::ffi::c_void, size: usize) -> Result<Arc<T>> {
+        if data.is_null() || size < core::mem::size_of::<T>() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: By the safety requirement of this function, we know that `ptr` came from
+            // a previous call to `Arc::into_data`, which guarantees that `ptr` is valid and
+            // holds a reference count increment that is transferrable to us.
+            unsafe { Ok(Arc::from_foreign(data)) }
+        }
+    }
+
+    unsafe fn borrow<'a>(data: *mut core::ffi::c_void, size: usize) -> Result<ArcBorrow<'a, T>> {
+        if data.is_null() || size < core::mem::size_of::<T>() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements of `from_data` ensure that the object remains alive
+            // for the lifetime of the returned value. Additionally, the safety requirements of
+            // `Transfer::borrow_mut` ensure that no new mutable references are created.
+            unsafe { Ok(<Arc<T> as ForeignOwnable>::borrow(data)) }
+        }
+    }
+
+    fn into_data(self) -> *mut core::ffi::c_void {
+        Arc::into_foreign(self).cast_mut()
+    }
+
+    fn transfer_len(&self) -> usize {
+        core::mem::size_of::<T>()
+    }
+}
+
+impl<T: Transfer + Deref> Transfer for Pin<T>
+where
+    <T as Deref>::Target: Transfer,
+{
+    type Borrowed<'a> = T::Borrowed<'a>;
+
+    unsafe fn from_data(data: *mut core::ffi::c_void, size: usize) -> Result<Pin<T>> {
+        if data.is_null() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The object was originally pinned.
+            // The passed pointer comes from a previous call to `T::into_data`.
+            Ok(unsafe { Pin::new_unchecked(T::from_data(data.cast(), size)?) })
+        }
+    }
+
+    unsafe fn borrow<'a>(data: *mut core::ffi::c_void, size: usize) -> Result<Self::Borrowed<'a>> {
+        if data.is_null() {
+            Err(EINVAL)
+        } else {
+            // SAFETY: The safety requirements for this function are the same as the ones for
+            // `T::borrow`.
+            unsafe { T::borrow(data, size) }
+        }
+    }
+
+    fn into_data(self) -> *mut core::ffi::c_void {
+        // SAFETY: We continue to treat the pointer as pinned by returning just a pointer to it to
+        // the caller.
+        let inner = unsafe { Pin::into_inner_unchecked(self) };
+        inner.into_data()
+    }
+
+    fn transfer_len(&self) -> usize {
+        self.as_ref().transfer_len()
+    }
+}
+
+/// URB completion handler.
+pub trait Completion<T: Transfer, C: ForeignOwnable + Send + Sync> {
+    /// URB completion routine.
+    ///
+    /// Made when the action of the URB has been successfully completed or cancelled.
+    fn complete(urb: Urb<T, C>);
+}
+
+/// Setup data for a USB device control request.
+#[derive(Default, Copy, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct ControlRequest {
+    /// Matches the USB bmRequestType field.
+    pub b_request_type: u8,
+    /// Matches the USB bRequest field.
+    pub b_request: u8,
+    /// Matches the USB wValue field (le16 byte order).
+    pub w_value: bindings::__le16,
+    /// Matches the USB wIndex field (le16 byte order).
+    pub w_index: bindings::__le16,
+    /// Matches the USB wLength field (le16 byte order).
+    pub w_length: bindings::__le16,
+}
+
+impl ControlRequest {
+    /// Allocates a control request with `GFP_KERNEL` and boxes it.
+    ///
+    /// See [`try_boxed_flagged`].
+    #[inline]
+    pub fn try_boxed() -> Result<Box<Self>> {
+        Self::try_boxed_flagged(GFP_KERNEL)
+    }
+
+    /// Allocates a control request with `GFP_ATOMIC` and boxes it.
+    ///
+    /// See [`try_boxed_flagged`].
+    #[inline]
+    pub fn try_boxed_atomic() -> Result<Box<Self>> {
+        Self::try_boxed_flagged(GFP_ATOMIC)
+    }
+
+    /// Allocates a control request with the provided `gfp_t` flag combination and boxes it.
+    ///
+    /// # Errors
+    ///
+    /// An allocation error is returned upon failure.
+    pub fn try_boxed_flagged(flags: gfp_t) -> Result<Box<Self>> {
+        // SAFETY: FFI call.
+        let cr =
+            unsafe { bindings::krealloc(core::ptr::null(), core::mem::size_of::<Self>(), flags) };
+        if cr.is_null() {
+            Err(ENOMEM)
+        } else {
+            Ok(unsafe { Box::from_raw(cr.cast()) })
+        }
+    }
+}
+
+unsafe extern "C" fn complete_callback<
+    R: Completion<T, C>,
+    C: ForeignOwnable + Send + Sync,
+    T: Transfer,
+>(
+    ptr: *mut bindings::urb,
+) {
+    // SAFETY: The pointer `ptr` is non-null and valid for the duration of the callback.
+    unsafe {
+        let mut urb = Urb::from_ptr(ptr);
+        urb.get();
+        R::complete(urb);
+    }
+}
+
+/// An USB request block (URB).
+///
+/// # Invariants
+///
+/// The field `ptr` is non-null and valid for the lifetime of the object.
+pub struct Urb<T: Transfer, C: ForeignOwnable + Send + Sync> {
+    ptr: *mut bindings::urb,
+    _transfer: PhantomData<T>,
+    _context: PhantomData<C>,
+}
+
+impl<T: Transfer, C: ForeignOwnable + Send + Sync> Urb<T, C> {
+    /// Creates an URB for a USB driver to use with [`GFP_KERNEL`] memory type.
+    ///
+    /// See [`try_new_flagged`].
+    #[inline]
+    pub fn try_new(pkts: i32) -> Result<Self> {
+        Self::try_new_flagged(pkts, GFP_KERNEL)
+    }
+
+    /// Creates an URB for a USB driver to use with [`GFP_ATOMIC`] memory type.
+    ///
+    /// See [`try_new_flagged`].
+    #[inline]
+    pub fn try_new_atomic(pkts: i32) -> Result<Self> {
+        Self::try_new_flagged(pkts, GFP_ATOMIC)
+    }
+
+    /// Creates an URB for a USB driver to use with the provided [`gfp_t`] flag combination.
+    ///
+    /// If the driver wants to use this urb for interrupt, control, or bulk endpoints, pass `0` as
+    /// the number of iso packets.
+    ///
+    /// # Errors
+    ///
+    /// An allocation error is returned upon failure.
+    #[inline]
+    pub fn try_new_flagged(pkts: i32, flags: gfp_t) -> Result<Self> {
+        // SAFETY: FFI call.
+        let urb = unsafe { Self::from_ptr(bindings::usb_alloc_urb(pkts, flags)) };
+        if urb.ptr.is_null() {
+            Err(ENOMEM)
+        } else {
+            Ok(urb)
+        }
+    }
+
+    /// Creates an URB from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// It requires that a valid pointer to [`bindings::urb`] has to be passed.
+    /// Must remain as valid during the life time of the instance as well.
+    #[inline]
+    unsafe fn from_ptr(ptr: *mut bindings::urb) -> Self {
+        Self {
+            ptr,
+            _transfer: PhantomData,
+            _context: PhantomData,
+        }
+    }
+
+    /// Returns the raw `struct urb` related to `self`.
+    pub fn raw(&self) -> *mut bindings::urb {
+        self.ptr
+    }
+
+    /// Current status of the URB.
+    pub fn status(&self) -> Result {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { to_result((*self.ptr).status) }
+    }
+
+    /// Increments the reference count of the URB.
+    ///
+    /// # Safety
+    ///
+    /// The URB must not been freed prior to calling this function.
+    #[inline]
+    pub fn get(&mut self) {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            self.ptr = bindings::usb_get_urb(self.ptr);
+        }
+    }
+
+    /// Gets the URB transfer flags.
+    #[inline]
+    pub fn transfer_flags(&self) -> u32 {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { (*self.ptr).transfer_flags }
+    }
+
+    /// Sets the URB transfer flags.
+    #[inline]
+    pub fn set_transfer_flags(&mut self, flags: u32) {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            (*self.ptr).transfer_flags = flags;
+        }
+    }
+
+    /// Fills a control request with the URB.
+    #[inline]
+    pub fn fill_control<R: Completion<T, C>>(
+        &mut self,
+        dev: &Device,
+        pipe: u32,
+        setup_pkt: Box<ControlRequest>,
+        transfer: Option<T>,
+        ctx: Option<C>,
+    ) {
+        let len = transfer
+            .as_ref()
+            .map_or(0, T::transfer_len)
+            .try_into()
+            .unwrap_or(i32::MAX);
+        // SAFETY: FFI call.
+        unsafe {
+            bindings::usb_fill_control_urb(
+                self.ptr,
+                dev.ptr,
+                pipe,
+                (Box::into_raw(setup_pkt)).cast::<u8>(),
+                transfer.map_or(core::ptr::null_mut(), T::into_data),
+                len,
+                Some(complete_callback::<R, C, T>),
+                ctx.map_or(core::ptr::null_mut(), |c| c.into_foreign() as *mut _),
+            );
+        };
+    }
+
+    /// Fills a bulk request with the URB.
+    #[inline]
+    pub fn fill_bulk<R: Completion<T, C>>(
+        &mut self,
+        dev: &Device,
+        pipe: u32,
+        transfer: Option<T>,
+        ctx: Option<C>,
+    ) {
+        let len = transfer
+            .as_ref()
+            .map_or(0, T::transfer_len)
+            .try_into()
+            .unwrap_or(i32::MAX);
+        // SAFETY: FFI call.
+        unsafe {
+            bindings::usb_fill_bulk_urb(
+                self.ptr,
+                dev.ptr,
+                pipe,
+                transfer.map_or(core::ptr::null_mut(), T::into_data),
+                len,
+                Some(complete_callback::<R, C, T>),
+                ctx.map_or(core::ptr::null_mut(), |c| c.into_foreign() as *mut _),
+            );
+        };
+    }
+
+    /// Fills an interrupt request with the URB.
+    #[inline]
+    pub fn fill_int<R: Completion<T, C>>(
+        &mut self,
+        dev: &Device,
+        pipe: u32,
+        transfer: Option<T>,
+        ctx: Option<C>,
+        interval: i32,
+    ) {
+        let len = transfer
+            .as_ref()
+            .map_or(0, T::transfer_len)
+            .try_into()
+            .unwrap_or(i32::MAX);
+        // SAFETY: FFI call.
+        unsafe {
+            bindings::usb_fill_int_urb(
+                self.ptr,
+                dev.ptr,
+                pipe,
+                transfer.map_or(core::ptr::null_mut(), T::into_data),
+                len,
+                Some(complete_callback::<R, C, T>),
+                ctx.map_or(core::ptr::null_mut(), |c| c.into_foreign() as *mut _),
+                interval,
+            );
+        };
+    }
+
+    /// Returns a reference to the context of the URB.
+    pub fn context<'a>(&self) -> Option<C::Borrowed<'a>> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { NonNull::new((*self.ptr).context).map(|c| C::borrow(c.as_ptr())) }
+    }
+
+    /// Returns a mutable reference to the context of the URB.
+    pub fn context_mut(&mut self) -> Option<ScopeGuard<C, fn(C)>> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { NonNull::new((*self.ptr).context).map(|c| C::borrow_mut(c.as_ptr())) }
+    }
+
+    /// Takes ownership over the context of the URB.
+    pub fn take_context(&mut self) -> Option<C> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            let ctx = NonNull::new((*self.ptr).context).map(|c| C::from_foreign(c.as_ptr()));
+            (*self.ptr).context = core::ptr::null_mut();
+            ctx
+        }
+    }
+
+    /// Returns a reference to the transfer buffer of the URB.
+    pub fn borrow_transfer<'a>(&self) -> Result<T::Borrowed<'a>> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            T::borrow(
+                (*self.ptr).transfer_buffer,
+                (*self.ptr).transfer_buffer_length as usize,
+            )
+        }
+    }
+
+    /// Returns a mutable reference to the transfer buffer of the URB.
+    pub fn borrow_transfer_mut(&mut self) -> Result<ScopeGuard<T, fn(T)>> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            T::borrow_mut(
+                (*self.ptr).transfer_buffer,
+                (*self.ptr).transfer_buffer_length as usize,
+            )
+        }
+    }
+
+    /// Takes ownership over the transfer buffer of the URB.
+    pub fn take_transfer(&mut self) -> Result<T> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            let transfer = T::from_data(
+                (*self.ptr).transfer_buffer,
+                (*self.ptr).transfer_buffer_length as usize,
+            );
+            (*self.ptr).transfer_buffer = core::ptr::null_mut();
+            (*self.ptr).transfer_buffer_length = 0;
+            transfer
+        }
+    }
+
+    /// Returns a reference to the setup packet of the URB.
+    pub fn setup_packet<'a>(&self) -> Option<&'a ControlRequest> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { NonNull::new((*self.ptr).setup_packet).map(|p| &*(p.as_ptr().cast())) }
+    }
+
+    /// Returns a mutable reference to the setup packet of the URB.
+    pub fn setup_packet_mut<'a>(&mut self) -> Option<&'a mut ControlRequest> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe { NonNull::new((*self.ptr).setup_packet).map(|p| &mut *(p.as_ptr().cast())) }
+    }
+
+    /// Takes ownership over the setup packet of the URB.
+    pub fn take_setup_packet(&mut self) -> Option<Box<ControlRequest>> {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        unsafe {
+            let setup_pkt =
+                NonNull::new((*self.ptr).setup_packet).map(|p| Box::from_raw(p.as_ptr().cast()));
+            (*self.ptr).setup_packet = core::ptr::null_mut();
+            setup_pkt
+        }
+    }
+
+    /// Submits the URB for completion.
+    #[inline]
+    pub fn submit(&mut self, flags: gfp_t) -> Result {
+        // SAFETY: FFI call.
+        unsafe { to_result(bindings::usb_submit_urb(self.ptr, flags)) }
+    }
+
+    /// Kills the URB.
+    #[inline]
+    pub fn kill(&mut self) {
+        // SAFETY: FFI call.
+        unsafe {
+            bindings::usb_kill_urb(self.ptr);
+        }
+    }
+
+    /// Poisons the URB.
+    #[inline]
+    pub fn poison(&mut self) {
+        // SAFETY: FFI call.
+        unsafe {
+            bindings::usb_poison_urb(self.ptr);
+        }
+    }
+
+    /// Unpoisons the URB.
+    #[inline]
+    pub fn unpoison(&mut self) {
+        // SAFETY: FFI call.
+        unsafe {
+            bindings::usb_unpoison_urb(self.ptr);
+        }
+    }
+}
+
+impl<T: Transfer, C: ForeignOwnable + Send + Sync> Drop for Urb<T, C> {
+    fn drop(&mut self) {
+        // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
+        if unsafe { bindings::refcount_read(&mut (*self.ptr).kref.refcount) == 0 } {
+            // Take ownership of every optional passed to the `Urb::fill_*` routines.
+            self.take_setup_packet();
+            self.take_context();
+            self.take_transfer().ok();
+        }
+        unsafe { bindings::usb_free_urb(self.ptr) };
+    }
+}
+
+// SAFETY: `Urb` only holds a pointer to an URB, which is safe to be used from any thread.
+unsafe impl<T: Transfer, C: ForeignOwnable + Send + Sync> Send for Urb<T, C> {}
+
+// SAFETY: `Urb` only holds a pointer to an URB, which is safe to be used from any thread.
+unsafe impl<T: Transfer, C: ForeignOwnable + Send + Sync> Sync for Urb<T, C> {}

--- a/rust/kernel/xarray.rs
+++ b/rust/kernel/xarray.rs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! XArray abstraction.
+//!
+//! C header: [`include/linux/xarray.h`](../../include/linux/xarray.h)
+
+use crate::{
+    bindings,
+    error::{Error, Result},
+    types::{ForeignOwnable, Opaque, ScopeGuard},
+};
+use core::{marker::PhantomData, ops::Deref};
+
+/// Flags passed to `XArray::new` to configure the `XArray`.
+type Flags = bindings::gfp_t;
+
+/// Flag values passed to `XArray::new` to configure the `XArray`.
+pub mod flags {
+    /// Use IRQ-safe locking
+    pub const LOCK_IRQ: super::Flags = bindings::BINDINGS_XA_FLAGS_LOCK_IRQ;
+    /// Use softirq-safe locking
+    pub const LOCK_BH: super::Flags = bindings::BINDINGS_XA_FLAGS_LOCK_BH;
+    /// Track which entries are free (distinct from None)
+    pub const TRACK_FREE: super::Flags = bindings::BINDINGS_XA_FLAGS_TRACK_FREE;
+    /// Initialize array index 0 as busy
+    pub const ZERO_BUSY: super::Flags = bindings::BINDINGS_XA_FLAGS_ZERO_BUSY;
+    /// Use GFP_ACCOUNT for internal memory allocations
+    pub const ACCOUNT: super::Flags = bindings::BINDINGS_XA_FLAGS_ACCOUNT;
+    /// Create an allocating `XArray` starting at index 0
+    pub const ALLOC: super::Flags = bindings::BINDINGS_XA_FLAGS_ALLOC;
+    /// Create an allocating `XArray` starting at index 1
+    pub const ALLOC1: super::Flags = bindings::BINDINGS_XA_FLAGS_ALLOC1;
+}
+
+/// Wrapper for a value owned by the `XArray` which holds the `XArray` lock until dropped.
+///
+/// # Invariants
+///
+/// The `*mut T` is always non-NULL and owned by the referenced `XArray`
+pub struct Guard<'a, T: ForeignOwnable>(*mut T, &'a Opaque<bindings::xarray>);
+
+impl<'a, T: ForeignOwnable> Guard<'a, T> {
+    /// Borrow the underlying value wrapped by the `Guard`.
+    ///
+    /// Returns a `T::Borrowed` type for the owned `ForeignOwnable` type.
+    pub fn borrow<'b>(&'b self) -> T::Borrowed<'b>
+    where
+        'a: 'b,
+    {
+        // SAFETY: The value is owned by the `XArray`, the lifetime it is borrowed for must not
+        // outlive the `XArray` itself, nor the Guard that holds the lock ensuring the value
+        // remains in the `XArray`.
+        unsafe { T::borrow(self.0 as _) }
+    }
+}
+
+// Convenience impl for `ForeignOwnable` types whose `Borrowed`
+// form implements Deref.
+impl<'a, T: ForeignOwnable> Deref for Guard<'a, T>
+where
+    T::Borrowed<'static>: Deref,
+{
+    type Target = <T::Borrowed<'static> as Deref>::Target;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: See the `borrow()` method. The dereferenced `T::Borrowed` value
+        // must share the same lifetime, so we can return a reference to it.
+        // TODO: Is this really sound?
+        unsafe { &*(T::borrow(self.0 as _).deref() as *const _) }
+    }
+}
+
+impl<'a, T: ForeignOwnable> Drop for Guard<'a, T> {
+    fn drop(&mut self) {
+        // SAFETY: The XArray we have a reference to owns the C xarray object.
+        unsafe { bindings::xa_unlock(self.1.get()) };
+    }
+}
+
+/// Represents a reserved slot in an `XArray`, which does not yet have a value but has an assigned
+/// index and may not be allocated by any other user. If the Reservation is dropped without
+/// being filled, the entry is marked as available again.
+///
+/// Users must ensure that reserved slots are not filled by other mechanisms, or otherwise their
+/// contents may be dropped and replaced (which will print a warning).
+pub struct Reservation<'a, T: ForeignOwnable>(&'a XArray<T>, usize, PhantomData<T>);
+
+impl<'a, T: ForeignOwnable> Reservation<'a, T> {
+    /// Store a value into the reserved slot.
+    pub fn store(self, value: T) -> Result<usize> {
+        if self.0.replace(self.1, value)?.is_some() {
+            crate::pr_err!("XArray: Reservation stored but the entry already had data!\n");
+            // Consider it a success anyway, not much we can do
+        }
+        let index = self.1;
+        core::mem::forget(self);
+        Ok(index)
+    }
+
+    /// Returns the index of this reservation.
+    pub fn index(&self) -> usize {
+        self.1
+    }
+}
+
+impl<'a, T: ForeignOwnable> Drop for Reservation<'a, T> {
+    fn drop(&mut self) {
+        if self.0.remove(self.1).is_some() {
+            crate::pr_err!("XArray: Reservation dropped but the entry was not empty!\n");
+        }
+    }
+}
+
+/// An array which efficiently maps sparse integer indices to owned objects.
+///
+/// This is similar to a `Vec<Option<T>>`, but more efficient when there are holes in the
+/// index space, and can be efficiently grown.
+///
+/// This structure is expected to often be used with an inner type that can either be efficiently
+/// cloned, such as an `Arc<T>`.
+pub struct XArray<T: ForeignOwnable> {
+    xa: Opaque<bindings::xarray>,
+    _p: PhantomData<T>,
+}
+
+impl<T: ForeignOwnable> XArray<T> {
+    /// Creates a new `XArray` with the given flags.
+    pub const fn new(flags: Flags) -> XArray<T> {
+        let xa = Opaque::new(bindings::xarray {
+            xa_lock: bindings::spinlock {
+                _bindgen_opaque_blob: 0,
+            },
+            xa_flags: flags,
+            xa_head: core::ptr::null_mut(),
+        });
+
+        // INVARIANT: Initialize the `XArray` with a valid `xa`.
+        XArray {
+            xa,
+            _p: PhantomData,
+        }
+    }
+
+    /// Replaces an entry with a new value, returning the old value (if any).
+    pub fn replace(&self, index: usize, value: T) -> Result<Option<T>> {
+        let new = value.into_foreign();
+        let guard = ScopeGuard::new(|| unsafe {
+            T::from_foreign(new);
+        });
+
+        let old = unsafe {
+            bindings::xa_store(
+                self.xa.get(),
+                index.try_into()?,
+                new as *mut _,
+                bindings::GFP_KERNEL,
+            )
+        };
+
+        let err = unsafe { bindings::xa_err(old) };
+        if err != 0 {
+            Err(Error::from_kernel_errno(err))
+        } else if old.is_null() {
+            guard.dismiss();
+            Ok(None)
+        } else {
+            guard.dismiss();
+            Ok(Some(unsafe { T::from_foreign(old) }))
+        }
+    }
+
+    /// Replaces an entry with a new value, dropping the old value (if any).
+    pub fn set(&self, index: usize, value: T) -> Result {
+        self.replace(index, value)?;
+        Ok(())
+    }
+
+    /// Looks up and returns a reference to an entry in the array, returning a `Guard` if it
+    /// exists.
+    ///
+    /// This guard blocks all other actions on the `XArray`. Callers are expected to drop the
+    /// `Guard` eagerly to avoid blocking other users, such as by taking a clone of the value.
+    pub fn get(&self, index: usize) -> Option<Guard<'_, T>> {
+        // SAFETY: `self.xa` is always valid by the type invariant.
+        let p = unsafe {
+            bindings::xa_lock(self.xa.get());
+            bindings::xa_load(self.xa.get(), index.try_into().ok()?)
+        };
+
+        if p.is_null() {
+            unsafe { bindings::xa_unlock(self.xa.get()) };
+            None
+        } else {
+            Some(Guard(p as _, &self.xa))
+        }
+    }
+
+    /// Removes and returns an entry, returning it if it existed.
+    pub fn remove(&self, index: usize) -> Option<T> {
+        let p = unsafe { bindings::xa_erase(self.xa.get(), index.try_into().ok()?) };
+        if p.is_null() {
+            None
+        } else {
+            Some(unsafe { T::from_foreign(p) })
+        }
+    }
+
+    /// Allocate a new index in the array, optionally storing a new value into it, with
+    /// configurable bounds for the index range to allocate from.
+    ///
+    /// If `value` is `None`, then the index is reserved from further allocation but remains
+    /// free for storing a value into it.
+    pub fn alloc_limits(&self, value: Option<T>, min: u32, max: u32) -> Result<usize> {
+        let new = value.map_or(core::ptr::null(), |a| a.into_foreign());
+        let mut id: u32 = 0;
+
+        // SAFETY: `self.xa` is always valid by the type invariant. If this succeeds, it
+        // takes ownership of the passed `T` (if any). If it fails, we must drop the
+        // `T` again.
+        let ret = unsafe {
+            bindings::xa_alloc(
+                self.xa.get(),
+                &mut id,
+                new as *mut _,
+                bindings::xa_limit { min, max },
+                bindings::GFP_KERNEL,
+            )
+        };
+
+        if ret < 0 {
+            // Make sure to drop the value we failed to store
+            if !new.is_null() {
+                // SAFETY: If `new` is not NULL, it came from the `ForeignOwnable` we got
+                // from the caller.
+                unsafe { T::from_foreign(new) };
+            }
+            Err(Error::from_kernel_errno(ret))
+        } else {
+            Ok(id as usize)
+        }
+    }
+
+    /// Allocate a new index in the array, optionally storing a new value into it.
+    ///
+    /// If `value` is `None`, then the index is reserved from further allocation but remains
+    /// free for storing a value into it.
+    pub fn alloc(&self, value: Option<T>) -> Result<usize> {
+        self.alloc_limits(value, 0, u32::MAX)
+    }
+
+    /// Reserve a new index in the array within configurable bounds for the index.
+    ///
+    /// Returns a `Reservation` object, which can then be used to store a value at this index or
+    /// otherwise free it for reuse.
+    pub fn reserve_limits(&self, min: u32, max: u32) -> Result<Reservation<'_, T>> {
+        Ok(Reservation(
+            self,
+            self.alloc_limits(None, min, max)?,
+            PhantomData,
+        ))
+    }
+
+    /// Reserve a new index in the array.
+    ///
+    /// Returns a `Reservation` object, which can then be used to store a value at this index or
+    /// otherwise free it for reuse.
+    pub fn reserve(&self) -> Result<Reservation<'_, T>> {
+        Ok(Reservation(self, self.alloc(None)?, PhantomData))
+    }
+}
+
+impl<T: ForeignOwnable> Drop for XArray<T> {
+    fn drop(&mut self) {
+        // SAFETY: `self.xa` is valid by the type invariant, and as we have the only reference to
+        // the `XArray` we can safely iterate its contents and drop everything.
+        unsafe {
+            let mut index: core::ffi::c_ulong = 0;
+            let mut entry = bindings::xa_find(
+                self.xa.get(),
+                &mut index,
+                core::ffi::c_ulong::MAX,
+                bindings::BINDINGS_XA_PRESENT,
+            );
+            while !entry.is_null() {
+                T::from_foreign(entry);
+                entry = bindings::xa_find_after(
+                    self.xa.get(),
+                    &mut index,
+                    core::ffi::c_ulong::MAX,
+                    bindings::BINDINGS_XA_PRESENT,
+                );
+            }
+
+            bindings::xa_destroy(self.xa.get());
+        }
+    }
+}
+
+// SAFETY: XArray is thread-safe and all mutation operations are internally locked.
+unsafe impl<T: Send + ForeignOwnable> Send for XArray<T> {}
+unsafe impl<T: Sync + ForeignOwnable> Sync for XArray<T> {}

--- a/samples/rust/Kconfig
+++ b/samples/rust/Kconfig
@@ -70,6 +70,16 @@ config SAMPLE_RUST_MISCDEV
 
 	  If unsure, say N.
 
+config SAMPLE_RUST_USB_SIMPLE
+	tristate "USB simple device driver"
+	help
+	  This option builds the Rust USB simple driver sample.
+
+	  To compile this as a module, choose M here:
+	  the module will be called rust_usb_simple.
+
+	  If unsure, say N.
+
 config SAMPLE_RUST_STACK_PROBING
 	tristate "Stack probing"
 	help

--- a/samples/rust/Makefile
+++ b/samples/rust/Makefile
@@ -6,6 +6,7 @@ obj-$(CONFIG_SAMPLE_RUST_MODULE_PARAMETERS)	+= rust_module_parameters.o
 obj-$(CONFIG_SAMPLE_RUST_SYNC)			+= rust_sync.o
 obj-$(CONFIG_SAMPLE_RUST_CHRDEV)		+= rust_chrdev.o
 obj-$(CONFIG_SAMPLE_RUST_MISCDEV)		+= rust_miscdev.o
+obj-$(CONFIG_SAMPLE_RUST_USB_SIMPLE)		+= rust_usb_simple.o
 obj-$(CONFIG_SAMPLE_RUST_STACK_PROBING)		+= rust_stack_probing.o
 obj-$(CONFIG_SAMPLE_RUST_SEMAPHORE)		+= rust_semaphore.o
 obj-$(CONFIG_SAMPLE_RUST_SEMAPHORE_C)		+= rust_semaphore_c.o

--- a/samples/rust/rust_chrdev.rs
+++ b/samples/rust/rust_chrdev.rs
@@ -17,7 +17,7 @@ struct RustFile;
 
 #[vtable]
 impl file::Operations for RustFile {
-    fn open(_shared: &(), _file: &file::File) -> Result {
+    fn open(_shared: &(), _inode: &file::Inode, _file: &file::File) -> Result {
         Ok(())
     }
 }

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -4,7 +4,7 @@
 
 use kernel::prelude::*;
 use kernel::{
-    file::{self, File},
+    file::{self, File, Inode},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
     sync::{Arc, ArcBorrow, CondVar, Mutex, UniqueArc},
@@ -56,7 +56,7 @@ impl file::Operations for Token {
     type Data = Arc<SharedState>;
     type OpenData = Arc<SharedState>;
 
-    fn open(shared: &Arc<SharedState>, _file: &File) -> Result<Self::Data> {
+    fn open(shared: &Arc<SharedState>, _inode: &Inode, _file: &File) -> Result<Self::Data> {
         Ok(shared.clone())
     }
 

--- a/samples/rust/rust_random.rs
+++ b/samples/rust/rust_random.rs
@@ -6,7 +6,7 @@
 //! <https://github.com/alex/just-use/blob/master/src/lib.rs>.
 
 use kernel::{
-    file::{self, File},
+    file::{self, File, Inode},
     io_buffer::{IoBufferReader, IoBufferWriter},
     prelude::*,
 };
@@ -23,7 +23,7 @@ struct RandomFile;
 
 #[vtable]
 impl file::Operations for RandomFile {
-    fn open(_data: &(), _file: &File) -> Result {
+    fn open(_data: &(), _inode: &Inode, _file: &File) -> Result {
         Ok(())
     }
 

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -16,7 +16,7 @@
 use core::sync::atomic::{AtomicU64, Ordering};
 use kernel::{
     condvar_init,
-    file::{self, File, IoctlCommand, IoctlHandler},
+    file::{self, File, Inode, IoctlCommand, IoctlHandler},
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev::Registration,
     mutex_init,
@@ -66,7 +66,7 @@ impl file::Operations for FileState {
     type Data = Box<Self>;
     type OpenData = Arc<Semaphore>;
 
-    fn open(shared: &Arc<Semaphore>, _file: &File) -> Result<Box<Self>> {
+    fn open(shared: &Arc<Semaphore>, _inode: &Inode, _file: &File) -> Result<Box<Self>> {
         Ok(Box::try_new(Self {
             read_count: AtomicU64::new(0),
             shared: shared.clone(),

--- a/samples/rust/rust_usb_simple.rs
+++ b/samples/rust/rust_usb_simple.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Rust USB sample.
+
+use kernel::{
+    define_usb_id_table, device,
+    error::code::*,
+    file, init_static_sync,
+    io_buffer::IoBufferWriter,
+    miscdev, module_usb_driver, mutex_init, new_device_data,
+    prelude::*,
+    sync::{Arc, ArcBorrow, Mutex, NoWaitLock, UniqueArc},
+    usb,
+    xarray::XArray,
+    GFP_ATOMIC, GFP_KERNEL,
+};
+
+const USB_SIMPLE_MINORS: u32 = 16;
+
+init_static_sync! {
+    static TABLE_MUTEX: Mutex<XArray<Arc<Mutex<UsbSimpleSyncData>>>> = XArray::new(0);
+}
+
+struct UsbSimpleFile;
+
+struct UsbSimpleSyncData {
+    buf: Vec<u8>,
+    minor: usize,
+}
+
+#[vtable]
+impl file::Operations for UsbSimpleFile {
+    type Data = Arc<Mutex<UsbSimpleSyncData>>;
+
+    fn open(_: &(), inode: &file::Inode, _: &file::File) -> Result<Self::Data> {
+        let minors = TABLE_MUTEX.lock();
+        let sbuf = minors.get(inode.minor() as usize).ok_or(EAGAIN)?;
+        Ok(Arc::from(sbuf.borrow()))
+    }
+
+    fn read(
+        shared: ArcBorrow<'_, Mutex<UsbSimpleSyncData>>,
+        _: &file::File,
+        writer: &mut impl IoBufferWriter,
+        offset: u64,
+    ) -> Result<usize> {
+        if writer.is_empty() || offset != 0 {
+            return Ok(0);
+        }
+
+        let sbuf = shared.lock();
+        writer.write_slice(&sbuf.buf)?;
+        Ok(sbuf.buf.len())
+    }
+}
+
+struct UsbSimpleContext {
+    sbuf: Arc<Mutex<UsbSimpleSyncData>>,
+}
+
+impl UsbSimpleContext {
+    fn try_new(sbuf: UsbSimpleSyncData) -> Result<Arc<Self>> {
+        // SAFETY: `mutex_init!` is called below.
+        let mut sbuf = unsafe { Pin::from(UniqueArc::try_new(Mutex::new(sbuf))?) };
+        let pinned = sbuf.as_mut();
+        mutex_init!(pinned, "UsbSimpleContext::sbuf");
+        Arc::try_new(Self { sbuf: sbuf.into() })
+    }
+}
+
+struct UsbSimpleCompletion;
+
+impl usb::Completion<Vec<u8>, Arc<UsbSimpleContext>> for UsbSimpleCompletion {
+    fn complete(mut urb: UrbSimple) {
+        let ctx = urb.context().unwrap();
+        if let Some(mut sbuf) = ctx.sbuf.try_lock() {
+            sbuf.buf.copy_from_slice(urb.borrow_transfer().unwrap());
+        }
+        urb.submit(GFP_ATOMIC).unwrap_or_default();
+    }
+}
+
+type UsbSimpleRegistration = miscdev::Registration<UsbSimpleFile>;
+
+type UrbSimple = usb::Urb<Vec<u8>, Arc<UsbSimpleContext>>;
+
+struct UsbSimpleResources;
+
+struct UsbSimpleData {
+    urbs: Vec<UrbSimple>,
+}
+
+type DeviceData = device::Data<
+    Vec<Pin<Box<UsbSimpleRegistration>>>,
+    UsbSimpleResources,
+    NoWaitLock<UsbSimpleData>,
+>;
+
+fn alloc_minors(urbs: &mut [UrbSimple], ports: usize) -> Result {
+    let minors = TABLE_MUTEX.lock();
+
+    let mut res = Ok(());
+    let mut n = 0;
+    for (i, ctx) in urbs
+        .iter()
+        .take(ports)
+        .map_while(UrbSimple::context)
+        .enumerate()
+    {
+        let mut sbuf = ctx.sbuf.lock();
+        match minors.alloc_limits(Some(ctx.sbuf.clone()), 0, USB_SIMPLE_MINORS) {
+            Ok(m) => sbuf.minor = m,
+            Err(e) => {
+                res = Err(e);
+                n = i;
+                break;
+            }
+        }
+    }
+    if res.is_err() {
+        for ctx in urbs.iter().take(n).map_while(UrbSimple::context) {
+            minors.remove(ctx.sbuf.lock().minor);
+        }
+    }
+    res
+}
+
+fn release_minors(urbs: &mut [UrbSimple]) {
+    let minors = TABLE_MUTEX.lock();
+
+    for ctx in urbs.iter().map_while(UrbSimple::context) {
+        minors.remove(ctx.sbuf.lock().minor);
+    }
+}
+
+struct UsbSimpleDevice;
+
+#[vtable]
+impl usb::Driver for UsbSimpleDevice {
+    type Data = Arc<DeviceData>;
+
+    define_usb_id_table! {(), [(usb::DeviceId::default(), None)]}
+
+    fn probe(intf: &mut usb::Interface, _id: Option<&()>) -> Result<Self::Data> {
+        let dev = intf.to_usb_device();
+        if dev.descriptor().id_vendor != *id_vendor.read()
+            || dev.descriptor().id_product != *id_product.read()
+        {
+            return Err(ENODEV);
+        }
+        let mut in_edps = intf
+            .cur_altsetting()
+            .endpoints()
+            .iter()
+            .filter(|e| e.is_bulk_in());
+        let epd_count = in_edps.by_ref().count();
+        let mut urbs = Vec::try_with_capacity(epd_count)?;
+        let mut regs = Vec::try_with_capacity(epd_count)?;
+        for epd in in_edps {
+            let mut urb = UrbSimple::try_new(0)?;
+            let read_bulk = Vec::try_with_capacity(epd.maxp() as usize)?;
+            let read_ctx = UsbSimpleContext::try_new(UsbSimpleSyncData {
+                buf: Vec::try_with_capacity(epd.maxp() as usize)?,
+                minor: 0,
+            })?;
+            urb.fill_bulk::<UsbSimpleCompletion>(
+                &dev,
+                dev.rcvbulkpipe(epd.b_endpoint_address as u32),
+                Some(read_bulk),
+                Some(read_ctx),
+            );
+            urb.submit(GFP_KERNEL).unwrap_or_default();
+            regs.try_push(miscdev::Registration::<UsbSimpleFile>::new_pinned(
+                fmt!("usbsimple"),
+                (),
+            )?)?;
+            urbs.try_push(urb)?;
+        }
+        alloc_minors(&mut urbs, *num_ports.read() as usize)?;
+        let data = new_device_data!(
+            regs,
+            UsbSimpleResources,
+            NoWaitLock::new(UsbSimpleData { urbs }),
+            "UsbSimple::Registrations"
+        )?;
+        Ok(data.into())
+    }
+
+    fn disconnect(_intf: &mut usb::Interface, data: &Self::Data) {
+        if let Some(mut d) = data.try_lock() {
+            release_minors(d.urbs.as_mut_slice());
+            for urb in d.urbs.as_mut_slice() {
+                urb.poison();
+            }
+        }
+    }
+}
+
+module_usb_driver! {
+    type: UsbSimpleDevice,
+    name: "rust_usb_simple",
+    author: "Martin Rodriguez Reboredo",
+    description: "Rust USB sample",
+    license: "GPL v2",
+    params: {
+        id_vendor: u16 {
+            default: 0x0,
+            permissions: 0,
+            description: "USB Vendor ID to probe",
+        },
+        id_product: u16 {
+            default: 0x0,
+            permissions: 0,
+            description: "USB Product ID to probe",
+        },
+        num_ports: u16 {
+            default: 0,
+            permissions: 0,
+            description: "Number of ports to expose",
+        },
+    },
+}


### PR DESCRIPTION
Introduces a basic API for USB devices, drivers and interfaces. Features will be added on demand.
