### PR TITLE
Get bindgen libclang version correctly

### DIFF
--- a/scripts/rust_is_available.sh
+++ b/scripts/rust_is_available.sh
@@ -104,7 +104,7 @@ bindgen_libclang_version=$( \
 	LC_ALL=C "$BINDGEN" $(dirname $0)/rust_is_available_bindgen_libclang.h 2>&1 >/dev/null \
 		| grep -F 'clang version ' \
 		| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
-		| head -n 1 \
+		| tail -n 1 \
 )
 bindgen_libclang_min_version=$($min_tool_version llvm)
 bindgen_libclang_cversion=$(get_canonical_version $bindgen_libclang_version)


### PR DESCRIPTION
Currently the way to retreive the bindgen libclang version is susceptible to versions within the path. This commit fixes that by using `tail` rather than `head` on the version results. Fixes #942 .