### PR TITLE
MAINTAINERS: update Wedson's email address to match upstream

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17944,7 +17944,7 @@ F:	tools/verification/
 RUST
 M:	Miguel Ojeda <ojeda@kernel.org>
 M:	Alex Gaynor <alex.gaynor@gmail.com>
-M:	Wedson Almeida Filho <wedsonaf@google.com>
+M:	Wedson Almeida Filho <wedsonaf@gmail.com>
 R:	Boqun Feng <boqun.feng@gmail.com>
 R:	Gary Guo <gary@garyguo.net>
 R:	Björn Roy Baron <bjorn3_gh@protonmail.com>


### PR DESCRIPTION
Link: https://lore.kernel.org/lkml/CANeycqo3O3yh2ms6vpHkzBLtT7QuCYWeweLq_z9SVygsot43YA@mail.gmail.com/
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>