### PR TITLE
rust: build_error: fix several issues and remove `WARN`

### DIFF
--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -2820,12 +2820,6 @@ config RUST_BUILD_ASSERT_ALLOW
 	  Unoptimized calls to `build_error!` will be converted to `panic!`
 	  and checked at runtime.
 
-config RUST_BUILD_ASSERT_WARN
-	bool "Warn"
-	help
-	  Unoptimized calls to `build_error!` will be converted to `panic!`
-	  and checked at runtime, but warnings will be generated when building.
-
 config RUST_BUILD_ASSERT_DENY
 	bool "Deny"
 	help

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -2800,32 +2800,21 @@ config RUST_OVERFLOW_CHECKS
 
 	  If unsure, say Y.
 
-choice
-	prompt "Build-time assertions"
-	default RUST_BUILD_ASSERT_DENY
+config RUST_BUILD_ASSERT_ALLOW
+	bool "Allow unoptimized build-time assertions"
 	depends on RUST
 	help
 	  Controls how are `build_error!` and `build_assert!` handled during build.
 
 	  If calls to them exist in the binary, it may indicate a violated invariant
 	  or that the optimizer failed to verify the invariant during compilation.
-	  You can choose to abort compilation or ignore them during build and let the
-	  check be carried to runtime.
 
-	  If unsure, say "Deny".
+	  This should not happen, thus by default the build is aborted. However,
+	  as an escape hatch, you can choose Y here to ignore them during build
+	  and let the check be carried at runtime (with `panic!` being called if
+	  the check fails).
 
-config RUST_BUILD_ASSERT_ALLOW
-	bool "Allow"
-	help
-	  Unoptimized calls to `build_error!` will be converted to `panic!`
-	  and checked at runtime.
-
-config RUST_BUILD_ASSERT_DENY
-	bool "Deny"
-	help
-	  Unoptimized calls to `build_error!` will abort compilation.
-
-endchoice
+	  If unsure, say N.
 
 config RUST_KERNEL_KUNIT_TEST
 	bool "KUnit test for the `kernel` crate" if !KUNIT_ALL_TESTS

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -2812,8 +2812,6 @@ choice
 	  You can choose to abort compilation or ignore them during build and let the
 	  check be carried to runtime.
 
-	  If optimizations are turned off, you cannot select "Deny".
-
 	  If unsure, say "Deny".
 
 config RUST_BUILD_ASSERT_ALLOW

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -19,10 +19,10 @@ obj-$(CONFIG_RUST) += alloc.o bindings.o kernel.o
 always-$(CONFIG_RUST) += exports_alloc_generated.h exports_bindings_generated.h \
     exports_kernel_generated.h
 
-ifdef CONFIG_RUST_BUILD_ASSERT_DENY
-always-$(CONFIG_RUST) += build_error.o
-else
+ifdef CONFIG_RUST_BUILD_ASSERT_ALLOW
 obj-$(CONFIG_RUST) += build_error.o
+else
+always-$(CONFIG_RUST) += build_error.o
 endif
 
 obj-$(CONFIG_RUST) += exports.o

--- a/rust/build_error.rs
+++ b/rust/build_error.rs
@@ -22,8 +22,3 @@
 pub const fn build_error(msg: &'static str) -> ! {
     panic!("{}", msg);
 }
-
-#[cfg(CONFIG_RUST_BUILD_ASSERT_WARN)]
-#[link_section = ".gnu.warning.rust_build_error"]
-#[used]
-static BUILD_ERROR_WARNING: [u8; 45] = *b"call to build_error present after compilation";

--- a/rust/exports.c
+++ b/rust/exports.c
@@ -21,6 +21,6 @@
 #include "exports_kernel_generated.h"
 
 // For modules using `rust/build_error.rs`.
-#ifndef CONFIG_RUST_BUILD_ASSERT_DENY
+#ifdef CONFIG_RUST_BUILD_ASSERT_ALLOW
 EXPORT_SYMBOL_RUST_GPL(rust_build_error);
 #endif

--- a/rust/exports.c
+++ b/rust/exports.c
@@ -19,3 +19,8 @@
 #include "exports_alloc_generated.h"
 #include "exports_bindings_generated.h"
 #include "exports_kernel_generated.h"
+
+// For modules using `rust/build_error.rs`.
+#ifndef CONFIG_RUST_BUILD_ASSERT_DENY
+EXPORT_SYMBOL_RUST_GPL(rust_build_error);
+#endif


### PR DESCRIPTION
Several fixes to `build_error`:
  - Remove outdated optimization note.
  - Export the symbol for loadable modules.
  - Remove `WARN` support since it doesn't work on non-GNU linkers nor loadable modules.
  - Since now it is only 2 choices, use a `config`.

See individual commits for details.

Cc'ing @nbdd0121 since we were discussing them.