### PR TITLE
gpio: pl061: fix new clippy error

### DIFF
--- a/drivers/gpio/gpio_pl061_rust.rs
+++ b/drivers/gpio/gpio_pl061_rust.rs
@@ -282,7 +282,7 @@ impl amba::Driver for PL061Device {
         )?;
 
         // SAFETY: General part of the data is pinned when `data` is.
-        let gen_inner = unsafe { data.as_mut().map_unchecked_mut(|d| &mut (**d).inner) };
+        let gen_inner = unsafe { data.as_mut().map_unchecked_mut(|d| &mut d.inner) };
         kernel::rawspinlock_init!(gen_inner, "PL061Data::inner");
 
         let data = Arc::<DeviceData>::from(data);


### PR DESCRIPTION
Without this fix, we get the following new clippy error:

```
error: deref which would be done by auto-deref
   --> drivers/gpio/gpio_pl061_rust.rs:285:75
    |
285 |         let gen_inner = unsafe { data.as_mut().map_unchecked_mut(|d| &mut (**d).inner) };
    |                                                                           ^^^^^ help: try this: `d`
    |
```

Signed-off-by: Wedson Almeida Filho <walmeida@microsoft.com>