### PR TITLE
rust: delete rust-project.json when running make mrproper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1573,7 +1573,7 @@ endif # CONFIG_MODULES
 CLEAN_FILES += include/ksym vmlinux.symvers modules-only.symvers \
 	       modules.builtin modules.builtin.modinfo modules.nsdeps \
 	       compile_commands.json .thinlto-cache rust/test rust/doc \
-	       .vmlinux.objs .vmlinux.export.c
+	       rust-project.json .vmlinux.objs .vmlinux.export.c
 
 # Directories & files removed with 'make mrproper'
 MRPROPER_FILES += include/config include/generated          \


### PR DESCRIPTION
rust-project.json is the configuration file used by rust-analyzer. As it is a configuration file, it should be deleted by make mrproper. So, delete rust-project.json when running make mrproper.

Closes #939 

Link: https://github.com/Rust-for-Linux/linux/issues/939
Signed-off-by: Maíra Canal <mcanal@igalia.com>