### PR TITLE
Made `Guard<Mutex>` not `Send`, because of #862

### DIFF
--- a/rust/kernel/sync/guard.rs
+++ b/rust/kernel/sync/guard.rs
@@ -166,3 +166,5 @@ impl<L: LockIniter> NeedsLockClass for L {
         self.init_lock(name, key);
     }
 }
+
+pub struct EmptyGuardContext;

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -4,7 +4,9 @@
 //!
 //! This module allows Rust code to use the kernel's [`struct mutex`].
 
-use super::{Guard, Lock, LockClassKey, LockFactory, LockIniter, WriteLock};
+use super::{
+    guard::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockIniter, WriteLock,
+};
 use crate::{bindings, str::CStr, Opaque};
 use core::{cell::UnsafeCell, marker::PhantomPinned, pin::Pin};
 
@@ -86,8 +88,6 @@ impl<T> LockIniter for Mutex<T> {
         unsafe { bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key.get()) };
     }
 }
-
-pub struct EmptyGuardContext;
 
 // SAFETY: The underlying kernel `struct mutex` object ensures mutual exclusion.
 unsafe impl<T: ?Sized> Lock for Mutex<T> {

--- a/rust/kernel/sync/rwsem.rs
+++ b/rust/kernel/sync/rwsem.rs
@@ -7,7 +7,7 @@
 //! C header: [`include/linux/rwsem.h`](../../../../include/linux/rwsem.h)
 
 use super::{
-    mutex::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockIniter, ReadLock,
+    guard::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockIniter, ReadLock,
     WriteLock,
 };
 use crate::{bindings, str::CStr, Opaque};

--- a/rust/kernel/sync/smutex.rs
+++ b/rust/kernel/sync/smutex.rs
@@ -46,7 +46,7 @@
 //! When the waiter queue is non-empty, unlocking the mutex always results in the first waiter being
 //! popped form the queue and awakened.
 
-use super::{mutex::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockIniter};
+use super::{guard::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockIniter};
 use crate::{bindings, str::CStr, Opaque};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{cell::UnsafeCell, pin::Pin};

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -7,7 +7,7 @@
 //! See <https://www.kernel.org/doc/Documentation/locking/spinlocks.txt>.
 
 use super::{
-    mutex::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockInfo, LockIniter,
+    guard::EmptyGuardContext, Guard, Lock, LockClassKey, LockFactory, LockInfo, LockIniter,
     WriteLock,
 };
 use crate::{bindings, str::CStr, Opaque, True};


### PR DESCRIPTION
We should also do this with other guards, as sending a `Guard<SpinLock>` is probably a footgun