### PR TITLE
ci: update container to Ubuntu 22.04 and provide `libssl-dev`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-20.04
-    container: ghcr.io/rust-for-linux/ci:Rust-1.62.0
+    container: ghcr.io/rust-for-linux/ci:Rust-1.62.0-2
     timeout-minutes: 25
 
     strategy:

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -278,6 +278,11 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
 	-fno-inline-functions-called-once \
 	--param=% --param asan-%
 
+# Ignore RISC-V extensions that Clang does not recognize.
+bindgen_c_flags_patsubst2 = $(patsubst -march=rv%_zihintpause,-march=rv%,$(c_flags))
+bindgen_c_flags_patsubst1 = $(patsubst -march=rv%_zicbom,-march=rv%,$(bindgen_c_flags_patsubst2))
+bindgen_c_flags_patsubst  = $(patsubst -march=rv%_zicsr_zifencei,-march=rv%,$(bindgen_c_flags_patsubst1))
+
 # Derived from `scripts/Makefile.clang`.
 BINDGEN_TARGET_arm	:= arm-linux-gnueabi
 BINDGEN_TARGET_arm64	:= aarch64-linux-gnu
@@ -291,7 +296,7 @@ BINDGEN_TARGET		:= $(BINDGEN_TARGET_$(SRCARCH))
 # some configurations, with new GCC versions, etc.
 bindgen_extra_c_flags = -w --target=$(BINDGEN_TARGET)
 
-bindgen_c_flags = $(filter-out $(bindgen_skip_c_flags), $(c_flags)) \
+bindgen_c_flags = $(filter-out $(bindgen_skip_c_flags), $(bindgen_c_flags_patsubst)) \
 	$(bindgen_extra_c_flags)
 endif
 


### PR DESCRIPTION
Fixes https://github.com/Rust-for-Linux/linux/issues/892.

Based on top of https://github.com/Rust-for-Linux/linux/pull/895.

Contains two updates:

  - Ubuntu 22.04 (instead of 21.10 which is EOL).
  - Adding the `libssl-dev` package.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>