### PR TITLE
rust: add initial netdevice support

### DIFF
--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -22,6 +22,7 @@
 #include <linux/irq.h>
 #include <linux/miscdevice.h>
 #include <linux/module.h>
+#include <linux/netdevice.h>
 #include <linux/netfilter_arp.h>
 #include <linux/netfilter.h>
 #include <linux/netfilter_ipv4.h>

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -23,6 +23,7 @@
 #include <linux/build_bug.h>
 #include <linux/clk.h>
 #include <linux/errname.h>
+#include <linux/etherdevice.h>
 #include <linux/fs_parser.h>
 #include <linux/gfp.h>
 #include <linux/highmem.h>
@@ -478,6 +479,12 @@ void *rust_helper_dev_get_drvdata(struct device *dev)
 }
 EXPORT_SYMBOL_GPL(rust_helper_dev_get_drvdata);
 
+void rust_helper_dev_set_drvdata(struct device *dev, void *data)
+{
+	dev_set_drvdata(dev, data);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dev_set_drvdata);
+
 const char *rust_helper_dev_name(const struct device *dev)
 {
 	return dev_name(dev);
@@ -654,6 +661,36 @@ int rust_helper_fs_parse(struct fs_context *fc,
 	return fs_parse(fc, desc, param, result);
 }
 EXPORT_SYMBOL_GPL(rust_helper_fs_parse);
+
+#ifdef CONFIG_NET
+void rust_helper_eth_hw_addr_set(struct net_device *dev, const u8 *addr)
+{
+	eth_hw_addr_set(dev, addr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_eth_hw_addr_set);
+
+void rust_helper_netif_start_queue(struct net_device *dev)
+{
+	netif_start_queue(dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_netif_start_queue);
+
+void rust_helper_netif_stop_queue(struct net_device *dev) {
+	netif_stop_queue(dev);
+}
+EXPORT_SYMBOL_GPL(rust_helper_netif_stop_queue);
+
+void rust_helper_netdev_sent_queue(struct net_device *dev, unsigned int bytes) {
+	return netdev_sent_queue(dev, bytes);
+}
+EXPORT_SYMBOL_GPL(rust_helper_netdev_sent_queue);
+
+struct sk_buff *rust_helper_netdev_alloc_skb_ip_align(struct net_device *dev,
+						      unsigned int length) {
+	return netdev_alloc_skb_ip_align(dev, length);
+}
+EXPORT_SYMBOL_GPL(rust_helper_netdev_alloc_skb_ip_align);
+#endif
 
 /*
  * We use `bindgen`'s `--size_t-is-usize` option to bind the C `size_t` type


### PR DESCRIPTION
Added minimum abstration APIs for network device drivers.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>