### PR TITLE
Add rust/.kunitconfig and document unit testing

### DIFF
--- a/Documentation/rust/index.rst
+++ b/Documentation/rust/index.rst
@@ -13,6 +13,7 @@ in the kernel, please read the quick-start.rst guide.
     general-information
     coding-guidelines
     arch-support
+    testing
 
 .. only::  subproject and html
 

--- a/Documentation/rust/testing.rst
+++ b/Documentation/rust/testing.rst
@@ -1,0 +1,52 @@
+.. SPDX-License-Identifier: GPL-2.0
+
+Testing
+=======
+
+Like in any other Rust project it is possible to write and run unit tests and
+documentation tests in the kernel.
+
+Running Unit Tests
+------------------
+
+Unit tests in the kernel are identical to user-space Rust tests:
+
+.. code-block:: rust
+
+	#[cfg(test)]
+	mod tests {
+	    #[test]
+	    fn it_works() {
+	        let result = 2 + 2;
+	        assert_eq!(result, 4);
+	    }
+	}
+
+And can be run using the ``rusttest`` Make target:
+
+.. code-block:: bash
+
+	$ make LLVM=1 rusttest
+
+Running Documentation Tests
+---------------------------
+
+Like in user-space, it is possible to write documentation tests:
+
+.. code-block:: rust
+
+	/// ```
+	/// let result = 2 + 2;
+	/// assert_eq!(result, 4);
+	/// ```
+
+Documentation tests use KUnit and it is possible to run them either on boot or
+using the ``kunit.py`` tool:
+
+.. code-block:: bash
+
+	$ ./tools/testing/kunit/kunit.py run --kunitconfig=rust \
+	  --make_options LLVM=1 --arch=x86_64
+
+For general information about KUnit and `kunit.py``, please refer to
+Documentation/dev-tools/kunit/start.rst.

--- a/rust/.kunitconfig
+++ b/rust/.kunitconfig
@@ -1,0 +1,6 @@
+CONFIG_KUNIT=y
+CONFIG_RUST=y
+CONFIG_RUST_KERNEL_KUNIT_TEST=y
+
+# UML is not supported at the moment
+CONFIG_UML=n


### PR DESCRIPTION
Hi everyone,

This series adds a `rust/.kunitconfig` file with the required configuration options to allow to easily run the KUnit tests without adding them manually using `--kconfig_add`.
A similar approach is used in other subsystems, like HID or DRM, to simplify running the tests.

I found information about the `rusttest` make target in the quick start guide, but, I wasn't able to find information about how to run the documentation tests, so I added a page explaining how to do it.

Note that `--arch=x86_64` is mentioned in the documentation because UML is not working at the moment. Once https://github.com/Rust-for-Linux/linux/pull/881 is merged, the flag can be dropped from the documentation.

cc @sulix