### PR TITLE
ci: reduce frequency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   pull_request: {}
   schedule:
-    - cron: '30 5,17 * * *'
+    - cron: '0 8 * * MON,WED,FRI'
   push:
 
 jobs:


### PR DESCRIPTION
Reduce the frequency from 14 times a week to 3 (08:00 UTC on Monday, Wednesday and Friday), since the `rust` branch does not change that often now, PRs run the CI too and other services are/will also be testing the different branches (e.g. 0-DAY CI, KernelCI...).

Suggested-by: Alex Gaynor <alex.gaynor@gmail.com>
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>