### PR TITLE
increase the CI timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   ci:
     runs-on: ubuntu-20.04
     container: ghcr.io/rust-for-linux/ci:Rust-1.62.0-2
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     strategy:
       matrix:


### PR DESCRIPTION
it's been flaking a lot lately. ideally we'd speed up CI, but for now let's keep it passing consistently

Signed-off-by: Alex Gaynor <alex.gaynor@gmail.com>