### PR TITLE
add initial support for reset framework

### DIFF
--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -31,6 +31,7 @@
 #include <linux/platform_device.h>
 #include <linux/poll.h>
 #include <linux/random.h>
+#include <linux/reset.h>
 #include <linux/security.h>
 #include <linux/slab.h>
 #include <linux/sysctl.h>

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -34,6 +34,7 @@
 #include <linux/netdevice.h>
 #include <linux/of_device.h>
 #include <linux/platform_device.h>
+#include <linux/reset.h>
 #include <linux/sched/signal.h>
 #include <linux/security.h>
 #include <linux/skbuff.h>
@@ -45,6 +46,12 @@ __noreturn void rust_helper_BUG(void)
 	BUG();
 }
 EXPORT_SYMBOL_GPL(rust_helper_BUG);
+
+struct reset_control *rust_helper_reset_control_get_optional_exclusive(struct device *dev, const char *id)
+{
+	return __reset_control_get(dev, id, 0, false, true, true);
+}
+EXPORT_SYMBOL_GPL(rust_helper_reset_control_get_optional_exclusive);
 
 void rust_helper_clk_disable_unprepare(struct clk *clk)
 {

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -65,6 +65,8 @@ pub mod mm;
 pub mod net;
 pub mod pages;
 pub mod power;
+#[cfg(CONFIG_RESET_CONTROLLER)]
+pub mod reset;
 pub mod revocable;
 pub mod security;
 pub mod str;

--- a/rust/kernel/reset.rs
+++ b/rust/kernel/reset.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Reset controller abstractions.
+//!
+//! C header: [`include/linux/reset.h`](../../../../include/linux/reset.h)
+
+use crate::{bindings, to_result, Result};
+
+/// Represents `struct reset_control *`.
+///
+/// # Invariants
+///
+/// The pointer is valid.
+pub struct Reset(*mut bindings::reset_control);
+
+// SAFETY: ‘Reset‘ is not restricted to a single thread so it is safe
+// to move it between threads
+unsafe impl Send for Reset {}
+
+impl Reset {
+    /// Creates a new reset_control structure from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be valid.
+    pub unsafe fn new(rst: *mut bindings::reset_control) -> Self {
+        Self(rst)
+    }
+
+    /// Resets the reset control
+    pub fn control_reset(&self) -> Result {
+        // SAFETY: The pointer is valid by the type invariant.
+        to_result(unsafe { bindings::reset_control_reset(self.0) })
+    }
+}
+
+impl Drop for Reset {
+    fn drop(&mut self) {
+        // SAFETY: The pointer is valid by the type invariant.
+        unsafe { bindings::reset_control_put(self.0) };
+    }
+}


### PR DESCRIPTION
This patch adds a basic abstraction over `reset.h`.

It provides the following:

* `Reset` struct wrapper over `struct reset_control *`
* `control_reset()` method for type `Reset`
* `reset_control_get_optional_exclusive()` method for type `device::RawDevice`
* constructor and drop for `Reset`

Signed-off-by: Nikos Maragkos <nmaragkos@ceid.upatras.gr>