### PR TITLE
rust: implement `Display` and `Debug` for `BStr`

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -3,8 +3,8 @@
 //! Broadcom BCM2835 Random Number Generator support.
 
 use kernel::{
-    device, file, file::File, io_buffer::IoBufferWriter, miscdev, module_platform_driver, of,
-    platform, prelude::*, sync::Ref,
+    b_str, device, file, file::File, io_buffer::IoBufferWriter, miscdev, module_platform_driver,
+    of, platform, prelude::*, str::BStr, sync::Ref,
 };
 
 module_platform_driver! {
@@ -41,7 +41,7 @@ impl platform::Driver for RngDriver {
     type Data = Ref<DeviceData>;
 
     kernel::define_of_id_table! {(), [
-        (of::DeviceId::Compatible(b"brcm,bcm2835-rng"), None),
+        (of::DeviceId::Compatible(b_str!("brcm,bcm2835-rng")), None),
     ]}
 
     fn probe(dev: &mut platform::Device, _id_info: Option<&Self::IdInfo>) -> Result<Self::Data> {

--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -21,12 +21,12 @@ pub enum DeviceId {
 /// # Examples
 ///
 /// ```
-/// # use kernel::define_of_id_table;
+/// # use kernel::{define_of_id_table, str::BStr, b_str};
 /// use kernel::of;
 ///
 /// define_of_id_table! {u32, [
-///     (of::DeviceId::Compatible(b"test-device1,test-device2"), Some(0xff)),
-///     (of::DeviceId::Compatible(b"test-device3"), None),
+///     (of::DeviceId::Compatible(b_str!("test-device1,test-device2")), Some(0xff)),
+///     (of::DeviceId::Compatible(b_str!("test-device3")), None),
 /// ]};
 /// ```
 #[macro_export]

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -195,7 +195,7 @@ unsafe impl device::RawDevice for Device {
 /// # Examples
 ///
 /// ```ignore
-/// # use kernel::{platform, define_of_id_table, module_platform_driver};
+/// # use kernel::{platform, define_of_id_table, module_platform_driver, str::BStr, b_str};
 /// #
 /// struct MyDriver;
 /// impl platform::Driver for MyDriver {
@@ -204,7 +204,7 @@ unsafe impl device::RawDevice for Device {
 /// #       Ok(())
 /// #   }
 /// #   define_of_id_table! {(), [
-/// #       (of::DeviceId::Compatible(b"brcm,bcm2835-rng"), None),
+/// #       (of::DeviceId::Compatible(b_str!("brcm,bcm2835-rng")), None),
 /// #   ]}
 /// }
 ///

--- a/samples/rust/rust_platform.rs
+++ b/samples/rust/rust_platform.rs
@@ -2,7 +2,7 @@
 
 //! Rust platform device driver sample.
 
-use kernel::{module_platform_driver, of, platform, prelude::*};
+use kernel::{b_str, module_platform_driver, of, platform, prelude::*, str::BStr};
 
 module_platform_driver! {
     type: Driver,
@@ -13,7 +13,7 @@ module_platform_driver! {
 struct Driver;
 impl platform::Driver for Driver {
     kernel::define_of_id_table! {(), [
-        (of::DeviceId::Compatible(b"rust,sample"), None),
+        (of::DeviceId::Compatible(b_str!("rust,sample")), None),
     ]}
 
     fn probe(_dev: &mut platform::Device, _id_info: Option<&Self::IdInfo>) -> Result {


### PR DESCRIPTION
Implement `Display` and `Debug` for `BStr`. Also, for this purpose, change `BStr` from a type alias to a newtype wrapper.

Closes https://github.com/Rust-for-Linux/linux/issues/534

Similar PR [here](https://github.com/Rust-for-Linux/linux/pull/578), but it seems to be out of date. And a little different from my PR.