### PR TITLE
rust: add new api for initialization

### DIFF
--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -29,7 +29,7 @@ unsafe impl Sync for Context {}
 
 impl Context {
     pub(crate) fn new() -> Result<Arc<Self>> {
-        Arc::pin_init::<core::convert::Infallible>(pin_init!(Self {
+        Arc::pin_init(pin_init!(Self {
             manager: new_mutex!(
                 Manager {
                     node: None,

--- a/drivers/android/context.rs
+++ b/drivers/android/context.rs
@@ -17,7 +17,7 @@ struct Manager {
     uid: Option<bindings::kuid_t>,
 }
 
-#[pin_project]
+#[pin_data]
 pub(crate) struct Context {
     #[pin]
     manager: Mutex<Manager>,

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -56,7 +56,7 @@ struct NodeDeathInner {
     aborted: bool,
 }
 
-#[pin_project]
+#[pin_data]
 pub(crate) struct NodeDeath {
     node: Arc<Node>,
     process: Arc<Process>,

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -712,7 +712,7 @@ impl Process {
                     self.clone(),
                     cookie,
                 ))
-                .map_err(|(i, _)| i)?,
+                .unwrap_or_else(|(err, _)| match err {}),
         );
 
         info.death = Some(death.clone());

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -242,7 +242,7 @@ impl ProcessNodeRefs {
     }
 }
 
-#[pin_project]
+#[pin_data]
 pub(crate) struct Process {
     ctx: Arc<Context>,
 

--- a/drivers/android/process.rs
+++ b/drivers/android/process.rs
@@ -271,7 +271,7 @@ unsafe impl Sync for Process {}
 
 impl Process {
     fn new(ctx: Arc<Context>, cred: ARef<Credential>) -> Result<Arc<Self>> {
-        Arc::pin_init::<core::convert::Infallible>(pin_init!(Self {
+        Arc::pin_init(pin_init!(Self {
             ctx,
             cred,
             task: ARef::from(Task::current().group_leader()),

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -245,7 +245,7 @@ impl Thread {
     pub(crate) fn new(id: i32, process: Arc<Process>) -> Result<Arc<Self>> {
         let return_work = Arc::try_new(ThreadError::new(InnerThread::set_return_work))?;
         let reply_work = Arc::try_new(ThreadError::new(InnerThread::set_reply_work))?;
-        let thread = Arc::pin_init::<core::convert::Infallible>(pin_init!(Self {
+        let thread = Arc::pin_init(pin_init!(Self {
             id,
             process,
             inner: new_spinlock!(InnerThread::new(), "Thread::inner"),

--- a/drivers/android/thread.rs
+++ b/drivers/android/thread.rs
@@ -230,7 +230,7 @@ impl InnerThread {
     }
 }
 
-#[pin_project]
+#[pin_data]
 pub(crate) struct Thread {
     pub(crate) id: i32,
     pub(crate) process: Arc<Process>,

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -28,7 +28,7 @@ struct TransactionInner {
     file_list: List<Box<FileInfo>>,
 }
 
-#[pin_project(PinnedDrop)]
+#[pin_data(PinnedDrop)]
 pub(crate) struct Transaction {
     #[pin]
     inner: SpinLock<TransactionInner>,

--- a/drivers/android/transaction.rs
+++ b/drivers/android/transaction.rs
@@ -59,7 +59,7 @@ impl Transaction {
         let data_address = alloc.ptr;
         let file_list = alloc.take_file_list();
         alloc.keep_alive();
-        let tr = UniqueArc::pin_init::<core::convert::Infallible>(pin_init!(Self {
+        let tr = UniqueArc::pin_init(pin_init!(Self {
             inner: new_spinlock!(TransactionInner { file_list }, "Transaction::inner"),
             node_ref: Some(node_ref),
             stack_next,
@@ -86,7 +86,7 @@ impl Transaction {
         let data_address = alloc.ptr;
         let file_list = alloc.take_file_list();
         alloc.keep_alive();
-        let tr = UniqueArc::pin_init::<core::convert::Infallible>(pin_init!(Self {
+        let tr = UniqueArc::pin_init(pin_init!(Self {
             inner: new_spinlock!(TransactionInner { file_list }, "Transaction::inner"),
             node_ref: None,
             stack_next: None,

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -9,7 +9,7 @@ use crate::{clk::Clk, error::from_kernel_err_ptr};
 
 use crate::{
     bindings,
-    macros::pin_project,
+    macros::pin_data,
     pin_init,
     prelude::*,
     revocable::{Revocable, RevocableGuard},
@@ -249,7 +249,7 @@ impl Drop for Device {
 ///
 /// This struct implements the `DeviceRemoval` trait so that it can clean resources up even if not
 /// explicitly called by the device drivers.
-#[pin_project]
+#[pin_data]
 pub struct Data<T, U, V> {
     #[pin]
     registrations: RevocableMutex<T>,

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -283,7 +283,7 @@ impl<T, U, V> Data<T, U, V> {
         name: &'static CStr,
         key1: &'static LockClassKey,
     ) -> Result<Pin<UniqueArc<Self>>> {
-        UniqueArc::pin_init::<core::convert::Infallible>(pin_init!(Self {
+        UniqueArc::pin_init(pin_init!(Self {
             registrations: RevocableMutex::new(registrations, name, key1),
             resources: Revocable::new(resources),
             general,

--- a/rust/kernel/init.rs
+++ b/rust/kernel/init.rs
@@ -1,0 +1,863 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! API to safely and fallibly initialize pinned structs using in-place constructors.
+//!
+//! It also allows in-place initialization of big structs that would otherwise produce a stack overflow.
+//!
+//! Most structs from the [sync] module need to be pinned, because they contain self referential
+//! structs from C. [Pinning][pinning] is Rust's way of ensuring data does not move.
+//!
+//! # Overview
+//!
+//! To initialize a struct with an in-place constructor you will need two things:
+//! - an in-place constructor,
+//! - a memory location that can hold your struct (this can be the [stack], an [`Arc<T>`],
+//!   [`UniqueArc<T>`], [`Box<T>`] or any other smart pointer [^1]).
+//!
+//! To get an in-place constructor there are generally two options:
+//! - directly creating an in-place constructor,
+//! - a function/macro returning an in-place constructor.
+//!
+//! # Examples
+//!
+//! ## Directly creating an in-place constructor
+//!
+//! If you want to use [`PinInit`], then you will have to annotate your struct with [`#[pin_project]`].
+//! It is a macro that uses `#[pin]` as a marker for [structurally pinned fields].
+//!
+//! ```rust
+//! # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+//! use kernel::{prelude::*, sync::Mutex, new_mutex};
+//! # use core::pin::Pin;
+//! #[pin_project]
+//! struct Foo {
+//!     #[pin]
+//!     a: Mutex<usize>,
+//!     b: u32,
+//! }
+//!
+//! let foo = pin_init!(Foo {
+//!     a: new_mutex!(42, "Foo::a"),
+//!     b: 24,
+//! });
+//! # let foo: Result<Pin<Box<Foo>>> = Box::pin_init::<core::convert::Infallible>(foo);
+//! ```
+//!
+//! `foo` now is of the type `impl`[`PinInit<Foo>`]. We can now use any smart pointer that we like
+//! (or just the stack) to actually initialize a `Foo`:
+//!
+//! ```rust
+//! # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+//! # use kernel::{prelude::*, sync::Mutex, new_mutex};
+//! # use core::pin::Pin;
+//! # #[pin_project]
+//! # struct Foo {
+//! #     #[pin]
+//! #     a: Mutex<usize>,
+//! #     b: u32,
+//! # }
+//! # let foo = pin_init!(Foo {
+//! #     a: new_mutex!(42, "Foo::a"),
+//! #     b: 24,
+//! # });
+//! let foo: Result<Pin<Box<Foo>>> = Box::pin_init::<core::convert::Infallible>(foo);
+//! ```
+//!
+//! ## Using a function/macro that returns an initializer
+//!
+//! Many types from the kernel supply a function/macro that returns an initializer, because the
+//! above method only works for types where you can access the fields.
+//!
+//! ```rust
+//! # use kernel::{new_mutex, sync::{Arc, Mutex}};
+//! let mtx: Result<Arc<Mutex<usize>>> = Arc::pin_init(new_mutex!(42, "example::mtx"));
+//! ```
+//!
+//! To declare an init macro/function you just return an `impl`[`PinInit<T, E>`]:
+//! ```rust
+//! # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+//! # use kernel::{sync::Mutex, prelude::*, new_mutex, init::PinInit};
+//! #[pin_project]
+//! struct DriverData {
+//!     #[pin]
+//!     status: Mutex<i32>,
+//!     buffer: Box<[u8; 1_000_000]>,
+//! }
+//!
+//! impl DriverData {
+//!     fn new() -> impl PinInit<Self, Error> {
+//!         pin_init!(Self {
+//!             status: new_mutex!(0, "DriverData::status"),
+//!             buffer: Box::init(kernel::init::zeroed())?,
+//!         })
+//!     }
+//! }
+//! ```
+//!
+//!
+//! [^1]: That is not entirely true, only smart pointers that implement [`InPlaceInit`].
+//!
+//! [sync]: ../sync/index.html
+//! [pinning]: https://doc.rust-lang.org/std/pin/index.html
+//! [structurally pinned fields]: https://doc.rust-lang.org/std/pin/index.html#pinning-is-structural-for-field
+//! [stack]: crate::stack_init
+//! [`Arc<T>`]: crate::sync::Arc
+
+use crate::{
+    error::{self, Error},
+    sync::UniqueArc,
+};
+use alloc::boxed::Box;
+use core::{
+    convert::Infallible,
+    marker::{PhantomData, Unpin},
+    mem::MaybeUninit,
+    pin::Pin,
+    ptr,
+};
+
+#[doc(hidden)]
+pub mod __private;
+mod pin_project;
+mod pinned_drop;
+
+/// Initialize a type directly on the stack.
+///
+/// # Examples
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, stack_init, init::*, macros::pin_project, sync::Mutex, new_mutex};
+/// # use core::pin::Pin;
+/// #[pin_project]
+/// struct Foo {
+///     #[pin]
+///     a: Mutex<usize>,
+///     b: Bar,
+/// }
+///
+/// #[pin_project]
+/// struct Bar {
+///     x: u32,
+/// }
+///
+/// let a = new_mutex!(42, "Foo::a");
+///
+/// stack_init!(let foo = pin_init!(Foo {
+///     a,
+///     b: Bar {
+///         x: 64,
+///     },
+/// }));
+/// let foo: Result<Pin<&mut Foo>> = foo;
+/// ```
+#[macro_export]
+macro_rules! stack_init {
+    (let $var:ident = $val:expr) => {
+        let mut $var = $crate::init::__private::StackInit::uninit();
+        let val = $val;
+        let mut $var = unsafe { $crate::init::__private::StackInit::init(&mut $var, val) };
+    };
+    (let $var:ident $(: $t:ty)? =? $val:expr) => {
+        let mut $var = $crate::init::__private::StackInit$(::<$t>)?::uninit();
+        let val = $val;
+        let mut $var = unsafe { $crate::init::__private::StackInit::init(&mut $var, val)? };
+    };
+}
+
+/// Construct an in-place initializer for structs.
+///
+/// The syntax is identical to a normal struct initializer:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use core::pin::Pin;
+/// #[pin_project]
+/// struct Foo {
+///     a: usize,
+///     b: Bar,
+/// }
+///
+/// #[pin_project]
+/// struct Bar {
+///     x: u32,
+/// }
+///
+/// # fn demo() -> impl PinInit<Foo> {
+/// let a = 42;
+///
+/// let initializer = pin_init!(Foo {
+///     a,
+///     b: Bar {
+///         x: 64,
+///     },
+/// });
+/// # initializer }
+/// # Box::pin_init(demo()).unwrap();
+/// ```
+/// Arbitrary rust expressions can be used to set the value of a variable.
+///
+/// # Init-functions
+///
+/// When working with this library it is often desired to let others construct your types without
+/// giving access to all fields. This is where you would normally write a plain function `new`
+/// that would return a new instance of your type. With this library that is also possible, however
+/// there are a few extra things to keep in mind.
+///
+/// To create an initializer function, simple declare it like this:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, prelude::*, init::*};
+/// # use core::pin::Pin;
+/// # #[pin_project]
+/// # struct Foo {
+/// #     a: usize,
+/// #     b: Bar,
+/// # }
+/// # #[pin_project]
+/// # struct Bar {
+/// #     x: u32,
+/// # }
+///
+/// impl Foo {
+///     fn new() -> impl PinInit<Self> {
+///         pin_init!(Self {
+///             a: 42,
+///             b: Bar {
+///                 x: 64,
+///             },
+///         })
+///     }
+/// }
+/// ```
+///
+/// Users of `Foo` can now create it like this:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use core::pin::Pin;
+/// # #[pin_project]
+/// # struct Foo {
+/// #     a: usize,
+/// #     b: Bar,
+/// # }
+/// # #[pin_project]
+/// # struct Bar {
+/// #     x: u32,
+/// # }
+/// # impl Foo {
+/// #     fn new() -> impl PinInit<Self> {
+/// #         pin_init!(Self {
+/// #             a: 42,
+/// #             b: Bar {
+/// #                 x: 64,
+/// #             },
+/// #         })
+/// #     }
+/// # }
+/// let foo = Box::pin_init(Foo::new());
+/// ```
+///
+/// They can also easily embed it into their own `struct`s:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use core::pin::Pin;
+/// # #[pin_project]
+/// # struct Foo {
+/// #     a: usize,
+/// #     b: Bar,
+/// # }
+/// # #[pin_project]
+/// # struct Bar {
+/// #     x: u32,
+/// # }
+/// # impl Foo {
+/// #     fn new() -> impl PinInit<Self> {
+/// #         pin_init!(Self {
+/// #             a: 42,
+/// #             b: Bar {
+/// #                 x: 64,
+/// #             },
+/// #         })
+/// #     }
+/// # }
+/// #[pin_project]
+/// struct FooContainer {
+///     #[pin]
+///     foo1: Foo,
+///     #[pin]
+///     foo2: Foo,
+///     other: u32,
+/// }
+///
+/// impl FooContainer {
+///     fn new(other: u32) -> impl PinInit<Self> {
+///         pin_init!(Self {
+///             foo1: Foo::new(),
+///             foo2: Foo::new(),
+///             other,
+///         })
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! pin_init {
+    ($(&$this:ident in)? $t:ident $(<$($generics:ty),* $(,)?>)? {
+        $($field:ident $(: $val:expr)?),*
+        $(,)?
+    }) => {
+        $crate::pin_init!(@this($($this)?), @type_name($t $(<$($generics),*>)?), @typ($t $(<$($generics),*>)?), @fields($($field $(: $val)?),*))
+    };
+    (@this($($this:ident)?), @type_name($t:ident $(<$($generics:ty),*>)?), @typ($ty:ty), @fields($($field:ident $(: $val:expr)?),*)) => {{
+        // we do not want to allow arbitrary returns
+        struct __InitOk;
+        let init = move |slot: *mut $ty| -> ::core::result::Result<__InitOk, _> {
+            {
+                // shadow the structure so it cannot be used to return early
+                struct __InitOk;
+                $(let $this = unsafe { ::core::ptr::NonNull::new_unchecked(slot) };)?
+                $(
+                    $(let $field = $val;)?
+                    // call the initializer
+                    // SAFETY: slot is valid, because we are inside of an initializer closure, we return
+                    //         when an error/panic occurs.
+                    unsafe {
+                        <$ty as $crate::init::__private::__PinData>::__PinData::$field(
+                            ::core::ptr::addr_of_mut!((*slot).$field),
+                            $field,
+                        )?;
+                    }
+                    // create the drop guard
+                    // SAFETY: we forget the guard later when initialization has succeeded.
+                    let $field = unsafe { $crate::init::__private::DropGuard::new(::core::ptr::addr_of_mut!((*slot).$field)) };
+                    // only give access to &DropGuard, so it cannot be accidentally forgotten
+                    let $field = &$field;
+                )*
+                #[allow(unreachable_code, clippy::diverging_sub_expression)]
+                if false {
+                    let _: $t $(<$($generics),*>)? = $t {
+                        $($field: ::core::todo!()),*
+                    };
+                }
+                $(
+                    // forget each guard
+                    unsafe { $crate::init::__private::DropGuard::forget($field) };
+                )*
+            }
+            Ok(__InitOk)
+        };
+        let init = move |slot: *mut $ty| -> ::core::result::Result<(), _> {
+            init(slot).map(|__InitOk| ())
+        };
+        let init = unsafe { $crate::init::pin_init_from_closure::<$t $(<$($generics),*>)?, _>(init) };
+        init
+    }}
+}
+
+/// Construct an in-place initializer for structs.
+///
+/// The syntax is identical to a normal struct initializer:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, init::*};
+/// # use core::pin::Pin;
+/// struct Foo {
+///     a: usize,
+///     b: Bar,
+/// }
+///
+/// struct Bar {
+///     x: u32,
+/// }
+///
+/// # fn demo() -> impl Init<Foo> {
+/// let a = 42;
+///
+/// let initializer = init!(Foo {
+///     a,
+///     b: Bar {
+///         x: 64,
+///     },
+/// });
+/// # initializer }
+/// # Box::init(demo()).unwrap();
+/// ```
+///
+/// Arbitrary rust expressions can be used to set the value of a variable.
+///
+/// # Init-functions
+///
+/// When working with this library it is often desired to let others construct your types without
+/// giving access to all fields. This is where you would normally write a plain function `new`
+/// that would return a new instance of your type. With this library that is also possible, however
+/// there are a few extra things to keep in mind.
+///
+/// To create an initializer function, simple declare it like this:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, init::*};
+/// # use core::pin::Pin;
+/// # struct Foo {
+/// #     a: usize,
+/// #     b: Bar,
+/// # }
+/// # struct Bar {
+/// #     x: u32,
+/// # }
+///
+/// impl Foo {
+///     fn new() -> impl Init<Self> {
+///         init!(Self {
+///             a: 42,
+///             b: Bar {
+///                 x: 64,
+///             },
+///         })
+///     }
+/// }
+/// ```
+///
+/// Users of `Foo` can now create it like this:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, init::*};
+/// # use core::pin::Pin;
+/// # struct Foo {
+/// #     a: usize,
+/// #     b: Bar,
+/// # }
+/// # struct Bar {
+/// #     x: u32,
+/// # }
+/// # impl Foo {
+/// #     fn new() -> impl Init<Self> {
+/// #         init!(Self {
+/// #             a: 42,
+/// #             b: Bar {
+/// #                 x: 64,
+/// #             },
+/// #         })
+/// #     }
+/// # }
+/// let foo = Box::init(Foo::new());
+/// ```
+///
+/// They can also easily embed it into their own `struct`s:
+///
+/// ```rust
+/// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
+/// # use kernel::{init, pin_init, init::*};
+/// # use core::pin::Pin;
+/// # struct Foo {
+/// #     a: usize,
+/// #     b: Bar,
+/// # }
+/// # struct Bar {
+/// #     x: u32,
+/// # }
+/// # impl Foo {
+/// #     fn new() -> impl Init<Self> {
+/// #         init!(Self {
+/// #             a: 42,
+/// #             b: Bar {
+/// #                 x: 64,
+/// #             },
+/// #         })
+/// #     }
+/// # }
+/// struct FooContainer {
+///     foo1: Foo,
+///     foo2: Foo,
+///     other: u32,
+/// }
+///
+/// impl FooContainer {
+///     fn new(other: u32) -> impl Init<Self> {
+///         init!(Self {
+///             foo1: Foo::new(),
+///             foo2: Foo::new(),
+///             other,
+///         })
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! init {
+    ($t:ident $(<$($generics:ty),* $(,)?>)? {
+        $($field:ident $(: $val:expr)?),*
+        $(,)?
+    }) => {{
+        // we do not want to allow arbitrary returns
+        struct __InitOk;
+        let init = move |slot: *mut $t $(<$($generics),*>)?| -> ::core::result::Result<__InitOk, _> {
+            {
+                // shadow the structure so it cannot be used to return early
+                struct __InitOk;
+                $(
+                    $(let $field = $val;)?
+                    // call the initializer
+                    // SAFETY: slot is valid, because we are inside of an initializer closure, we return
+                    //         when an error/panic occurs.
+                    unsafe { $crate::init::__private::__InitImpl::__init($field, ::core::ptr::addr_of_mut!((*slot).$field))? };
+                    // create the drop guard
+                    // SAFETY: we forget the guard later when initialization has succeeded.
+                    let $field = unsafe { $crate::init::__private::DropGuard::new(::core::ptr::addr_of_mut!((*slot).$field)) };
+                    // only give access to &DropGuard, so it cannot be accidentally forgotten
+                    let $field = &$field;
+                )*
+                #[allow(unreachable_code, clippy::diverging_sub_expression)]
+                if false {
+                    let _: $t $(<$($generics),*>)? = $t {
+                        $($field: ::core::todo!()),*
+                    };
+                }
+                $(
+                    // forget each guard
+                    unsafe { $crate::init::__private::DropGuard::forget($field) };
+                )*
+            }
+            Ok(__InitOk)
+        };
+        let init = move |slot: *mut $t $(<$($generics),*>)?| -> ::core::result::Result<(), _> {
+            init(slot).map(|__InitOk| ())
+        };
+        let init = unsafe { $crate::init::init_from_closure::<$t $(<$($generics),*>)?, _>(init) };
+        init
+    }}
+}
+
+/// A pinned initializer for `T`.
+///
+/// To use this initializer, you will need a suitable memory location that can hold a `T`. This can
+/// be [`Box<T>`], [`Arc<T>`], [`UniqueArc<T>`], or even the stack (see [`stack_init!`]). Use the
+/// `pin_init` function of a smart pointer like [`Arc::pin_init`] on this.
+///
+/// Also see the [module description](self).
+///
+/// # Safety
+///
+/// When implementing this type you will need to take great care. Also there are probably very few
+/// cases where a manual implementation is necessary. Use [`from_value`] and
+/// [`pin_init_from_closure`] where possible.
+///
+/// The [`PinInit::__pinned_init`] function
+/// - returns `Ok(())` iff it initialized every field of slot,
+/// - returns `Err(err)` iff it encountered an error and then cleaned slot, this means:
+///     - slot can be deallocated without UB ocurring,
+///     - slot does not need to be dropped,
+///     - slot is not partially initialized.
+///
+/// [`Arc<T>`]: crate::sync::Arc
+/// [`Arc::pin_init`]: crate::sync::Arc::pin_init
+#[must_use = "An initializer must be used in order to create its value."]
+pub unsafe trait PinInit<T, E = Infallible>: Sized {
+    /// Initializes `slot`.
+    ///
+    /// # Safety
+    ///
+    /// `slot` is a valid pointer to uninitialized memory.
+    /// The caller does not touch `slot` when `Err` is returned, they are only permitted to
+    /// deallocate.
+    /// The slot will not move, i.e. it will be pinned.
+    unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E>;
+}
+
+/// An initializer for `T`.
+///
+/// To use this initializer, you will need a suitable memory location that can hold a `T`. This can
+/// be [`Box<T>`], [`Arc<T>`], [`UniqueArc<T>`], or even the stack (see [`stack_init!`]). Use the
+/// `init` function of a smart pointer like [`Box::init`] on this. Because [`PinInit<T, E>`] is a
+/// super trait, you can use every function that takes it as well.
+///
+/// Also see the [module description](self).
+///
+/// # Safety
+///
+/// When implementing this type you will need to take great care. Also there are probably very few
+/// cases where a manual implementation is necessary. Use [`from_value`] and
+/// [`init_from_closure`] where possible.
+///
+/// The [`Init::__init`] function
+/// - returns `Ok(())` iff it initialized every field of slot,
+/// - returns `Err(err)` iff it encountered an error and then cleaned slot, this means:
+///     - slot can be deallocated without UB ocurring,
+///     - slot does not need to be dropped,
+///     - slot is not partially initialized.
+///
+/// The `__pinned_init` function from the supertrait [`PinInit`] needs to exectute the exact same
+/// code as `__init`.
+///
+/// Contrary to its supertype [`PinInit<T, E>`] the caller is allowed to
+/// move the pointee after initialization.
+///
+/// [`Arc<T>`]: crate::sync::Arc
+#[must_use = "An initializer must be used in order to create its value."]
+pub unsafe trait Init<T, E = Infallible>: PinInit<T, E> {
+    /// Initializes `slot`.
+    ///
+    /// # Safety
+    ///
+    /// `slot` is a valid pointer to uninitialized memory.
+    /// The caller does not touch `slot` when `Err` is returned, they are only permitted to
+    /// deallocate.
+    unsafe fn __init(self, slot: *mut T) -> Result<(), E>;
+}
+
+type Invariant<T> = PhantomData<fn(T) -> T>;
+
+struct InitClosure<F, T, E>(F, Invariant<(T, E)>);
+
+unsafe impl<T, F, E> PinInit<T, E> for InitClosure<F, T, E>
+where
+    F: FnOnce(*mut T) -> Result<(), E>,
+{
+    #[inline]
+    unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
+        (self.0)(slot)
+    }
+}
+
+unsafe impl<T, F, E> Init<T, E> for InitClosure<F, T, E>
+where
+    F: FnOnce(*mut T) -> Result<(), E>,
+{
+    #[inline]
+    unsafe fn __init(self, slot: *mut T) -> Result<(), E> {
+        (self.0)(slot)
+    }
+}
+
+/// Creates a new [`Init<T, E>`] from the given closure.
+///
+/// # Safety
+///
+/// The closure
+/// - returns `Ok(())` iff it initialized every field of slot,
+/// - returns `Err(err)` iff it encountered an error and then cleaned slot, this means:
+///     - slot can be deallocated without UB ocurring,
+///     - slot does not need to be dropped,
+///     - slot is not partially initialized.
+/// - slot may move after initialization
+#[inline]
+pub const unsafe fn init_from_closure<T, E>(
+    f: impl FnOnce(*mut T) -> Result<(), E>,
+) -> impl Init<T, E> {
+    InitClosure(f, PhantomData)
+}
+
+/// Creates a new [`PinInit<T, E>`] from the given closure.
+///
+/// # Safety
+///
+/// The closure
+/// - returns `Ok(())` iff it initialized every field of slot,
+/// - returns `Err(err)` iff it encountered an error and then cleaned slot, this means:
+///     - slot can be deallocated without UB ocurring,
+///     - slot does not need to be dropped,
+///     - slot is not partially initialized.
+/// - may assume that the slot does not move if `T: !Unpin`
+#[inline]
+pub const unsafe fn pin_init_from_closure<T, E>(
+    f: impl FnOnce(*mut T) -> Result<(), E>,
+) -> impl PinInit<T, E> {
+    InitClosure(f, PhantomData)
+}
+
+/// Trait facilitating pinned destruction.
+///
+/// Use [`pinned_drop`] to implement this trait safely:
+/// ```rust
+/// # use kernel::sync::Mutex;
+/// use kernel::macros::pinned_drop;
+/// #[pin_project(PinnedDrop)]
+/// struct Foo {
+///     #[pin]
+///     mtx: Mutex<usize>,
+/// }
+///
+/// #[pinned_drop]
+/// impl PinnedDrop for Foo {
+///     fn drop(self: Pin<&mut Self>) {
+///         pr_info!("Foo is being dropped!");
+///     }
+/// }
+/// ```
+///
+/// # Safety
+///
+/// This trait must be implemented with [`pinned_drop`].
+///
+/// [`pinned_drop`]: kernel::macros::pinned_drop
+pub unsafe trait PinnedDrop {
+    /// Executes the pinned destructor of this type.
+    ///
+    /// # Safety
+    ///
+    /// Only call this from `<Self as Drop>::drop`.
+    unsafe fn drop(self: Pin<&mut Self>);
+
+    // used by `pinned_drop` to ensure that only safe operations are used in `drop`.
+    #[doc(hidden)]
+    fn __ensure_no_unsafe_op_in_drop(self: Pin<&mut Self>);
+}
+
+/// Smart pointer that can initialize memory in-place.
+pub trait InPlaceInit<T>: Sized {
+    /// Use the given initializer to in-place initialize a `T`.
+    ///
+    /// If `T: !Unpin` it will not be able to move afterwards.
+    fn pin_init<E>(init: impl PinInit<T, E>) -> error::Result<Pin<Self>>
+    where
+        Error: From<E>;
+
+    /// Use the given initializer to in-place initialize a `T`.
+    fn init<E>(init: impl Init<T, E>) -> error::Result<Self>
+    where
+        Error: From<E>;
+}
+
+impl<T> InPlaceInit<T> for Box<T> {
+    #[inline]
+    fn pin_init<E>(init: impl PinInit<T, E>) -> error::Result<Pin<Self>>
+    where
+        Error: From<E>,
+    {
+        let mut this = Box::try_new_uninit()?;
+        let slot = this.as_mut_ptr();
+        // SAFETY: when init errors/panics, slot will get deallocated but not dropped,
+        // slot is valid and will not be moved because of the `Pin::new_unchecked`
+        unsafe { init.__pinned_init(slot)? };
+        // SAFETY: all fields have been initialized
+        Ok(unsafe { Pin::new_unchecked(this.assume_init()) })
+    }
+
+    #[inline]
+    fn init<E>(init: impl Init<T, E>) -> error::Result<Self>
+    where
+        Error: From<E>,
+    {
+        let mut this = Box::try_new_uninit()?;
+        let slot = this.as_mut_ptr();
+        // SAFETY: when init errors/panics, slot will get deallocated but not dropped,
+        // slot is valid
+        unsafe { init.__init(slot)? };
+        // SAFETY: all fields have been initialized
+        Ok(unsafe { this.assume_init() })
+    }
+}
+
+impl<T> InPlaceInit<T> for UniqueArc<T> {
+    #[inline]
+    fn pin_init<E>(init: impl PinInit<T, E>) -> error::Result<Pin<Self>>
+    where
+        Error: From<E>,
+    {
+        let mut this = UniqueArc::try_new_uninit()?;
+        let slot = this.as_mut_ptr();
+        // SAFETY: when init errors/panics, slot will get deallocated but not dropped,
+        // slot is valid and will not be moved because of the `Pin::new_unchecked`
+        unsafe { init.__pinned_init(slot)? };
+        // SAFETY: all fields have been initialized
+        Ok(unsafe { Pin::new_unchecked(this.assume_init()) })
+    }
+
+    #[inline]
+    fn init<E>(init: impl Init<T, E>) -> error::Result<Self>
+    where
+        Error: From<E>,
+    {
+        let mut this = UniqueArc::try_new_uninit()?;
+        let slot = this.as_mut_ptr();
+        // SAFETY: when init errors/panics, slot will get deallocated but not dropped,
+        // slot is valid
+        unsafe { init.__init(slot)? };
+        // SAFETY: all fields have been initialized
+        Ok(unsafe { this.assume_init() })
+    }
+}
+
+/// Marker trait for types that can be initialized by writing just zeroes.
+///
+/// # Safety
+///
+/// The bit pattern consisting of only zeroes must be a valid bit pattern for the type.
+pub unsafe trait Zeroable {}
+
+/// Create a new zeroed T.
+///
+/// The returned initializer will write `0x00` to every byte of the given slot.
+#[inline]
+pub fn zeroed<T: Zeroable + Unpin>() -> impl Init<T> {
+    // SAFETY: because `T: Zeroable`, all bytes zero is a valid bit pattern for `T`
+    //         and because we write all zeroes, the memory is initialized.
+    unsafe {
+        init_from_closure(|slot: *mut T| {
+            slot.write_bytes(0, 1);
+            Ok(())
+        })
+    }
+}
+
+/// An initializer that leaves the memory uninitialized.
+///
+/// The initializer is a no-op. The slot memory is not changed.
+#[inline]
+pub fn uninit<T>() -> impl Init<MaybeUninit<T>> {
+    // SAFETY: The memory is allowed to be uninitialized.
+    unsafe { init_from_closure(|_| Ok(())) }
+}
+
+/// Convert a value into an initializer.
+///
+/// Directly moves the value into the given slot.
+#[inline]
+pub fn from_value<T>(value: T) -> impl Init<T> {
+    // SAFETY: we use the value to initialize the slot.
+    unsafe {
+        init_from_closure(move |slot: *mut T| {
+            slot.write(value);
+            Ok(())
+        })
+    }
+}
+
+macro_rules! impl_zeroable {
+    ($($t:ty),*) => {
+        $(unsafe impl Zeroable for $t {})*
+    };
+}
+// All primitives that are allowed to be zero.
+impl_zeroable!(
+    bool, char, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64
+);
+// There is nothing to zero.
+impl_zeroable!(core::marker::PhantomPinned, Infallible, ());
+
+// We are allowed to zero padding bytes.
+unsafe impl<const N: usize, T: Zeroable> Zeroable for [T; N] {}
+
+// There is nothing to zero.
+unsafe impl<T: ?Sized> Zeroable for PhantomData<T> {}
+
+// `null` pointer is valid.
+unsafe impl<T: ?Sized> Zeroable for *mut T {}
+unsafe impl<T: ?Sized> Zeroable for *const T {}
+
+macro_rules! impl_tuple_zeroable {
+    ($(,)?) => {};
+    ($first:ident, $($t:ident),* $(,)?) => {
+        // all elements are zeroable and padding can be zero
+        unsafe impl<$first: Zeroable, $($t: Zeroable),*> Zeroable for ($first, $($t),*) {}
+        impl_tuple_zeroable!($($t),* ,);
+    }
+}
+
+impl_tuple_zeroable!(A, B, C, D, E, F, G, H, I, J);

--- a/rust/kernel/init.rs
+++ b/rust/kernel/init.rs
@@ -117,6 +117,7 @@ use core::{
 
 #[doc(hidden)]
 pub mod __private;
+pub mod common;
 mod pin_project;
 mod pinned_drop;
 

--- a/rust/kernel/init.rs
+++ b/rust/kernel/init.rs
@@ -22,14 +22,14 @@
 //!
 //! ## Directly creating an in-place constructor
 //!
-//! If you want to use [`PinInit`], then you will have to annotate your struct with [`#[pin_project]`].
+//! If you want to use [`PinInit`], then you will have to annotate your struct with [`#[pin_data]`].
 //! It is a macro that uses `#[pin]` as a marker for [structurally pinned fields].
 //!
 //! ```rust
 //! # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
 //! use kernel::{prelude::*, sync::Mutex, new_mutex};
 //! # use core::pin::Pin;
-//! #[pin_project]
+//! #[pin_data]
 //! struct Foo {
 //!     #[pin]
 //!     a: Mutex<usize>,
@@ -49,7 +49,7 @@
 //! # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
 //! # use kernel::{prelude::*, sync::Mutex, new_mutex};
 //! # use core::pin::Pin;
-//! # #[pin_project]
+//! # #[pin_data]
 //! # struct Foo {
 //! #     #[pin]
 //! #     a: Mutex<usize>,
@@ -76,7 +76,7 @@
 //! ```rust
 //! # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
 //! # use kernel::{sync::Mutex, prelude::*, new_mutex, init::PinInit, try_pin_init};
-//! #[pin_project]
+//! #[pin_data]
 //! struct DriverData {
 //!     #[pin]
 //!     status: Mutex<i32>,
@@ -118,7 +118,7 @@ use core::{
 #[doc(hidden)]
 pub mod __private;
 pub mod common;
-mod pin_project;
+mod pin_data;
 mod pinned_drop;
 
 /// Initialize a type directly on the stack.
@@ -127,16 +127,16 @@ mod pinned_drop;
 ///
 /// ```rust
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
-/// # use kernel::{init, pin_init, stack_init, init::*, macros::pin_project, sync::Mutex, new_mutex};
+/// # use kernel::{init, pin_init, stack_init, init::*, macros::pin_data, sync::Mutex, new_mutex};
 /// # use core::pin::Pin;
-/// #[pin_project]
+/// #[pin_data]
 /// struct Foo {
 ///     #[pin]
 ///     a: Mutex<usize>,
 ///     b: Bar,
 /// }
 ///
-/// #[pin_project]
+/// #[pin_data]
 /// struct Bar {
 ///     x: u32,
 /// }
@@ -175,15 +175,15 @@ macro_rules! stack_init {
 ///
 /// ```rust
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
-/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use kernel::{init, pin_init, macros::pin_data, init::*};
 /// # use core::pin::Pin;
-/// #[pin_project]
+/// #[pin_data]
 /// struct Foo {
 ///     a: usize,
 ///     b: Bar,
 /// }
 ///
-/// #[pin_project]
+/// #[pin_data]
 /// struct Bar {
 ///     x: u32,
 /// }
@@ -215,12 +215,12 @@ macro_rules! stack_init {
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
 /// # use kernel::{init, pin_init, prelude::*, init::*};
 /// # use core::pin::Pin;
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Foo {
 /// #     a: usize,
 /// #     b: Bar,
 /// # }
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Bar {
 /// #     x: u32,
 /// # }
@@ -241,14 +241,14 @@ macro_rules! stack_init {
 ///
 /// ```rust
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
-/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use kernel::{init, pin_init, macros::pin_data, init::*};
 /// # use core::pin::Pin;
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Foo {
 /// #     a: usize,
 /// #     b: Bar,
 /// # }
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Bar {
 /// #     x: u32,
 /// # }
@@ -269,14 +269,14 @@ macro_rules! stack_init {
 ///
 /// ```rust
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
-/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use kernel::{init, pin_init, macros::pin_data, init::*};
 /// # use core::pin::Pin;
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Foo {
 /// #     a: usize,
 /// #     b: Bar,
 /// # }
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Bar {
 /// #     x: u32,
 /// # }
@@ -290,7 +290,7 @@ macro_rules! stack_init {
 /// #         })
 /// #     }
 /// # }
-/// #[pin_project]
+/// #[pin_data]
 /// struct FooContainer {
 ///     #[pin]
 ///     foo1: Foo,
@@ -337,15 +337,15 @@ macro_rules! pin_init {
 ///
 /// ```rust
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
-/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use kernel::{init, pin_init, macros::pin_data, init::*};
 /// # use core::pin::Pin;
-/// #[pin_project]
+/// #[pin_data]
 /// struct Foo {
 ///     a: usize,
 ///     b: Bar,
 /// }
 ///
-/// #[pin_project]
+/// #[pin_data]
 /// struct Bar {
 ///     x: u32,
 /// }
@@ -377,12 +377,12 @@ macro_rules! pin_init {
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
 /// # use kernel::{init, pin_init, prelude::*, init::*};
 /// # use core::pin::Pin;
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Foo {
 /// #     a: usize,
 /// #     b: Bar,
 /// # }
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Bar {
 /// #     x: u32,
 /// # }
@@ -403,14 +403,14 @@ macro_rules! pin_init {
 ///
 /// ```rust
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
-/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use kernel::{init, pin_init, macros::pin_data, init::*};
 /// # use core::pin::Pin;
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Foo {
 /// #     a: usize,
 /// #     b: Bar,
 /// # }
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Bar {
 /// #     x: u32,
 /// # }
@@ -431,14 +431,14 @@ macro_rules! pin_init {
 ///
 /// ```rust
 /// # #![allow(clippy::disallowed_names, clippy::new_ret_no_self)]
-/// # use kernel::{init, pin_init, macros::pin_project, init::*};
+/// # use kernel::{init, pin_init, macros::pin_data, init::*};
 /// # use core::pin::Pin;
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Foo {
 /// #     a: usize,
 /// #     b: Bar,
 /// # }
-/// # #[pin_project]
+/// # #[pin_data]
 /// # struct Bar {
 /// #     x: u32,
 /// # }
@@ -452,7 +452,7 @@ macro_rules! pin_init {
 /// #         })
 /// #     }
 /// # }
-/// #[pin_project]
+/// #[pin_data]
 /// struct FooContainer {
 ///     #[pin]
 ///     foo1: Foo,
@@ -1050,7 +1050,7 @@ pub const unsafe fn pin_init_from_closure<T, E>(
 /// ```rust
 /// # use kernel::sync::Mutex;
 /// use kernel::macros::pinned_drop;
-/// #[pin_project(PinnedDrop)]
+/// #[pin_data(PinnedDrop)]
 /// struct Foo {
 ///     #[pin]
 ///     mtx: Mutex<usize>,

--- a/rust/kernel/init.rs
+++ b/rust/kernel/init.rs
@@ -153,8 +153,8 @@ mod pinned_drop;
 /// ```
 #[macro_export]
 macro_rules! stack_init {
-    (let $var:ident = $val:expr) => {
-        let mut $var = $crate::init::__private::StackInit::uninit();
+    (let $var:ident $(: $t:ty)? = $val:expr) => {
+        let mut $var = $crate::init::__private::StackInit$(::<$t>)?::uninit();
         let val = $val;
         let mut $var = unsafe { $crate::init::__private::StackInit::init(&mut $var, val) };
     };

--- a/rust/kernel/init/__private.rs
+++ b/rust/kernel/init/__private.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Workaround for specialization
+
+use super::*;
+use core::cell::Cell;
+
+mod sealed {
+    use super::*;
+    pub trait Sealed {}
+
+    impl Sealed for Direct {}
+    impl Sealed for Closure {}
+}
+
+pub trait InitWay: sealed::Sealed {}
+
+impl InitWay for Direct {}
+impl InitWay for Closure {}
+
+pub struct Direct;
+pub struct Closure;
+
+/// # Safety
+/// Same as [`PinInit`]
+pub unsafe trait __PinInitImpl<T: ?Sized, E, W: InitWay> {
+    /// # Safety
+    /// Same as [`PinInit::__pinned_init`]
+    unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E>;
+}
+
+/// # Safety
+/// Same as [`Init`]
+pub unsafe trait __InitImpl<T: ?Sized, E, W: InitWay>: __PinInitImpl<T, E, W> {
+    /// # Safety
+    /// Same as [`Init::__init`]
+    unsafe fn __init(self, slot: *mut T) -> Result<(), E>;
+}
+
+/// # Safety
+/// Only implemented by pin_data!
+pub unsafe trait __PinData {
+    type __PinData;
+}
+
+unsafe impl<T> __PinInitImpl<T, Infallible, Direct> for T {
+    #[inline]
+    unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), Infallible> {
+        // SAFETY: pointer valid as per function contract
+        unsafe { slot.write(self) };
+        Ok(())
+    }
+}
+
+unsafe impl<T> __InitImpl<T, Infallible, Direct> for T {
+    #[inline]
+    unsafe fn __init(self, slot: *mut T) -> Result<(), Infallible> {
+        // SAFETY: pointer valid as per function contract
+        unsafe { slot.write(self) };
+        Ok(())
+    }
+}
+
+unsafe impl<I, T, E> __InitImpl<T, E, Closure> for I
+where
+    I: Init<T, E>,
+{
+    #[inline]
+    unsafe fn __init(self, slot: *mut T) -> Result<(), E> {
+        unsafe { Init::__init(self, slot) }
+    }
+}
+
+unsafe impl<I, T, E> __PinInitImpl<T, E, Closure> for I
+where
+    I: PinInit<T, E>,
+{
+    #[inline]
+    unsafe fn __pinned_init(self, slot: *mut T) -> Result<(), E> {
+        unsafe { PinInit::__pinned_init(self, slot) }
+    }
+}
+
+/// When a value of this type is dropped, it drops something else.
+pub struct DropGuard<T: ?Sized>(*mut T, Cell<bool>);
+
+impl<T: ?Sized> DropGuard<T> {
+    /// Creates a new [`DropGuard<T>`]. It will [`ptr::drop_in_place`] `ptr` when it gets dropped.
+    ///
+    /// # Safety
+    /// `ptr` must be a valid poiner.
+    ///
+    /// It is the callers responsibility that `self` will only get dropped if the pointee of `ptr`:
+    /// - has not been dropped,
+    /// - is not accesible by any other means,
+    /// - will not be dropped by any other means.
+    #[inline]
+    pub unsafe fn new(ptr: *mut T) -> Self {
+        Self(ptr, Cell::new(true))
+    }
+
+    #[inline]
+    pub unsafe fn forget(&self) {
+        self.1.set(false);
+    }
+}
+
+impl<T: ?Sized> Drop for DropGuard<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.1.get() {
+            // SAFETY: safe as a `DropGuard` can only be constructed using the unsafe new function.
+            unsafe { ptr::drop_in_place(self.0) }
+        }
+    }
+}
+
+/// Stack initializer helper type. See [`stack_init`].
+///
+/// [`stack_init`]: kernel::stack_init
+pub struct StackInit<T>(MaybeUninit<T>, bool);
+
+impl<T> Drop for StackInit<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.1 {
+            unsafe { self.0.assume_init_drop() };
+        }
+    }
+}
+impl<T> StackInit<T> {
+    #[inline]
+    pub fn uninit() -> Self {
+        Self(MaybeUninit::uninit(), false)
+    }
+
+    /// # Safety
+    /// The caller ensures that `self` is on the stack and not accesible to **any** other code.
+    #[inline]
+    pub unsafe fn init<E>(&mut self, init: impl PinInit<T, E>) -> Result<Pin<&mut T>, E> {
+        unsafe { init.__pinned_init(self.0.as_mut_ptr()) }?;
+        self.1 = true;
+        Ok(unsafe { Pin::new_unchecked(self.0.assume_init_mut()) })
+    }
+}

--- a/rust/kernel/init/common.rs
+++ b/rust/kernel/init/common.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Module containing common kernel initializer functions.
+
+use crate::{
+    init::{self, PinInit},
+    Opaque,
+};
+
+macro_rules! create_func {
+    ($name:ident $(, $arg_name:ident: $arg_typ:ident)*) => {
+        /// Create an initializer using the given initalizer function from C.
+        ///
+        /// # Safety
+        /// The given function **must** under all circumstances initialize the memory location to a valid
+        /// `T`. If it fails to do so it results in UB.
+        ///
+        /// If any parameters are given, those need to be valid for the function. Valid means that
+        /// calling the function with those parameters complies with the above requirement **and** every
+        /// other requirement on the function itself.
+        pub unsafe fn $name<T $(, $arg_typ)*>(init_func: unsafe extern "C" fn(*mut T $(, $arg_name: $arg_typ)*) $(, $arg_name: $arg_typ)*) -> impl PinInit<Opaque<T>> {
+            unsafe {
+                init::pin_init_from_closure(move |slot| {
+                    init_func(Opaque::raw_get(slot) $(, $arg_name)*);
+                    Ok(())
+                })
+            }
+        }
+    }
+}
+
+create_func!(ffi_init);
+create_func!(ffi_init1, arg1: A1);
+create_func!(ffi_init2, arg1: A1, arg2: A2);
+create_func!(ffi_init3, arg1: A1, arg2: A2, arg3: A3);
+create_func!(ffi_init4, arg1: A1, arg2: A2, arg3: A3, arg4: A4);

--- a/rust/kernel/init/pin_data.rs
+++ b/rust/kernel/init/pin_data.rs
@@ -3,7 +3,7 @@
 // use the proc macro instead
 #[doc(hidden)]
 #[macro_export]
-macro_rules! pin_project {
+macro_rules! _pin_data {
     (parse_input:
         @args($($pinned_drop:ident)?),
         @sig(
@@ -15,7 +15,7 @@ macro_rules! pin_project {
         @ty_generics($($ty_generics:tt)*),
         @body({ $($fields:tt)* }),
     ) => {
-        $crate::pin_project!(find_pinned_fields:
+        $crate::_pin_data!(find_pinned_fields:
             @struct_attrs($(#[$($struct_attr)*])*),
             @vis($vis),
             @name($name),
@@ -46,7 +46,7 @@ macro_rules! pin_project {
         @is_pinned(yes),
         @pinned_drop($($pinned_drop:ident)?),
     ) => {
-        $crate::pin_project!(find_pinned_fields:
+        $crate::_pin_data!(find_pinned_fields:
             @struct_attrs($($struct_attrs)*),
             @vis($vis),
             @name($name),
@@ -77,7 +77,7 @@ macro_rules! pin_project {
         @is_pinned(),
         @pinned_drop($($pinned_drop:ident)?),
     ) => {
-        $crate::pin_project!(find_pinned_fields:
+        $crate::_pin_data!(find_pinned_fields:
             @struct_attrs($($struct_attrs)*),
             @vis($vis),
             @name($name),
@@ -108,7 +108,7 @@ macro_rules! pin_project {
         @is_pinned($($is_pinned:ident)?),
         @pinned_drop($($pinned_drop:ident)?),
     ) => {
-        $crate::pin_project!(find_pinned_fields:
+        $crate::_pin_data!(find_pinned_fields:
             @struct_attrs($($struct_attrs)*),
             @vis($vis),
             @name($name),
@@ -139,7 +139,7 @@ macro_rules! pin_project {
         @is_pinned($($is_pinned:ident)?),
         @pinned_drop($($pinned_drop:ident)?),
     ) => {
-        $crate::pin_project!(find_pinned_fields:
+        $crate::_pin_data!(find_pinned_fields:
             @struct_attrs($($struct_attrs)*),
             @vis($vis),
             @name($name),
@@ -170,7 +170,7 @@ macro_rules! pin_project {
         @is_pinned($($is_pinned:ident)?),
         @pinned_drop($($pinned_drop:ident)?),
     ) => {
-        $crate::pin_project!(find_pinned_fields:
+        $crate::_pin_data!(find_pinned_fields:
             @struct_attrs($($struct_attrs)*),
             @vis($vis),
             @name($name),
@@ -215,7 +215,7 @@ macro_rules! pin_project {
                 __phantom: ::core::marker::PhantomData<fn($name<$($ty_generics)*>) -> $name<$($ty_generics)*>>,
             }
 
-            $crate::pin_project!(make_pin_data:
+            $crate::_pin_data!(make_pin_data:
                 @pin_data(__ThePinData),
                 @impl_generics($($impl_generics)*),
                 @ty_generics($($ty_generics)*),
@@ -246,7 +246,7 @@ macro_rules! pin_project {
                 $($whr)*
             {}
 
-            $crate::pin_project!(drop_prevention:
+            $crate::_pin_data!(drop_prevention:
                 @name($name),
                 @impl_generics($($impl_generics)*),
                 @ty_generics($($ty_generics)*),

--- a/rust/kernel/init/pin_project.rs
+++ b/rust/kernel/init/pin_project.rs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: GPL-2.0
+
+// use the proc macro instead
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pin_project {
+    (parse_input:
+        @args($($pinned_drop:ident)?),
+        @sig(
+            $(#[$($struct_attr:tt)*])*
+            $vis:vis struct $name:ident
+            $(where $($whr:tt)*)?
+        ),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @body({ $($fields:tt)* }),
+    ) => {
+        $crate::pin_project!(find_pinned_fields:
+            @struct_attrs($(#[$($struct_attr)*])*),
+            @vis($vis),
+            @name($name),
+            @impl_generics($($impl_generics)*),
+            @ty_generics($($ty_generics)*),
+            @where($($($whr)*)?),
+            @fields_munch($($fields)*),
+            @pinned(),
+            @not_pinned(),
+            @fields(),
+            @accum(),
+            @is_pinned(),
+            @pinned_drop($($pinned_drop)?),
+        );
+    };
+    (find_pinned_fields:
+        @struct_attrs($($struct_attrs:tt)*),
+        @vis($vis:vis),
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @fields_munch($field:ident : $type:ty, $($rest:tt)*),
+        @pinned($($pinned:tt)*),
+        @not_pinned($($not_pinned:tt)*),
+        @fields($($fields:tt)*),
+        @accum($($accum:tt)*),
+        @is_pinned(yes),
+        @pinned_drop($($pinned_drop:ident)?),
+    ) => {
+        $crate::pin_project!(find_pinned_fields:
+            @struct_attrs($($struct_attrs)*),
+            @vis($vis),
+            @name($name),
+            @impl_generics($($impl_generics)*),
+            @ty_generics($($ty_generics)*),
+            @where($($whr)*),
+            @fields_munch($($rest)*),
+            @pinned($($pinned)* $($accum)* $field: $type,),
+            @not_pinned($($not_pinned)*),
+            @fields($($fields)* $($accum)* $field: $type,),
+            @accum(),
+            @is_pinned(),
+            @pinned_drop($($pinned_drop)?),
+        );
+    };
+    (find_pinned_fields:
+        @struct_attrs($($struct_attrs:tt)*),
+        @vis($vis:vis),
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @fields_munch($field:ident : $type:ty, $($rest:tt)*),
+        @pinned($($pinned:tt)*),
+        @not_pinned($($not_pinned:tt)*),
+        @fields($($fields:tt)*),
+        @accum($($accum:tt)*),
+        @is_pinned(),
+        @pinned_drop($($pinned_drop:ident)?),
+    ) => {
+        $crate::pin_project!(find_pinned_fields:
+            @struct_attrs($($struct_attrs)*),
+            @vis($vis),
+            @name($name),
+            @impl_generics($($impl_generics)*),
+            @ty_generics($($ty_generics)*),
+            @where($($whr)*),
+            @fields_munch($($rest)*),
+            @pinned($($pinned)*),
+            @not_pinned($($not_pinned)* $($accum)* $field: $type,),
+            @fields($($fields)* $($accum)* $field: $type,),
+            @accum(),
+            @is_pinned(),
+            @pinned_drop($($pinned_drop)?),
+        );
+    };
+    (find_pinned_fields:
+        @struct_attrs($($struct_attrs:tt)*),
+        @vis($vis:vis),
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @fields_munch(#[pin] $($rest:tt)*),
+        @pinned($($pinned:tt)*),
+        @not_pinned($($not_pinned:tt)*),
+        @fields($($fields:tt)*),
+        @accum($($accum:tt)*),
+        @is_pinned($($is_pinned:ident)?),
+        @pinned_drop($($pinned_drop:ident)?),
+    ) => {
+        $crate::pin_project!(find_pinned_fields:
+            @struct_attrs($($struct_attrs)*),
+            @vis($vis),
+            @name($name),
+            @impl_generics($($impl_generics)*),
+            @ty_generics($($ty_generics)*),
+            @where($($whr)*),
+            @fields_munch($($rest)*),
+            @pinned($($pinned)*),
+            @not_pinned($($not_pinned)*),
+            @fields($($fields)*),
+            @accum($($accum)*),
+            @is_pinned(yes),
+            @pinned_drop($($pinned_drop)?),
+        );
+    };
+    (find_pinned_fields:
+        @struct_attrs($($struct_attrs:tt)*),
+        @vis($vis:vis),
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @fields_munch($fvis:vis $field:ident $($rest:tt)*),
+        @pinned($($pinned:tt)*),
+        @not_pinned($($not_pinned:tt)*),
+        @fields($($fields:tt)*),
+        @accum($($accum:tt)*),
+        @is_pinned($($is_pinned:ident)?),
+        @pinned_drop($($pinned_drop:ident)?),
+    ) => {
+        $crate::pin_project!(find_pinned_fields:
+            @struct_attrs($($struct_attrs)*),
+            @vis($vis),
+            @name($name),
+            @impl_generics($($impl_generics)*),
+            @ty_generics($($ty_generics)*),
+            @where($($whr)*),
+            @fields_munch($field $($rest)*),
+            @pinned($($pinned)*),
+            @not_pinned($($not_pinned)*),
+            @fields($($fields)*),
+            @accum($($accum)* $fvis),
+            @is_pinned(yes),
+            @pinned_drop($($pinned_drop)?),
+        );
+    };
+    (find_pinned_fields:
+        @struct_attrs($($struct_attrs:tt)*),
+        @vis($vis:vis),
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @fields_munch(#[$($attr:tt)*] $($rest:tt)*),
+        @pinned($($pinned:tt)*),
+        @not_pinned($($not_pinned:tt)*),
+        @fields($($fields:tt)*),
+        @accum($($accum:tt)*),
+        @is_pinned($($is_pinned:ident)?),
+        @pinned_drop($($pinned_drop:ident)?),
+    ) => {
+        $crate::pin_project!(find_pinned_fields:
+            @struct_attrs($($struct_attrs)*),
+            @vis($vis),
+            @name($name),
+            @impl_generics($($impl_generics)*),
+            @ty_generics($($ty_generics)*),
+            @where($($whr)*),
+            @fields_munch($($rest)*),
+            @pinned($($pinned)*),
+            @not_pinned($($not_pinned)*),
+            @fields($($fields)*),
+            @accum($($accum)* #[$($attr)*]),
+            @is_pinned(yes),
+            @pinned_drop($($pinned_drop)?),
+        );
+    };
+    (find_pinned_fields:
+        @struct_attrs($($struct_attrs:tt)*),
+        @vis($vis:vis),
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @fields_munch(),
+        @pinned($($pinned:tt)*),
+        @not_pinned($($not_pinned:tt)*),
+        @fields($($fields:tt)*),
+        @accum(),
+        @is_pinned(),
+        @pinned_drop($($pinned_drop:ident)?),
+    ) => {
+        $($struct_attrs)*
+        $vis struct $name <$($impl_generics)*>
+        where $($whr)*
+        {
+            $($fields)*
+        }
+
+        const _: () = {
+            $vis struct __ThePinData<$($impl_generics)*>
+            where $($whr)*
+            {
+                __phantom: ::core::marker::PhantomData<fn($name<$($ty_generics)*>) -> $name<$($ty_generics)*>>,
+            }
+
+            $crate::pin_project!(make_pin_data:
+                @pin_data(__ThePinData),
+                @impl_generics($($impl_generics)*),
+                @ty_generics($($ty_generics)*),
+                @where($($whr)*),
+                @pinned($($pinned)*),
+                @not_pinned($($not_pinned)*),
+            );
+
+            unsafe impl<$($impl_generics)*> $crate::init::__private::__PinData for $name<$($ty_generics)*>
+            where $($whr)*
+            {
+                type __PinData = __ThePinData<$($ty_generics)*>;
+            }
+
+            #[allow(dead_code)]
+            struct __Unpin <'__pin, $($impl_generics)*>
+            where $($whr)*
+            {
+                __phantom_pin: ::core::marker::PhantomData<fn(&'__pin ()) -> &'__pin ()>,
+                __phantom: ::core::marker::PhantomData<fn($name<$($ty_generics)*>) -> $name<$($ty_generics)*>>,
+                $($pinned)*
+            }
+
+            #[doc(hidden)]
+            impl<'__pin, $($impl_generics)*> ::core::marker::Unpin for $name<$($ty_generics)*>
+            where
+                __Unpin<'__pin, $($ty_generics)*>: ::core::marker::Unpin,
+                $($whr)*
+            {}
+
+            $crate::pin_project!(drop_prevention:
+                @name($name),
+                @impl_generics($($impl_generics)*),
+                @ty_generics($($ty_generics)*),
+                @where($($whr)*),
+                @pinned_drop($($pinned_drop)?),
+            );
+        };
+    };
+    (drop_prevention:
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @pinned_drop(),
+    ) => {
+        trait MustNotImplDrop {}
+        #[allow(drop_bounds)]
+        impl<T: ::core::ops::Drop> MustNotImplDrop for T {}
+        impl<$($impl_generics)*> MustNotImplDrop for $name<$($ty_generics)*>
+        where $($whr)*
+        {}
+        #[allow(non_camel_case_types)]
+        trait UselessPinnedDropImpl_you_need_to_specify_PinnedDrop {}
+        impl<T: $crate::init::PinnedDrop> UselessPinnedDropImpl_you_need_to_specify_PinnedDrop for T {}
+        impl<$($impl_generics)*> UselessPinnedDropImpl_you_need_to_specify_PinnedDrop for $name<$($ty_generics)*>
+        where
+            $($whr)*
+        {}
+    };
+    (drop_prevention:
+        @name($name:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @pinned_drop(PinnedDrop),
+    ) => {
+        impl<$($impl_generics)*> ::core::ops::Drop for $name<$($ty_generics)*>
+        where $($whr)*
+        {
+            fn drop(&mut self) {
+                let pinned = unsafe { ::core::pin::Pin::new_unchecked(self) };
+                unsafe { $crate::init::PinnedDrop::drop(pinned) }
+            }
+        }
+    };
+    (make_pin_data:
+        @pin_data($pin_data:ident),
+        @impl_generics($($impl_generics:tt)*),
+        @ty_generics($($ty_generics:tt)*),
+        @where($($whr:tt)*),
+        @pinned($($(#[$($p_attr:tt)*])* $pvis:vis $p_field:ident : $p_type:ty),* $(,)?),
+        @not_pinned($($(#[$($attr:tt)*])* $fvis:vis $field:ident : $type:ty),* $(,)?),
+    ) => {
+        #[allow(dead_code)]
+        impl<$($impl_generics)*> $pin_data<$($ty_generics)*>
+        where $($whr)*
+        {
+            $(
+                $pvis unsafe fn $p_field<E, W: $crate::init::__private::InitWay>(
+                    slot: *mut $p_type,
+                    init: impl $crate::init::__private::__PinInitImpl<$p_type, E, W>,
+                ) -> ::core::result::Result<(), E> {
+                    unsafe { $crate::init::__private::__PinInitImpl::__pinned_init(init, slot) }
+                }
+            )*
+            $(
+                $fvis unsafe fn $field<E, W: $crate::init::__private::InitWay>(
+                    slot: *mut $type,
+                    init: impl $crate::init::__private::__InitImpl<$type, E, W>,
+                ) -> ::core::result::Result<(), E> {
+                    unsafe { $crate::init::__private::__InitImpl::__init(init, slot) }
+                }
+            )*
+        }
+    };
+}

--- a/rust/kernel/init/pinned_drop.rs
+++ b/rust/kernel/init/pinned_drop.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0
+
+// use the proc macro instead
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pinned_drop {
+    (
+        @impl_sig($($impl_sig:tt)*),
+        @impl_body(
+            $(#[$($attr:tt)*])*
+            fn drop($self:ident: $st:ty) {
+                $($inner:stmt)*
+            }
+        ),
+    ) => {
+        unsafe $($impl_sig)* {
+            $(#[$($attr)*])*
+            unsafe fn drop($self: $st) {
+                $($inner)*
+            }
+
+            fn __ensure_no_unsafe_op_in_drop($self: $st) {
+                if false {
+                    $($inner)*
+                }
+            }
+        }
+    }
+}

--- a/rust/kernel/kasync/executor/workqueue.rs
+++ b/rust/kernel/kasync/executor/workqueue.rs
@@ -5,7 +5,7 @@
 use super::{ArcWake, AutoStopHandle};
 use crate::{
     error::code::*,
-    macros::pin_project,
+    macros::pin_data,
     new_mutex, pin_init,
     prelude::*,
     revocable::AsyncRevocable,
@@ -190,7 +190,7 @@ struct ExecutorInner {
 ///
 /// # Ok::<(), Error>(())
 /// ```
-#[pin_project]
+#[pin_data]
 pub struct Executor {
     queue: Either<BoxedQueue, &'static Queue>,
     #[pin]

--- a/rust/kernel/kasync/executor/workqueue.rs
+++ b/rust/kernel/kasync/executor/workqueue.rs
@@ -223,7 +223,7 @@ impl Executor {
     /// It uses the given work queue to run its tasks.
     fn new_internal(queue: Either<BoxedQueue, &'static Queue>) -> Result<AutoStopHandle<Self>> {
         Ok(AutoStopHandle::new(
-            UniqueArc::pin_init::<core::convert::Infallible>(pin_init!(Self {
+            UniqueArc::pin_init(pin_init!(Self {
                 inner: new_mutex!(
                     ExecutorInner {
                         stopped: false,

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -25,6 +25,7 @@
 #![feature(ptr_metadata)]
 #![feature(receiver_trait)]
 #![feature(unsize)]
+#![feature(new_uninit)]
 
 // Ensure conditional compilation based on the kernel configuration works;
 // otherwise we may silently break things like initcall handling.
@@ -57,6 +58,7 @@ pub mod file;
 pub mod fs;
 pub mod gpio;
 pub mod hwrng;
+pub mod init;
 pub mod irq;
 pub mod kasync;
 pub mod miscdev;

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -31,6 +31,9 @@
 #[cfg(not(CONFIG_RUST))]
 compile_error!("Missing kernel configuration for conditional compilation");
 
+// allow proc-macros to refer to `::kernel`.
+extern crate self as kernel;
+
 #[cfg(not(test))]
 #[cfg(not(testlib))]
 mod allocator;

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -21,7 +21,7 @@ pub use super::build_assert;
 
 pub use super::{
     dbg, dev_alert, dev_crit, dev_dbg, dev_emerg, dev_err, dev_info, dev_notice, dev_warn, fmt,
-    init, macros::pin_data, pin_init, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info,
+    init, macros::pin_project, pin_init, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info,
     pr_notice, pr_warn,
 };
 
@@ -35,3 +35,5 @@ pub use super::static_assert;
 pub use super::{error::code::*, Error, Result};
 
 pub use super::{str::CStr, ARef, ThisModule};
+
+pub use super::init::InPlaceInit;

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -21,7 +21,8 @@ pub use super::build_assert;
 
 pub use super::{
     dbg, dev_alert, dev_crit, dev_dbg, dev_emerg, dev_err, dev_info, dev_notice, dev_warn, fmt,
-    pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info, pr_notice, pr_warn,
+    init, macros::pin_data, pin_init, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info,
+    pr_notice, pr_warn,
 };
 
 pub use super::{module_fs, module_misc_device};

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -21,7 +21,7 @@ pub use super::build_assert;
 
 pub use super::{
     dbg, dev_alert, dev_crit, dev_dbg, dev_emerg, dev_err, dev_info, dev_notice, dev_warn, fmt,
-    init, macros::pin_project, pin_init, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info,
+    init, macros::pin_data, pin_init, pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info,
     pr_notice, pr_warn,
 };
 

--- a/rust/kernel/sync.rs
+++ b/rust/kernel/sync.rs
@@ -158,13 +158,13 @@ impl<T> StaticInit<T> {
     /// # Safety
     ///
     /// The caller calls this function exactly once and before any other function (even implicitly
-    /// derefing) of `self` is called. `self` stays pinned indefinetly.
-    pub unsafe fn init<E>(&self, init: impl PinInit<T, E>)
+    /// derefing) of `self` is called. `self` stays pinned indefinitely.
+    pub unsafe fn init<E>(&'static self, init: impl PinInit<T, E>)
     where
         E: Into<core::convert::Infallible>,
     {
         // SAFETY: This function has unique access to `self` because of the unsafety contract.
-        // `self` is also pinned indefinetly and `inner` is structurally pinned.
+        // `self` is also pinned indefinitely and `inner` is structurally pinned.
         unsafe {
             let ptr = UnsafeCell::raw_get(self.inner.as_ptr());
             match init.__pinned_init(ptr).map_err(|e| e.into()) {

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -15,7 +15,12 @@
 //!
 //! [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 
-use crate::{bindings, error::code::*, Error, Opaque, Result};
+use crate::{
+    bindings,
+    init::{Init, PinInit},
+    prelude::*,
+    Error, Opaque, Result,
+};
 use alloc::{
     alloc::{alloc, dealloc},
     vec::Vec,
@@ -95,6 +100,14 @@ impl<T> Arc<T> {
         // SAFETY: We just created `inner` with a reference count of 1, which is owned by the new
         // `Arc` object.
         Ok(unsafe { Self::from_inner(inner) })
+    }
+
+    /// Creates a new `Arc` and initializes its contenst with the given initializer.
+    pub fn pin_init<E>(init: impl PinInit<T, E>) -> Result<Self>
+    where
+        Error: From<E>,
+    {
+        UniqueArc::pin_init(init).map(|u| u.into())
     }
 
     /// Deconstructs a [`Arc`] object into a `usize`.

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -49,7 +49,7 @@ pub struct Arc<T: ?Sized> {
     _p: PhantomData<ArcInner<T>>,
 }
 
-#[pin_project]
+#[pin_data]
 #[repr(C)]
 struct ArcInner<T: ?Sized> {
     #[pin]

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -9,7 +9,7 @@ use super::{Guard, Lock, LockClassKey, LockInfo};
 use crate::{
     bindings,
     init::{self, PinInit},
-    macros::pin_project,
+    macros::pin_data,
     pin_init,
     str::CStr,
     task::Task,
@@ -38,7 +38,7 @@ const POLLFREE: u32 = 0x4000;
 ///
 /// [`struct wait_queue_head`]: ../../../include/linux/wait.h
 /// [init]: ../init/index.html
-#[pin_project]
+#[pin_data]
 pub struct CondVar {
     #[pin]
     pub(crate) wait_list: Opaque<bindings::wait_queue_head>,

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -8,7 +8,7 @@ use super::{Guard, Lock, LockClassKey, LockFactory, WriteLock};
 use crate::{
     bindings,
     init::{self, PinInit},
-    macros::pin_project,
+    macros::pin_data,
     pin_init,
     str::CStr,
     Opaque,
@@ -34,7 +34,7 @@ macro_rules! new_mutex {
 ///
 /// [`struct mutex`]: ../../../include/linux/mutex.h
 /// [init]: ../init/index.html
-#[pin_project]
+#[pin_data]
 pub struct Mutex<T: ?Sized> {
     /// The kernel `struct mutex` object.
     #[pin]

--- a/rust/kernel/sync/revocable.rs
+++ b/rust/kernel/sync/revocable.rs
@@ -5,10 +5,9 @@
 use crate::{
     init::PinInit,
     macros::pin_project,
-    pin_init,
     str::CStr,
     sync::{Guard, Lock, LockClassKey, LockFactory, LockInfo, ReadLock, WriteLock},
-    True,
+    try_pin_init, True,
 };
 use core::{
     mem::MaybeUninit,
@@ -124,9 +123,9 @@ impl<F: LockFactory, T> Revocable<F, T> {
         name: &'static CStr,
         key: &'static LockClassKey,
     ) -> impl PinInit<Self, F::Error> {
-        pin_init!(Self {
+        try_pin_init!(Self {
             inner: F::new_lock(Inner::new(data), name, key),
-        })
+        }? F::Error)
     }
 }
 

--- a/rust/kernel/sync/revocable.rs
+++ b/rust/kernel/sync/revocable.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     init::PinInit,
-    macros::pin_project,
+    macros::pin_data,
     str::CStr,
     sync::{Guard, Lock, LockClassKey, LockFactory, LockInfo, ReadLock, WriteLock},
     try_pin_init, True,
@@ -101,7 +101,7 @@ impl<T> Drop for Inner<T> {
 /// ```
 /// [init]: ../init/index.html
 /// [`new_revocable!`]: kernel::new_revocable
-#[pin_project]
+#[pin_data]
 pub struct Revocable<F: LockFactory, T> {
     #[pin]
     inner: <F as LockFactory>::LockedType<Inner<T>>,

--- a/rust/kernel/sync/rwsem.rs
+++ b/rust/kernel/sync/rwsem.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     bindings,
     init::{self, PinInit},
-    macros::pin_project,
+    macros::pin_data,
     pin_init,
     str::CStr,
     Opaque,
@@ -39,7 +39,7 @@ macro_rules! new_rwsemaphore {
 ///
 /// [`struct rw_semaphore`]: ../../../include/linux/rwsem.h
 /// [init]: ../init/index.html
-#[pin_project]
+#[pin_data]
 pub struct RwSemaphore<T: ?Sized> {
     /// The kernel `struct rw_semaphore` object.
     #[pin]

--- a/rust/kernel/sync/seqlock.rs
+++ b/rust/kernel/sync/seqlock.rs
@@ -12,9 +12,8 @@ use crate::{
     bindings,
     init::{self, PinInit},
     macros::pin_project,
-    pin_init,
     str::CStr,
-    Opaque,
+    try_pin_init, Opaque,
 };
 use core::{cell::UnsafeCell, marker::PhantomPinned, ops::Deref};
 
@@ -111,11 +110,11 @@ impl<L: Lock> SeqLock<L> {
             };
             unsafe { init::pin_init_from_closure(init) }
         }
-        pin_init!(Self {
+        try_pin_init!(Self {
             _p: PhantomPinned,
             count: init_count(name, key2),
             write_lock: L::new_lock(data, name, key1),
-        })
+        }? L::Error)
     }
 }
 

--- a/rust/kernel/sync/seqlock.rs
+++ b/rust/kernel/sync/seqlock.rs
@@ -11,7 +11,7 @@ use super::{Guard, Lock, LockClassKey, LockFactory, ReadLock};
 use crate::{
     bindings,
     init::{self, PinInit},
-    macros::pin_project,
+    macros::pin_data,
     str::CStr,
     try_pin_init, Opaque,
 };
@@ -61,7 +61,7 @@ use core::{cell::UnsafeCell, marker::PhantomPinned, ops::Deref};
 /// }
 /// ```
 /// [init]: ../init/index.html
-#[pin_project]
+#[pin_data]
 pub struct SeqLock<L: ?Sized + Lock> {
     #[pin]
     _p: PhantomPinned,

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     bindings,
     init::{self, PinInit},
-    macros::pin_project,
+    macros::pin_data,
     pin_init,
     str::CStr,
     Opaque, True,
@@ -82,7 +82,7 @@ macro_rules! new_spinlock {
 ///
 /// [`spinlock_t`]: ../../../include/linux/spinlock.h
 /// [init]: ../init/index.html
-#[pin_project]
+#[pin_data]
 pub struct SpinLock<T: ?Sized> {
     #[pin]
     spin_lock: Opaque<bindings::spinlock>,
@@ -271,7 +271,7 @@ macro_rules! new_rawspinlock {
 /// ```
 ///
 /// [`raw_spinlock_t`]: ../../../include/linux/spinlock.h
-#[pin_project]
+#[pin_data]
 pub struct RawSpinLock<T: ?Sized> {
     #[pin]
     spin_lock: Opaque<bindings::raw_spinlock>,

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -15,7 +15,7 @@ use core::{
     mem::MaybeUninit,
     ops::{self, Deref, DerefMut},
     pin::Pin,
-    ptr::NonNull,
+    ptr::{addr_of, NonNull},
 };
 
 /// Permissions.
@@ -315,6 +315,18 @@ impl<T> Opaque<T> {
     /// Returns a raw pointer to the opaque data.
     pub fn get(&self) -> *mut T {
         UnsafeCell::raw_get(self.0.as_ptr())
+    }
+
+    /// Gets the value behind `this`.
+    ///
+    /// This function is useful to get access to the value without creating intermeditate
+    /// references.
+    ///
+    /// # Safety
+    ///
+    /// The pointer supplied is valid.
+    pub unsafe fn raw_get(this: *const Self) -> *mut T {
+        UnsafeCell::raw_get(addr_of!((*this).0).cast::<UnsafeCell<T>>())
     }
 }
 

--- a/rust/macros/lib.rs
+++ b/rust/macros/lib.rs
@@ -5,6 +5,8 @@
 mod concat_idents;
 mod helpers;
 mod module;
+mod pin_project;
+mod pinned_drop;
 mod vtable;
 
 use proc_macro::TokenStream;
@@ -188,4 +190,47 @@ pub fn vtable(attr: TokenStream, ts: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn concat_idents(ts: TokenStream) -> TokenStream {
     concat_idents::concat_idents(ts)
+}
+
+/// Used to specify the pin information of the fields of a struct.
+///
+/// This is somewhat similar in purpose as
+/// [pin-project-lite](https://crates.io/crates/pin-project-lite).
+/// Place this macro on a struct definition and then `#[pin]` in front of the attributes of each
+/// field you want to have structurally pinned.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// #[pin_data]
+/// struct A {
+///     #[pin]
+///     a: usize,
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn pin_project(inner: TokenStream, item: TokenStream) -> TokenStream {
+    pin_project::pin_project(inner, item)
+}
+
+/// Used to implement `PinnedDrop` safely.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// #[pin_project(PinnedDrop)]
+/// struct Foo {
+///     a: usize,
+/// }
+///
+/// #[pinned_drop]
+/// impl PinnedDrop for Foo {
+///     fn drop(self: Pin<&mut Self>) {
+///         pr_info!("dropping a Foo");
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn pinned_drop(args: TokenStream, input: TokenStream) -> TokenStream {
+    pinned_drop::pinned_drop(args, input)
 }

--- a/rust/macros/lib.rs
+++ b/rust/macros/lib.rs
@@ -5,7 +5,7 @@
 mod concat_idents;
 mod helpers;
 mod module;
-mod pin_project;
+mod pin_data;
 mod pinned_drop;
 mod vtable;
 
@@ -202,15 +202,15 @@ pub fn concat_idents(ts: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```rust,ignore
-/// #[pin_project]
+/// #[pin_data]
 /// struct A {
 ///     #[pin]
 ///     a: usize,
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn pin_project(inner: TokenStream, item: TokenStream) -> TokenStream {
-    pin_project::pin_project(inner, item)
+pub fn pin_data(inner: TokenStream, item: TokenStream) -> TokenStream {
+    pin_data::pin_data(inner, item)
 }
 
 /// Used to implement `PinnedDrop` safely.
@@ -218,7 +218,7 @@ pub fn pin_project(inner: TokenStream, item: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```rust,ignore
-/// #[pin_project(PinnedDrop)]
+/// #[pin_data(PinnedDrop)]
 /// struct Foo {
 ///     a: usize,
 /// }

--- a/rust/macros/lib.rs
+++ b/rust/macros/lib.rs
@@ -202,7 +202,7 @@ pub fn concat_idents(ts: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```rust,ignore
-/// #[pin_data]
+/// #[pin_project]
 /// struct A {
 ///     #[pin]
 ///     a: usize,

--- a/rust/macros/pin_data.rs
+++ b/rust/macros/pin_data.rs
@@ -2,7 +2,7 @@
 
 use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
 
-pub(crate) fn pin_project(args: TokenStream, input: TokenStream) -> TokenStream {
+pub(crate) fn pin_data(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut impl_generics = vec![];
     let mut ty_generics = vec![];
     let mut rest = vec![];
@@ -57,7 +57,7 @@ pub(crate) fn pin_project(args: TokenStream, input: TokenStream) -> TokenStream 
     rest.extend(toks);
     let last = rest.pop();
     let mut ret = vec![];
-    ret.extend("::kernel::pin_project!".parse::<TokenStream>().unwrap());
+    ret.extend("::kernel::_pin_data!".parse::<TokenStream>().unwrap());
     ret.push(TokenTree::Group(Group::new(
         Delimiter::Brace,
         TokenStream::from_iter(vec![

--- a/rust/macros/pin_project.rs
+++ b/rust/macros/pin_project.rs
@@ -42,7 +42,6 @@ pub(crate) fn pin_project(args: TokenStream, input: TokenStream) -> TokenStream 
                         TokenTree::Punct(p) if p.as_char() == ',' => at_start = true,
                         TokenTree::Punct(p) if p.as_char() == '\'' && at_start => {
                             ty_generics.push(tt.clone());
-                            ty_generics.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
                         }
                         _ => {}
                     }
@@ -57,55 +56,49 @@ pub(crate) fn pin_project(args: TokenStream, input: TokenStream) -> TokenStream 
     }
     rest.extend(toks);
     let last = rest.pop();
-    TokenStream::from_iter(vec![
-        TokenTree::Punct(Punct::new(':', Spacing::Joint)),
-        TokenTree::Punct(Punct::new(':', Spacing::Alone)),
-        TokenTree::Ident(Ident::new("kernel", Span::call_site())),
-        TokenTree::Punct(Punct::new(':', Spacing::Joint)),
-        TokenTree::Punct(Punct::new(':', Spacing::Alone)),
-        TokenTree::Ident(Ident::new("pin_project", Span::call_site())),
-        TokenTree::Punct(Punct::new('!', Spacing::Alone)),
-        TokenTree::Group(Group::new(
-            Delimiter::Brace,
-            TokenStream::from_iter(vec![
-                TokenTree::Ident(Ident::new("parse_input", Span::call_site())),
-                TokenTree::Punct(Punct::new(':', Spacing::Alone)),
-                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
-                TokenTree::Ident(Ident::new("args", Span::call_site())),
-                TokenTree::Group(Group::new(
-                    Delimiter::Parenthesis,
-                    TokenStream::from_iter(args),
-                )),
-                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
-                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
-                TokenTree::Ident(Ident::new("sig", Span::call_site())),
-                TokenTree::Group(Group::new(
-                    Delimiter::Parenthesis,
-                    TokenStream::from_iter(rest),
-                )),
-                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
-                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
-                TokenTree::Ident(Ident::new("impl_generics", Span::call_site())),
-                TokenTree::Group(Group::new(
-                    Delimiter::Parenthesis,
-                    TokenStream::from_iter(impl_generics),
-                )),
-                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
-                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
-                TokenTree::Ident(Ident::new("ty_generics", Span::call_site())),
-                TokenTree::Group(Group::new(
-                    Delimiter::Parenthesis,
-                    TokenStream::from_iter(ty_generics),
-                )),
-                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
-                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
-                TokenTree::Ident(Ident::new("body", Span::call_site())),
-                TokenTree::Group(Group::new(
-                    Delimiter::Parenthesis,
-                    TokenStream::from_iter(last),
-                )),
-                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
-            ]),
-        )),
-    ])
+    let mut ret = vec![];
+    ret.extend("::kernel::pin_project!".parse::<TokenStream>().unwrap());
+    ret.push(TokenTree::Group(Group::new(
+        Delimiter::Brace,
+        TokenStream::from_iter(vec![
+            TokenTree::Ident(Ident::new("parse_input", Span::call_site())),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("args", Span::call_site())),
+            TokenTree::Group(Group::new(
+                Delimiter::Parenthesis,
+                TokenStream::from_iter(args),
+            )),
+            TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+            TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("sig", Span::call_site())),
+            TokenTree::Group(Group::new(
+                Delimiter::Parenthesis,
+                TokenStream::from_iter(rest),
+            )),
+            TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+            TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("impl_generics", Span::call_site())),
+            TokenTree::Group(Group::new(
+                Delimiter::Parenthesis,
+                TokenStream::from_iter(impl_generics),
+            )),
+            TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+            TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("ty_generics", Span::call_site())),
+            TokenTree::Group(Group::new(
+                Delimiter::Parenthesis,
+                TokenStream::from_iter(ty_generics),
+            )),
+            TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+            TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("body", Span::call_site())),
+            TokenTree::Group(Group::new(
+                Delimiter::Parenthesis,
+                TokenStream::from_iter(last),
+            )),
+            TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+        ]),
+    )));
+    TokenStream::from_iter(ret)
 }

--- a/rust/macros/pin_project.rs
+++ b/rust/macros/pin_project.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
+
+pub(crate) fn pin_project(args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut impl_generics = vec![];
+    let mut ty_generics = vec![];
+    let mut rest = vec![];
+    let mut nesting = 0;
+    let mut toks = input.into_iter();
+    let mut at_start = true;
+    for tt in &mut toks {
+        match tt.clone() {
+            TokenTree::Punct(p) if p.as_char() == '<' => {
+                if nesting >= 1 {
+                    impl_generics.push(tt);
+                }
+                nesting += 1;
+            }
+            TokenTree::Punct(p) if p.as_char() == '>' => {
+                if nesting == 0 {
+                    break;
+                } else {
+                    nesting -= 1;
+                    if nesting >= 1 {
+                        impl_generics.push(tt);
+                    }
+                    if nesting == 0 {
+                        break;
+                    }
+                }
+            }
+            tt => {
+                if nesting == 1 {
+                    match &tt {
+                        TokenTree::Ident(i) if i.to_string() == "const" => {}
+                        TokenTree::Ident(_) if at_start => {
+                            ty_generics.push(tt.clone());
+                            ty_generics.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
+                            at_start = false;
+                        }
+                        TokenTree::Punct(p) if p.as_char() == ',' => at_start = true,
+                        TokenTree::Punct(p) if p.as_char() == '\'' && at_start => {
+                            ty_generics.push(tt.clone());
+                            ty_generics.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
+                        }
+                        _ => {}
+                    }
+                }
+                if nesting >= 1 {
+                    impl_generics.push(tt);
+                } else if nesting == 0 {
+                    rest.push(tt);
+                }
+            }
+        }
+    }
+    rest.extend(toks);
+    let last = rest.pop();
+    TokenStream::from_iter(vec![
+        TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+        TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+        TokenTree::Ident(Ident::new("kernel", Span::call_site())),
+        TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+        TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+        TokenTree::Ident(Ident::new("pin_project", Span::call_site())),
+        TokenTree::Punct(Punct::new('!', Spacing::Alone)),
+        TokenTree::Group(Group::new(
+            Delimiter::Brace,
+            TokenStream::from_iter(vec![
+                TokenTree::Ident(Ident::new("parse_input", Span::call_site())),
+                TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+                TokenTree::Ident(Ident::new("args", Span::call_site())),
+                TokenTree::Group(Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter(args),
+                )),
+                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+                TokenTree::Ident(Ident::new("sig", Span::call_site())),
+                TokenTree::Group(Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter(rest),
+                )),
+                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+                TokenTree::Ident(Ident::new("impl_generics", Span::call_site())),
+                TokenTree::Group(Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter(impl_generics),
+                )),
+                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+                TokenTree::Ident(Ident::new("ty_generics", Span::call_site())),
+                TokenTree::Group(Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter(ty_generics),
+                )),
+                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+                TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+                TokenTree::Ident(Ident::new("body", Span::call_site())),
+                TokenTree::Group(Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter(last),
+                )),
+                TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+            ]),
+        )),
+    ])
+}

--- a/rust/macros/pinned_drop.rs
+++ b/rust/macros/pinned_drop.rs
@@ -33,19 +33,7 @@ pub(crate) fn pinned_drop(_args: TokenStream, input: TokenStream) -> TokenStream
     }
     let idx = pinned_drop_idx.unwrap();
     // fully qualify the `PinnedDrop`.
-    toks.splice(
-        idx..idx,
-        vec![
-            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
-            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
-            TokenTree::Ident(Ident::new("kernel", Span::call_site())),
-            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
-            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
-            TokenTree::Ident(Ident::new("init", Span::call_site())),
-            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
-            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
-        ],
-    );
+    toks.splice(idx..idx, "::kernel::init::".parse::<TokenStream>().unwrap());
     // take the {} body.
     if let Some(TokenTree::Group(last)) = toks.pop() {
         TokenStream::from_iter(vec![

--- a/rust/macros/pinned_drop.rs
+++ b/rust/macros/pinned_drop.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
+
+pub(crate) fn pinned_drop(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut toks = input.into_iter().collect::<Vec<_>>();
+    assert!(!toks.is_empty());
+    // ensure that we have an impl item
+    assert!(matches!(&toks[0], TokenTree::Ident(i) if i.to_string() == "impl"));
+    // ensure that we are implementing `PinnedDrop`
+    let mut nesting: usize = 0;
+    let mut pinned_drop_idx = None;
+    for (i, tt) in toks.iter().enumerate() {
+        match tt {
+            TokenTree::Punct(p) if p.as_char() == '<' => {
+                nesting += 1;
+            }
+            TokenTree::Punct(p) if p.as_char() == '>' => {
+                nesting = nesting.checked_sub(1).unwrap();
+                continue;
+            }
+            _ => {}
+        }
+        if i >= 1 && nesting == 0 {
+            assert!(
+                matches!(tt, TokenTree::Ident(i) if i.to_string() == "PinnedDrop"),
+                "expected 'PinnedDrop', found: '{:?}'",
+                tt
+            );
+            pinned_drop_idx = Some(i);
+            break;
+        }
+    }
+    let idx = pinned_drop_idx.unwrap();
+    //inserting `::kernel::init::` in reverse order
+    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Alone)));
+    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Joint)));
+    toks.insert(idx, TokenTree::Ident(Ident::new("init", Span::call_site())));
+    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Alone)));
+    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Joint)));
+    toks.insert(
+        idx,
+        TokenTree::Ident(Ident::new("kernel", Span::call_site())),
+    );
+    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Alone)));
+    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Joint)));
+    // take the {} body
+    if let Some(TokenTree::Group(last)) = toks.pop() {
+        TokenStream::from_iter(vec![
+            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("kernel", Span::call_site())),
+            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("pinned_drop", Span::call_site())),
+            TokenTree::Punct(Punct::new('!', Spacing::Alone)),
+            TokenTree::Group(Group::new(
+                Delimiter::Brace,
+                TokenStream::from_iter(vec![
+                    TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+                    TokenTree::Ident(Ident::new("impl_sig", Span::call_site())),
+                    TokenTree::Group(Group::new(
+                        Delimiter::Parenthesis,
+                        TokenStream::from_iter(toks),
+                    )),
+                    TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+                    TokenTree::Punct(Punct::new('@', Spacing::Alone)),
+                    TokenTree::Ident(Ident::new("impl_body", Span::call_site())),
+                    TokenTree::Group(Group::new(
+                        Delimiter::Parenthesis,
+                        TokenStream::from_iter(last.stream()),
+                    )),
+                    TokenTree::Punct(Punct::new(',', Spacing::Alone)),
+                ]),
+            )),
+        ])
+    } else {
+        TokenStream::from_iter(toks)
+    }
+}

--- a/rust/macros/pinned_drop.rs
+++ b/rust/macros/pinned_drop.rs
@@ -32,19 +32,21 @@ pub(crate) fn pinned_drop(_args: TokenStream, input: TokenStream) -> TokenStream
         }
     }
     let idx = pinned_drop_idx.unwrap();
-    //inserting `::kernel::init::` in reverse order
-    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Alone)));
-    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Joint)));
-    toks.insert(idx, TokenTree::Ident(Ident::new("init", Span::call_site())));
-    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Alone)));
-    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Joint)));
-    toks.insert(
-        idx,
-        TokenTree::Ident(Ident::new("kernel", Span::call_site())),
+    // fully qualify the `PinnedDrop`.
+    toks.splice(
+        idx..idx,
+        vec![
+            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("kernel", Span::call_site())),
+            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+            TokenTree::Ident(Ident::new("init", Span::call_site())),
+            TokenTree::Punct(Punct::new(':', Spacing::Joint)),
+            TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+        ],
     );
-    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Alone)));
-    toks.insert(idx, TokenTree::Punct(Punct::new(':', Spacing::Joint)));
-    // take the {} body
+    // take the {} body.
     if let Some(TokenTree::Group(last)) = toks.pop() {
         TokenStream::from_iter(vec![
             TokenTree::Punct(Punct::new(':', Spacing::Joint)),

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -6,7 +6,7 @@ use kernel::prelude::*;
 use kernel::{
     file::{self, File},
     io_buffer::{IoBufferReader, IoBufferWriter},
-    macros::pin_project,
+    macros::pin_data,
     miscdev, new_condvar, new_mutex, pin_init,
     sync::{Arc, ArcBorrow, CondVar, Mutex},
 };
@@ -25,7 +25,7 @@ struct SharedStateInner {
     token_count: usize,
 }
 
-#[pin_project]
+#[pin_data]
 struct SharedState {
     #[pin]
     state_changed: CondVar,

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -8,7 +8,7 @@ use kernel::{
     io_buffer::{IoBufferReader, IoBufferWriter},
     macros::pin_project,
     miscdev, new_condvar, new_mutex, pin_init,
-    sync::{Arc, ArcBorrow, CondVar, Mutex, UniqueArc},
+    sync::{Arc, ArcBorrow, CondVar, Mutex},
 };
 
 module! {
@@ -35,13 +35,10 @@ struct SharedState {
 
 impl SharedState {
     fn try_new() -> Result<Arc<Self>> {
-        Ok(
-            UniqueArc::pin_init::<core::convert::Infallible>(pin_init!(Self {
-                state_changed: new_condvar!("SharedState::state_changed"),
-                inner: new_mutex!(SharedStateInner { token_count: 0 }, "SharedState::inner"),
-            }))?
-            .into(),
-        )
+        Arc::pin_init(pin_init!(Self {
+            state_changed: new_condvar!("SharedState::state_changed"),
+            inner: new_mutex!(SharedStateInner { token_count: 0 }, "SharedState::inner"),
+        }))
     }
 }
 

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -17,7 +17,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use kernel::{
     file::{self, File, IoctlCommand, IoctlHandler},
     io_buffer::{IoBufferReader, IoBufferWriter},
-    macros::pin_project,
+    macros::pin_data,
     miscdev::Registration,
     new_condvar, new_mutex, pin_init,
     prelude::*,
@@ -38,7 +38,7 @@ struct SemaphoreInner {
     max_seen: usize,
 }
 
-#[pin_project]
+#[pin_data]
 struct Semaphore {
     #[pin]
     changed: CondVar,

--- a/samples/rust/rust_semaphore.rs
+++ b/samples/rust/rust_semaphore.rs
@@ -112,7 +112,7 @@ impl kernel::Module for RustSemaphore {
     fn init(name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
         pr_info!("Rust semaphore sample (init)\n");
 
-        let sema = UniqueArc::pin_init::<core::convert::Infallible>(pin_init!(Semaphore {
+        let sema = UniqueArc::pin_init(pin_init!(Semaphore {
             changed: new_condvar!("Semaphore::changed"),
             inner: new_mutex!(
                 SemaphoreInner {

--- a/samples/rust/rust_sync.rs
+++ b/samples/rust/rust_sync.rs
@@ -4,8 +4,8 @@
 
 use kernel::prelude::*;
 use kernel::{
-    condvar_init, mutex_init, spinlock_init,
-    sync::{CondVar, Mutex, SpinLock},
+    new_condvar, new_mutex, new_spinlock,
+    sync::{CondVar, Mutex},
 };
 
 module! {
@@ -29,16 +29,11 @@ impl kernel::Module for RustSync {
 
         // Test mutexes.
         {
-            // SAFETY: `init` is called below.
-            let mut data = Pin::from(Box::try_new(unsafe { Mutex::new(0) })?);
-            mutex_init!(data.as_mut(), "RustSync::init::data1");
+            let data = Box::pin_init(new_mutex!(0, "RustSync::init::data1"))?;
             *data.lock() = 10;
             pr_info!("Value: {}\n", *data.lock());
 
-            // SAFETY: `init` is called below.
-            let mut cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
-            condvar_init!(cv.as_mut(), "RustSync::init::cv1");
-
+            let cv = Box::pin_init(new_condvar!("RustSync::init::cv1"))?;
             {
                 let mut guard = data.lock();
                 while *guard != 10 {
@@ -62,15 +57,11 @@ impl kernel::Module for RustSync {
 
         // Test spinlocks.
         {
-            // SAFETY: `init` is called below.
-            let mut data = Pin::from(Box::try_new(unsafe { SpinLock::new(0) })?);
-            spinlock_init!(data.as_mut(), "RustSync::init::data2");
+            let data = Box::pin_init(new_spinlock!(0, "RustSync::init::data2"))?;
             *data.lock() = 10;
             pr_info!("Value: {}\n", *data.lock());
 
-            // SAFETY: `init` is called below.
-            let mut cv = Pin::from(Box::try_new(unsafe { CondVar::new() })?);
-            condvar_init!(cv.as_mut(), "RustSync::init::cv2");
+            let cv = Box::pin_init(new_condvar!("RustSync::init::cv2"))?;
             {
                 let mut guard = data.lock();
                 while *guard != 10 {


### PR DESCRIPTION
This is my newest version of the pinned-initialization API. You can find it as a stand-alone crate here: [pinned-init](https://crates.io/crates/pinned-init).

I plan to squash 276ae43ce0e96492860b71b75c7d7d9c1d728cba onto 50f21212555fda9de7362b2ef13da335b01d9fe8. I separated the commits for better earlier review.

I also need to provide a better commit message better explaining the API (linking to my blog *might* help, but it is a long read, so...).

I removed all `unsafe` initialization API from the `sync` module. If we still want to keep the old API and we want to deprecate it instead just let me know.

Closes #772 