### PR TITLE
Experimental PR for introducing klint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.gcno
 *.gz
 *.i
+*.klint
 *.ko
 *.lex.c
 *.ll

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -382,6 +382,7 @@ quiet_cmd_rustc_library = $(if $(skip_clippy),RUSTC,$(RUSTC_OR_CLIPPY_QUIET)) L 
 	$(if $(skip_clippy),$(RUSTC),$(RUSTC_OR_CLIPPY)) \
 		$(filter-out $(skip_flags),$(rust_flags) $(rustc_target_flags)) \
 		--emit=dep-info,obj,metadata --crate-type rlib \
+		-Zcrate-attr='feature(register_tool)' -Zcrate-attr='register_tool(klint)' \
 		--out-dir $(objtree)/$(obj) -L$(objtree)/$(obj) \
 		--crate-name $(patsubst %.o,%,$(notdir $@)) $<; \
 	mv $(objtree)/$(obj)/$(patsubst %.o,%,$(notdir $@)).d $(depfile); \

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -11,7 +11,7 @@ use crate::{
     bindings,
     revocable::{Revocable, RevocableGuard},
     str::CStr,
-    sync::{LockClassKey, NeedsLockClass, RevocableMutex, RevocableMutexGuard, UniqueArc},
+    sync::{rcu, LockClassKey, NeedsLockClass, RevocableMutex, RevocableMutexGuard, UniqueArc},
     Result,
 };
 use core::{
@@ -294,7 +294,7 @@ impl<T, U, V> Data<T, U, V> {
     }
 
     /// Returns the resources if they're still available.
-    pub fn resources(&self) -> Option<RevocableGuard<'_, U>> {
+    pub fn resources(&self) -> Result<RevocableGuard<'_, U>, rcu::Guard> {
         self.resources.try_access()
     }
 

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -448,7 +448,7 @@ impl From<core::convert::Infallible> for Error {
 /// Note that even if a function does not return anything when it succeeds,
 /// it should still be modeled as returning a `Result` rather than
 /// just an [`Error`].
-pub type Result<T = ()> = core::result::Result<T, Error>;
+pub type Result<T = (), E = Error> = core::result::Result<T, E>;
 
 impl From<AllocError> for Error {
     fn from(_: AllocError) -> Error {

--- a/rust/kernel/kasync/net.rs
+++ b/rust/kernel/kasync/net.rs
@@ -185,6 +185,7 @@ impl<'a, Out, F: FnMut() -> Result<Out> + Send + 'a> SocketFuture<'a, Out, F> {
     ///
     /// If the state matches the one we're waiting on, we wake up the task so that the future can be
     /// polled again.
+    #[klint::preempt_count(expect = 0..)] // This function can be called from `wake_up` which must noy sleep.
     unsafe extern "C" fn wake_callback(
         wq_entry: *mut bindings::wait_queue_entry,
         _mode: core::ffi::c_uint,

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -279,9 +279,11 @@ rust_allowed_features := allocator_api,const_refs_to_cell
 
 rust_common_cmd = \
 	RUST_MODFILE=$(modfile) $(RUSTC_OR_CLIPPY) $(rust_flags) \
-	-Zallow-features=$(rust_allowed_features) \
+	-Zallow-features=$(rust_allowed_features),register_tool \
 	-Zcrate-attr=no_std \
 	-Zcrate-attr='feature($(rust_allowed_features))' \
+	-Zcrate-attr='feature(register_tool)' \
+	-Zcrate-attr='register_tool(klint)' \
 	--extern alloc --extern kernel \
 	--crate-type rlib --out-dir $(obj) -L $(objtree)/rust/ \
 	--crate-name $(basename $(notdir $@))


### PR DESCRIPTION
This is purely experimental and for demonstration purpose!

How to test it out:
* Compile klint (clone and `cargo build --release`)
* Execute `export LD_LIBRARY_PATH=$(rustup run 1.66.0 bash -c "echo \$LD_LIBRARY_PATH")`
* Run `make RUSTC=<path to klint binary>` on kernel tree