### PR TITLE
Change trim_whitespace implementation to use `while let`

### DIFF
--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -602,6 +602,8 @@ macro_rules! fmt {
 ///
 /// ```
 /// # use kernel::str::trim_whitespace;
+/// assert_eq!(trim_whitespace(b""       ), b"");
+/// assert_eq!(trim_whitespace(b"       "), b"");
 /// assert_eq!(trim_whitespace(b"foo    "), b"foo");
 /// assert_eq!(trim_whitespace(b"    foo"), b"foo");
 /// assert_eq!(trim_whitespace(b"  foo  "), b"foo");

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -595,3 +595,27 @@ impl Deref for CString {
 macro_rules! fmt {
     ($($f:tt)*) => ( core::format_args!($($f)*) )
 }
+
+/// Trims leading and trailing whitespace (` `, `\t` and `\n`).
+///
+/// # Examples
+///
+/// ```
+/// # use kernel::str::trim_whitespace;
+/// assert_eq!(trim_whitespace(b"foo    "), b"foo");
+/// assert_eq!(trim_whitespace(b"    foo"), b"foo");
+/// assert_eq!(trim_whitespace(b"  foo  "), b"foo");
+/// ```
+pub fn trim_whitespace(mut data: &[u8]) -> &[u8] {
+    while !data.is_empty() && (data[0] == b' ' || data[0] == b'\t' || data[0] == b'\n') {
+        data = &data[1..];
+    }
+    while !data.is_empty()
+        && (data[data.len() - 1] == b' '
+            || data[data.len() - 1] == b'\t'
+            || data[data.len() - 1] == b'\n')
+    {
+        data = &data[..data.len() - 1];
+    }
+    data
+}

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -608,16 +608,12 @@ macro_rules! fmt {
 /// assert_eq!(trim_whitespace(b"    foo"), b"foo");
 /// assert_eq!(trim_whitespace(b"  foo  "), b"foo");
 /// ```
-pub fn trim_whitespace(mut data: &[u8]) -> &[u8] {
-    while !data.is_empty() && (data[0] == b' ' || data[0] == b'\t' || data[0] == b'\n') {
-        data = &data[1..];
+pub const fn trim_whitespace(mut data: &[u8]) -> &[u8] {
+    while let [b' ' | b'\t' | b'\n', remainder @ ..] = data {
+        data = remainder;
     }
-    while !data.is_empty()
-        && (data[data.len() - 1] == b' '
-            || data[data.len() - 1] == b'\t'
-            || data[data.len() - 1] == b'\n')
-    {
-        data = &data[..data.len() - 1];
+    while let [remainder @ .., b' ' | b'\t' | b'\n'] = data {
+        data = remainder;
     }
     data
 }


### PR DESCRIPTION
This depends on Rust-for-Linux/linux#911 and was originally proposed there in a comment https://github.com/Rust-for-Linux/linux/pull/911#issuecomment-1275116388 

The first commit adds two additional tests, 
one for the empty string and the second for a string consisting only of spaces (maybe there should also be tests testing for other whitespace beside spaces?).

The second commit does the actual change of introducing `while let`.
Using `while let` allows us to combine the empty and whitespace character checks as well as the remainder calculation into one patter for each loop. 
As a result of no longer uses slice indexing and as such not using the `Index` trait,
the function can now be made `const`, which is also done here.


[Compiler Explorer](https://godbolt.org/z/Ex5dT8ffr) shows no significant change in assembly output.

[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=4ee99fda9f2dd65b8b0ab04ae500a9ce)

