### PR TITLE
samples: minimal: match upstream

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,10 +270,10 @@ jobs:
           grep '] ok 1 - rust_kernel_doctests$' qemu-stdout.log
 
       - run: |
-          grep '] rust_minimal: Rust minimal sample (init)$' qemu-stdout.log
-          grep '] rust_minimal: Am I built-in? false$'       qemu-stdout.log
-          grep '] rust_minimal: My message is on the heap!$' qemu-stdout.log
-          grep '] rust_minimal: Rust minimal sample (exit)$' qemu-stdout.log
+          grep '] rust_minimal: Rust minimal sample (init)$'     qemu-stdout.log
+          grep '] rust_minimal: Am I built-in? false$'           qemu-stdout.log
+          grep '] rust_minimal: My numbers are \[72, 108, 200]$' qemu-stdout.log
+          grep '] rust_minimal: Rust minimal sample (exit)$'     qemu-stdout.log
 
       - run: |
           grep '] rust_print: Rust printing macros sample (init)$'       qemu-stdout.log

--- a/samples/rust/rust_minimal.rs
+++ b/samples/rust/rust_minimal.rs
@@ -13,7 +13,7 @@ module! {
 }
 
 struct RustMinimal {
-    message: String,
+    numbers: Vec<i32>,
 }
 
 impl kernel::Module for RustMinimal {
@@ -21,15 +21,18 @@ impl kernel::Module for RustMinimal {
         pr_info!("Rust minimal sample (init)\n");
         pr_info!("Am I built-in? {}\n", !cfg!(MODULE));
 
-        Ok(RustMinimal {
-            message: "on the heap!".try_to_owned()?,
-        })
+        let mut numbers = Vec::new();
+        numbers.try_push(72)?;
+        numbers.try_push(108)?;
+        numbers.try_push(200)?;
+
+        Ok(RustMinimal { numbers })
     }
 }
 
 impl Drop for RustMinimal {
     fn drop(&mut self) {
-        pr_info!("My message is {}\n", self.message);
+        pr_info!("My numbers are {:?}\n", self.numbers);
         pr_info!("Rust minimal sample (exit)\n");
     }
 }


### PR DESCRIPTION
The minimal sample merged upstream used `Vec` instead of `String` in order to minimize `alloc` further.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>