### PR TITLE
rust: rename `Ref` to `Arc`

### DIFF
--- a/drivers/android/allocation.rs
+++ b/drivers/android/allocation.rs
@@ -2,7 +2,7 @@
 
 use core::mem::{replace, size_of, MaybeUninit};
 use kernel::{
-    bindings, linked_list::List, pages::Pages, prelude::*, sync::Ref, user_ptr::UserSlicePtrReader,
+    bindings, linked_list::List, pages::Pages, prelude::*, sync::Arc, user_ptr::UserSlicePtrReader,
 };
 
 use crate::{
@@ -17,7 +17,7 @@ pub(crate) struct Allocation<'a> {
     pub(crate) offset: usize,
     size: usize,
     pub(crate) ptr: usize,
-    pages: Ref<[Pages<0>]>,
+    pages: Arc<[Pages<0>]>,
     pub(crate) process: &'a Process,
     allocation_info: Option<AllocationInfo>,
     free_on_drop: bool,
@@ -30,7 +30,7 @@ impl<'a> Allocation<'a> {
         offset: usize,
         size: usize,
         ptr: usize,
-        pages: Ref<[Pages<0>]>,
+        pages: Arc<[Pages<0>]>,
     ) -> Self {
         Self {
             process,

--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -4,7 +4,7 @@ use kernel::{
     bindings,
     prelude::*,
     security,
-    sync::{Mutex, Ref, UniqueRef},
+    sync::{Arc, Mutex, UniqueArc},
 };
 
 use crate::{
@@ -26,8 +26,8 @@ unsafe impl Send for Context {}
 unsafe impl Sync for Context {}
 
 impl Context {
-    pub(crate) fn new() -> Result<Ref<Self>> {
-        let mut ctx = Pin::from(UniqueRef::try_new(Self {
+    pub(crate) fn new() -> Result<Arc<Self>> {
+        let mut ctx = Pin::from(UniqueArc::try_new(Self {
             // SAFETY: Init is called below.
             manager: unsafe {
                 Mutex::new(Manager {

--- a/drivers/android/rust_binder.rs
+++ b/drivers/android/rust_binder.rs
@@ -10,7 +10,7 @@ use kernel::{
     miscdev::Registration,
     prelude::*,
     str::CStr,
-    sync::Ref,
+    sync::Arc,
     user_ptr::UserSlicePtrWriter,
 };
 
@@ -37,11 +37,11 @@ trait DeliverToRead {
     /// Performs work. Returns true if remaining work items in the queue should be processed
     /// immediately, or false if it should return to caller before processing additional work
     /// items.
-    fn do_work(self: Ref<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool>;
+    fn do_work(self: Arc<Self>, thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool>;
 
     /// Cancels the given work item. This is called instead of [`DeliverToRead::do_work`] when work
     /// won't be delivered.
-    fn cancel(self: Ref<Self>) {}
+    fn cancel(self: Arc<Self>) {}
 
     /// Returns the linked list links for the work item.
     fn get_links(&self) -> &Links<dyn DeliverToRead>;
@@ -58,7 +58,7 @@ impl GetLinks for DeliverToReadListAdapter {
 }
 
 impl GetLinksWrapped for DeliverToReadListAdapter {
-    type Wrapped = Ref<dyn DeliverToRead>;
+    type Wrapped = Arc<dyn DeliverToRead>;
 }
 
 struct DeliverCode {
@@ -76,7 +76,7 @@ impl DeliverCode {
 }
 
 impl DeliverToRead for DeliverCode {
-    fn do_work(self: Ref<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
+    fn do_work(self: Arc<Self>, _thread: &Thread, writer: &mut UserSlicePtrWriter) -> Result<bool> {
         writer.write(&self.code)?;
         Ok(true)
     }

--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -4,7 +4,7 @@
 
 use kernel::{
     device, file, file::File, io_buffer::IoBufferWriter, miscdev, module_platform_driver, of,
-    platform, prelude::*, sync::Ref,
+    platform, prelude::*, sync::Arc,
 };
 
 module_platform_driver! {
@@ -38,7 +38,7 @@ type DeviceData = device::Data<miscdev::Registration<RngDevice>, (), ()>;
 
 struct RngDriver;
 impl platform::Driver for RngDriver {
-    type Data = Ref<DeviceData>;
+    type Data = Arc<DeviceData>;
 
     kernel::define_of_id_table! {(), [
         (of::DeviceId::Compatible(b"brcm,bcm2835-rng"), None),

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -11,7 +11,7 @@ use crate::{
     bindings,
     revocable::{Revocable, RevocableGuard},
     str::CStr,
-    sync::{LockClassKey, NeedsLockClass, RevocableMutex, RevocableMutexGuard, UniqueRef},
+    sync::{LockClassKey, NeedsLockClass, RevocableMutex, RevocableMutexGuard, UniqueArc},
     Result,
 };
 use core::{
@@ -263,8 +263,8 @@ impl<T, U, V> Data<T, U, V> {
         name: &'static CStr,
         key1: &'static LockClassKey,
         key2: &'static LockClassKey,
-    ) -> Result<Pin<UniqueRef<Self>>> {
-        let mut ret = Pin::from(UniqueRef::try_new(Self {
+    ) -> Result<Pin<UniqueArc<Self>>> {
+        let mut ret = Pin::from(UniqueArc::try_new(Self {
             // SAFETY: We call `RevocableMutex::init` below.
             registrations: unsafe { RevocableMutex::new(registrations) },
             resources: Revocable::new(resources),

--- a/rust/kernel/driver.rs
+++ b/rust/kernel/driver.rs
@@ -5,7 +5,7 @@
 //! Each bus/subsystem is expected to implement [`DriverOps`], which allows drivers to register
 //! using the [`Registration`] class.
 
-use crate::{error::code::*, str::CStr, sync::Ref, Result, ThisModule};
+use crate::{error::code::*, str::CStr, sync::Arc, Result, ThisModule};
 use alloc::boxed::Box;
 use core::{cell::UnsafeCell, marker::PhantomData, ops::Deref, pin::Pin};
 
@@ -397,7 +397,7 @@ impl DeviceRemoval for () {
     fn device_remove(&self) {}
 }
 
-impl<T: DeviceRemoval> DeviceRemoval for Ref<T> {
+impl<T: DeviceRemoval> DeviceRemoval for Arc<T> {
     fn device_remove(&self) {
         self.deref().device_remove();
     }

--- a/rust/kernel/irq.rs
+++ b/rust/kernel/irq.rs
@@ -455,20 +455,20 @@ pub trait ThreadedHandler {
 /// # use kernel::prelude::*;
 /// use kernel::{
 ///     irq,
-///     sync::{Ref, RefBorrow},
+///     sync::{Arc, ArcBorrow},
 /// };
 ///
 /// struct Example;
 ///
 /// impl irq::ThreadedHandler for Example {
-///     type Data = Ref<u32>;
+///     type Data = Arc<u32>;
 ///
-///     fn handle_threaded_irq(_data: RefBorrow<'_, u32>) -> irq::Return {
+///     fn handle_threaded_irq(_data: ArcBorrow<'_, u32>) -> irq::Return {
 ///         irq::Return::None
 ///     }
 /// }
 ///
-/// fn request_irq(irq: u32, data: Ref<u32>) -> Result<irq::ThreadedRegistration<Example>> {
+/// fn request_irq(irq: u32, data: Arc<u32>) -> Result<irq::ThreadedRegistration<Example>> {
 ///     irq::ThreadedRegistration::try_new(irq, data, irq::flags::SHARED, fmt!("example_{irq}"))
 /// }
 /// ```

--- a/rust/kernel/linked_list.rs
+++ b/rust/kernel/linked_list.rs
@@ -8,7 +8,7 @@ use alloc::boxed::Box;
 use core::ptr::NonNull;
 
 pub use crate::raw_list::{Cursor, GetLinks, Links};
-use crate::{raw_list, raw_list::RawList, sync::Ref};
+use crate::{raw_list, raw_list::RawList, sync::Arc};
 
 // TODO: Use the one from `kernel::file_operations::PointerWrapper` instead.
 /// Wraps an object to be inserted in a linked list.
@@ -41,14 +41,14 @@ impl<T: ?Sized> Wrapper<T> for Box<T> {
     }
 }
 
-impl<T: ?Sized> Wrapper<T> for Ref<T> {
+impl<T: ?Sized> Wrapper<T> for Arc<T> {
     fn into_pointer(self) -> NonNull<T> {
-        NonNull::new(Ref::into_raw(self) as _).unwrap()
+        NonNull::new(Arc::into_raw(self) as _).unwrap()
     }
 
     unsafe fn from_pointer(ptr: NonNull<T>) -> Self {
-        // SAFETY: The safety requirements of `from_pointer` satisfy the ones from `Ref::from_raw`.
-        unsafe { Ref::from_raw(ptr.as_ptr() as _) }
+        // SAFETY: The safety requirements of `from_pointer` satisfy the ones from `Arc::from_raw`.
+        unsafe { Arc::from_raw(ptr.as_ptr() as _) }
     }
 
     fn as_ref(&self) -> &T {
@@ -90,14 +90,14 @@ impl<T: GetLinks + ?Sized> GetLinks for Box<T> {
     }
 }
 
-impl<T: ?Sized> GetLinksWrapped for Ref<T>
+impl<T: ?Sized> GetLinksWrapped for Arc<T>
 where
-    Ref<T>: GetLinks,
+    Arc<T>: GetLinks,
 {
-    type Wrapped = Ref<<Ref<T> as GetLinks>::EntryType>;
+    type Wrapped = Arc<<Arc<T> as GetLinks>::EntryType>;
 }
 
-impl<T: GetLinks + ?Sized> GetLinks for Ref<T> {
+impl<T: GetLinks + ?Sized> GetLinks for Arc<T> {
     type EntryType = T::EntryType;
 
     fn get_links(data: &Self::EntryType) -> &Links<Self::EntryType> {

--- a/rust/kernel/sync.rs
+++ b/rust/kernel/sync.rs
@@ -37,7 +37,7 @@ mod seqlock;
 pub mod smutex;
 mod spinlock;
 
-pub use arc::{new_refcount, Ref, RefBorrow, StaticRef, UniqueRef};
+pub use arc::{new_refcount, Arc, ArcBorrow, StaticArc, UniqueArc};
 pub use condvar::CondVar;
 pub use guard::{Guard, Lock, LockFactory, LockInfo, LockIniter, ReadLock, WriteLock};
 pub use locked_by::LockedBy;

--- a/rust/kernel/sync/smutex.rs
+++ b/rust/kernel/sync/smutex.rs
@@ -64,7 +64,7 @@ const LOCKED: usize = 1;
 /// # Examples
 ///
 /// ```
-/// # use kernel::{Result, sync::Ref, sync::smutex::Mutex};
+/// # use kernel::{Result, sync::Arc, sync::smutex::Mutex};
 ///
 /// struct Example {
 ///     a: u32,
@@ -83,8 +83,8 @@ const LOCKED: usize = 1;
 ///     guard.a + guard.b
 /// }
 ///
-/// fn try_new(a: u32, b: u32) -> Result<Ref<Mutex<Example>>> {
-///     Ref::try_new(Mutex::new(Example { a, b }))
+/// fn try_new(a: u32, b: u32) -> Result<Arc<Mutex<Example>>> {
+///     Arc::try_new(Mutex::new(Example { a, b }))
 /// }
 ///
 /// assert_eq!(EXAMPLE.lock().a, 10);

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     bindings,
-    sync::{Ref, RefBorrow},
+    sync::{Arc, ArcBorrow},
 };
 use alloc::boxed::Box;
 use core::{
@@ -104,22 +104,22 @@ impl<T: 'static> PointerWrapper for Box<T> {
     }
 }
 
-impl<T: 'static> PointerWrapper for Ref<T> {
-    type Borrowed<'a> = RefBorrow<'a, T>;
+impl<T: 'static> PointerWrapper for Arc<T> {
+    type Borrowed<'a> = ArcBorrow<'a, T>;
 
     fn into_pointer(self) -> *const core::ffi::c_void {
-        Ref::into_usize(self) as _
+        Arc::into_usize(self) as _
     }
 
-    unsafe fn borrow<'a>(ptr: *const core::ffi::c_void) -> RefBorrow<'a, T> {
+    unsafe fn borrow<'a>(ptr: *const core::ffi::c_void) -> ArcBorrow<'a, T> {
         // SAFETY: The safety requirements for this function ensure that the underlying object
         // remains valid for the lifetime of the returned value.
-        unsafe { Ref::borrow_usize(ptr as _) }
+        unsafe { Arc::borrow_usize(ptr as _) }
     }
 
     unsafe fn from_pointer(ptr: *const core::ffi::c_void) -> Self {
         // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
-        unsafe { Ref::from_usize(ptr as _) }
+        unsafe { Arc::from_usize(ptr as _) }
     }
 }
 
@@ -597,7 +597,7 @@ unsafe impl Bool for False {}
 /// [`ARef<T>`].
 ///
 /// This is usually implemented by wrappers to existing structures on the C side of the code. For
-/// Rust code, the recommendation is to use [`Ref`] to create reference-counted instances of a
+/// Rust code, the recommendation is to use [`Arc`] to create reference-counted instances of a
 /// type.
 ///
 /// # Safety


### PR DESCRIPTION
When `Ref` was first introduced, we still had `alloc`'s `Arc` being used in the codebase, so we chose a different name. Now that `Arc` is gone, we can reclaim the name, which is desirable because it is consistent with userspace.

This is a pure refactor with no functional changes intended.

Signed-off-by: Wedson Almeida Filho <wedsonaf@gmail.com>