### PR TITLE
rust: kernel: Mark rust_fmt_argument as extern "C"

### DIFF
--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -18,7 +18,7 @@ use crate::bindings;
 
 // Called from `vsprintf` with format specifier `%pA`.
 #[no_mangle]
-unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_void) -> *mut c_char {
+unsafe extern "C" fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_void) -> *mut c_char {
     use fmt::Write;
     // SAFETY: The C contract guarantees that `buf` is valid if it's less than `end`.
     let mut w = unsafe { RawFormatter::from_ptrs(buf.cast(), end.cast()) };


### PR DESCRIPTION
(As noted in #966. Let me know if you'd rather this go out on the mailing lists, rather than as a PR for rust-fixes.)

The rust_fmt_argument function is called from printk() to handle the %pA format specifier.

Since it's called from C, we should mark it extern "C" to make sure it's ABI compatible.

Fixes: 247b365dc8dc ("rust: add `kernel` crate")
Signed-off-by: David Gow <davidgow@google.com>