### PR TITLE
rust: support delay functions

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -655,6 +655,11 @@ int rust_helper_fs_parse(struct fs_context *fc,
 }
 EXPORT_SYMBOL_GPL(rust_helper_fs_parse);
 
+void rust_helper_mdelay(unsigned long usecs) {
+	mdelay(usecs);
+}
+EXPORT_SYMBOL_GPL(rust_helper_mdelay);
+
 void rust_helper_udelay(unsigned long usecs) {
 	udelay(usecs);
 }

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -655,6 +655,16 @@ int rust_helper_fs_parse(struct fs_context *fc,
 }
 EXPORT_SYMBOL_GPL(rust_helper_fs_parse);
 
+void rust_helper_udelay(unsigned long usecs) {
+	udelay(usecs);
+}
+EXPORT_SYMBOL_GPL(rust_helper_udelay);
+
+void rust_helper_ndelay(unsigned long nsecs) {
+	ndelay(nsecs);
+}
+EXPORT_SYMBOL_GPL(rust_helper_ndelay);
+
 /*
  * We use `bindgen`'s `--size_t-is-usize` option to bind the C `size_t` type
  * as the Rust `usize` type, so we can use it in contexts where Rust

--- a/rust/kernel/delay.rs
+++ b/rust/kernel/delay.rs
@@ -56,6 +56,18 @@ pub fn coarse_sleep(duration: Duration) {
     unsafe { bindings::msleep(coarse_sleep_conversion(duration)) }
 }
 
+/// busy wait for enough loop cycles to achieve the desired delay.
+///
+/// This function supports the C side `mdelay`, `udelay`, and `ndelay` functions.
+pub fn coarse_delay(duration: Duration) {
+    let usecs = duration.subsec_micros();
+    if usecs == 0 {
+        unsafe { bindings::ndelay(duration.subsec_nanos() as _) }
+    } else {
+        unsafe { bindings::udelay(usecs as _) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{coarse_sleep_conversion, MILLIS_PER_SEC};

--- a/rust/kernel/delay.rs
+++ b/rust/kernel/delay.rs
@@ -60,11 +60,26 @@ pub fn coarse_sleep(duration: Duration) {
 ///
 /// This function supports the C side `mdelay`, `udelay`, and `ndelay` functions.
 pub fn coarse_delay(duration: Duration) {
-    let usecs = duration.subsec_micros();
-    if usecs == 0 {
-        unsafe { bindings::ndelay(duration.subsec_nanos() as _) }
+    let millis = min(
+        duration
+            .as_secs()
+            .saturating_mul(1_000)
+            .saturating_add(duration.subsec_millis() as u64) as core::ffi::c_ulong,
+        core::ffi::c_ulong::MAX,
+    );
+
+    if millis == 0 {
+        let usecs = duration.subsec_micros();
+        if usecs == 0 {
+            // SAFETY: `ndelay` is safe for all values of its argument.
+            unsafe { bindings::ndelay(duration.subsec_nanos() as _) }
+        } else {
+            // SAFETY: `udelay` is safe for all values of its argument.
+            unsafe { bindings::udelay(usecs as _) }
+        }
     } else {
-        unsafe { bindings::udelay(usecs as _) }
+        // SAFETY: `mdelay` is safe for all values of its argument.
+        unsafe { bindings::mdelay(millis) }
     }
 }
 

--- a/rust/kernel/delay.rs
+++ b/rust/kernel/delay.rs
@@ -60,13 +60,10 @@ pub fn coarse_sleep(duration: Duration) {
 ///
 /// This function supports the C side `mdelay`, `udelay`, and `ndelay` functions.
 pub fn coarse_delay(duration: Duration) {
-    let millis = min(
-        duration
-            .as_secs()
-            .saturating_mul(1_000)
-            .saturating_add(duration.subsec_millis() as u64) as core::ffi::c_ulong,
-        core::ffi::c_ulong::MAX,
-    );
+    let millis = duration
+        .as_secs()
+        .saturating_mul(1_000)
+        .saturating_add(duration.subsec_millis() as u64) as core::ffi::c_ulong;
 
     if millis == 0 {
         let usecs = duration.subsec_micros();


### PR DESCRIPTION
support the C side mdelay(), udelay(), and ndelay() functions. Device drivers need them.