### PR TITLE
rust: doctests: Mark generated rustdoc kunit tests extern "C"

### DIFF
--- a/scripts/rustdoc_test_gen.rs
+++ b/scripts/rustdoc_test_gen.rs
@@ -31,7 +31,7 @@ fn main() {
             rust_tests,
             r#"/// Generated `{name}` KUnit test case from a Rust documentation test.
 #[no_mangle]
-pub fn {name}(__kunit_test: *mut kernel::bindings::kunit) {{
+pub extern "C" fn {name}(__kunit_test: *mut kernel::bindings::kunit) {{
     /// Provides mutual exclusion (see `# Implementation` notes).
     static __KUNIT_TEST_MUTEX: kernel::sync::smutex::Mutex<()> =
         kernel::sync::smutex::Mutex::new(());


### PR DESCRIPTION
The generated rustdoc tests were marked no_mangle, but not extern "C". Since these are called from C by KUnit, they should use the C ABI.

This is a follow up to #967 and #966.

I'm away on a different computer than normal, so it's possible I've missed something: rustfmt passed on the ``rustdoc_test_gen.rs`` file itself (since we're just changing the string), but the generated ``doctests_kernel_generated.rs`` has lots of formatting issues. I elected not to try to fix those (they probably depend on the length of the test name), and quite a few predate this patch.