### PR TITLE
rust: kernel: workqueue: deref on an immutable reference

### DIFF
--- a/rust/kernel/workqueue.rs
+++ b/rust/kernel/workqueue.rs
@@ -391,7 +391,7 @@ impl Work {
             // SAFETY: When the work was queued, a call to `into_raw` was made. We just canceled
             // the work without it having the chance to run, so we need to explicitly destroy this
             // reference (which would have happened in `work_func` if it did run).
-            unsafe { Ref::from_raw(&*self) };
+            unsafe { Ref::from_raw(self) };
         }
     }
 


### PR DESCRIPTION
clippy error: if you would like to reborrow, try removing `&*`: `self`

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>
Reviewed-by: Luca Barbato <lu_zero@gentoo.org>