### PR TITLE
Verify that libclang is present

### DIFF
--- a/scripts/rust_is_available.sh
+++ b/scripts/rust_is_available.sh
@@ -106,6 +106,17 @@ bindgen_libclang_version=$( \
 		| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
 		| head -n 1 \
 )
+
+# Check that libclang is present.
+if [ -z $bindgen_libclang_version ]; then
+	if [ "$1" = -v ]; then
+		echo >&2 "***"
+		echo >&2 "*** libclang (used by the Rust bindings generator '$BINDGEN') does not seem to be present."
+		echo >&2 "***"
+	fi
+	exit 1
+fi
+
 bindgen_libclang_min_version=$($min_tool_version llvm)
 bindgen_libclang_cversion=$(get_canonical_version $bindgen_libclang_version)
 bindgen_libclang_min_cversion=$(get_canonical_version $bindgen_libclang_min_version)


### PR DESCRIPTION
This adds a verification to the `rust_is_available.sh` script that checks whether `libclang` is present. Without this, if it is is not present, the script returns an error when computing the canonical version.

The reason for sending this is that developers that are new to rust kernel support might easily miss installing it as they might assume (as I did) that `bindgen` installs it.

Signed-off-by: Alexandru Radovici <msg4alex@gmail.com>
