### PR TITLE
Fix rust-analyzer's complaint about not finding proc macro library

### DIFF
--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -65,7 +65,7 @@ def generate_crates(srctree, objtree, sysroot_src):
         [],
         is_proc_macro=True,
     )
-    crates[-1]["proc_macro_dylib_path"] = "rust/libmacros.so"
+    crates[-1]["proc_macro_dylib_path"] = str((objtree / "rust/libmacros.so").resolve(True))
 
     append_crate(
         "build_error",


### PR DESCRIPTION
The generated rust-project.json contains:
```json
      {
            "cfg": [],
            "deps": [],
            "display_name": "macros",
            "edition": "2021",
            "env": {
                "RUST_MODFILE": "This is only for rust-analyzer"
            },
            "is_proc_macro": true,
            "is_workspace_member": true,
            "proc_macro_dylib_path": "rust/libmacros.so",
            "root_module": "***/rust/macros/lib.rs"
        },
```
If we use this file in an out-of-tree module to let rust-analyzer index symbols it will complain about not finding proc macro library
<img width="924" alt="image" src="https://user-images.githubusercontent.com/41831480/196451558-04e2bc81-43eb-454b-b2b6-052c0046f1c2.png">

Make `proc_macro_dylib_path` absolute fix this issue.