### PR TITLE
macros: error: use `type` definitions for reduce complexity

### DIFF
--- a/rust/macros/helpers.rs
+++ b/rust/macros/helpers.rs
@@ -2,6 +2,8 @@
 
 use proc_macro::{token_stream, Group, TokenTree};
 
+pub(crate) type FnTrySimpleParam = Box<dyn Fn(&mut token_stream::IntoIter)-> Option<String>>;
+
 pub(crate) fn try_ident(it: &mut token_stream::IntoIter) -> Option<String> {
     if let Some(TokenTree::Ident(ident)) = it.next() {
         Some(ident.to_string())

--- a/rust/macros/module.rs
+++ b/rust/macros/module.rs
@@ -145,7 +145,7 @@ fn param_ops_path(param_type: &str) -> &'static str {
 
 fn try_simple_param_val(
     param_type: &str,
-) -> Box<dyn Fn(&mut token_stream::IntoIter) -> Option<String>> {
+) -> FnTrySimpleParam {
     match param_type {
         "bool" => Box::new(try_ident),
         "str" => Box::new(|param_it| {


### PR DESCRIPTION
fix clippy error: very complex type used.
Consider factoring parts into `type` definitions

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>
Reviewed-by: Luca Barbato <lu_zero@gentoo.org>