### PR TITLE
Reduce differences with mainline

### DIFF
--- a/rust/build_error.rs
+++ b/rust/build_error.rs
@@ -2,19 +2,26 @@
 
 //! Build-time error.
 //!
-//! This crate provides a function `build_error`, which will panic in
-//! compile-time if executed in const context, and will cause a build error
-//! if not executed at compile time and the optimizer does not optimise away the
-//! call.
+//! This crate provides a [const function][const-functions] `build_error`, which will panic in
+//! compile-time if executed in [const context][const-context], and will cause a build error
+//! if not executed at compile time and the optimizer does not optimise away the call.
 //!
 //! It is used by `build_assert!` in the kernel crate, allowing checking of
 //! conditions that could be checked statically, but could not be enforced in
-//! Rust yet (e.g. perform some checks in const functions, but those
+//! Rust yet (e.g. perform some checks in [const functions][const-functions], but those
 //! functions could still be called in the runtime).
+//!
+//! For details on constant evaluation in Rust, please see the [Reference][const-eval].
+//!
+//! [const-eval]: https://doc.rust-lang.org/reference/const_eval.html
+//! [const-functions]: https://doc.rust-lang.org/reference/const_eval.html#const-functions
+//! [const-context]: https://doc.rust-lang.org/reference/const_eval.html#const-context
 
 #![no_std]
 
-/// Panics if executed in const context, or triggers a build error if not.
+/// Panics if executed in [const context][const-context], or triggers a build error if not.
+///
+/// [const-context]: https://doc.rust-lang.org/reference/const_eval.html#const-context
 #[inline(never)]
 #[cold]
 #[export_name = "rust_build_error"]

--- a/rust/kernel/build_assert.rs
+++ b/rust/kernel/build_assert.rs
@@ -43,7 +43,6 @@ macro_rules! build_error {
 /// These examples show that different types of [`assert!`] will trigger errors
 /// at different stage of compilation. It is preferred to err as early as
 /// possible, so [`static_assert!`] should be used whenever possible.
-// TODO: Could be `compile_fail` when supported.
 /// ```ignore
 /// fn foo() {
 ///     static_assert!(1 > 1); // Compile-time error

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -257,6 +257,12 @@ impl fmt::Debug for Error {
     }
 }
 
+impl From<AllocError> for Error {
+    fn from(_: AllocError) -> Error {
+        code::ENOMEM
+    }
+}
+
 impl From<TryFromIntError> for Error {
     fn from(_: TryFromIntError) -> Error {
         code::EINVAL
@@ -314,12 +320,6 @@ impl From<core::convert::Infallible> for Error {
 /// it should still be modeled as returning a `Result` rather than
 /// just an [`Error`].
 pub type Result<T = ()> = core::result::Result<T, Error>;
-
-impl From<AllocError> for Error {
-    fn from(_: AllocError) -> Error {
-        code::ENOMEM
-    }
-}
 
 // # Invariant: `-bindings::MAX_ERRNO` fits in an `i16`.
 crate::static_assert!(bindings::MAX_ERRNO <= -(i16::MIN as i32) as u32);

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -27,79 +27,42 @@ pub mod code {
     }
 
     declare_err!(EPERM, "Operation not permitted.");
-
     declare_err!(ENOENT, "No such file or directory.");
-
     declare_err!(ESRCH, "No such process.");
-
     declare_err!(EINTR, "Interrupted system call.");
-
     declare_err!(EIO, "I/O error.");
-
     declare_err!(ENXIO, "No such device or address.");
-
     declare_err!(E2BIG, "Argument list too long.");
-
     declare_err!(ENOEXEC, "Exec format error.");
-
     declare_err!(EBADF, "Bad file number.");
-
     declare_err!(ECHILD, "Exec format error.");
-
     declare_err!(EAGAIN, "Try again.");
-
     declare_err!(ENOMEM, "Out of memory.");
-
     declare_err!(EACCES, "Permission denied.");
-
     declare_err!(EFAULT, "Bad address.");
-
     declare_err!(ENOTBLK, "Block device required.");
-
     declare_err!(EBUSY, "Device or resource busy.");
-
     declare_err!(EEXIST, "File exists.");
-
     declare_err!(EXDEV, "Cross-device link.");
-
     declare_err!(ENODEV, "No such device.");
-
     declare_err!(ENOTDIR, "Not a directory.");
-
     declare_err!(EISDIR, "Is a directory.");
-
     declare_err!(EINVAL, "Invalid argument.");
-
     declare_err!(ENFILE, "File table overflow.");
-
     declare_err!(EMFILE, "Too many open files.");
-
     declare_err!(ENOTTY, "Not a typewriter.");
-
     declare_err!(ETXTBSY, "Text file busy.");
-
     declare_err!(EFBIG, "File too large.");
-
     declare_err!(ENOSPC, "No space left on device.");
-
     declare_err!(ESPIPE, "Illegal seek.");
-
     declare_err!(EROFS, "Read-only file system.");
-
     declare_err!(EMLINK, "Too many links.");
-
     declare_err!(EPIPE, "Broken pipe.");
-
     declare_err!(EDOM, "Math argument out of domain of func.");
-
     declare_err!(ERANGE, "Math result not representable.");
-
     declare_err!(EDEADLK, "Resource deadlock would occur");
-
     declare_err!(ENAMETOOLONG, "File name too long");
-
     declare_err!(ENOLCK, "No record locks available");
-
     declare_err!(
         ENOSYS,
         "Invalid system call number.",
@@ -110,201 +73,103 @@ pub mod code {
         "failures due to attempts to use a nonexistent syscall, syscall",
         "implementations should refrain from returning [`ENOSYS`]."
     );
-
     declare_err!(ENOTEMPTY, "Directory not empty.");
-
     declare_err!(ELOOP, "Too many symbolic links encountered.");
-
     declare_err!(EWOULDBLOCK, "Operation would block.");
-
     declare_err!(ENOMSG, "No message of desired type.");
-
     declare_err!(EIDRM, "Identifier removed.");
-
     declare_err!(ECHRNG, "Channel number out of range.");
-
     declare_err!(EL2NSYNC, "Level 2 not synchronized.");
-
     declare_err!(EL3HLT, "Level 3 halted.");
-
     declare_err!(EL3RST, "Level 3 reset.");
-
     declare_err!(ELNRNG, "Link number out of range.");
-
     declare_err!(EUNATCH, "Protocol driver not attached.");
-
     declare_err!(ENOCSI, "No CSI structure available.");
-
     declare_err!(EL2HLT, "Level 2 halted.");
-
     declare_err!(EBADE, "Invalid exchange.");
-
     declare_err!(EBADR, "Invalid request descriptor.");
-
     declare_err!(EXFULL, "Exchange full.");
-
     declare_err!(ENOANO, "No anode.");
-
     declare_err!(EBADRQC, "Invalid request code.");
-
     declare_err!(EBADSLT, "Invalid slot.");
-
     declare_err!(EDEADLOCK, "Resource deadlock would occur.");
-
     declare_err!(EBFONT, "Bad font file format.");
-
     declare_err!(ENOSTR, "Device not a stream.");
-
     declare_err!(ENODATA, "No data available.");
-
     declare_err!(ETIME, "Timer expired.");
-
     declare_err!(ENOSR, "Out of streams resources.");
-
     declare_err!(ENONET, "Machine is not on the network.");
-
     declare_err!(ENOPKG, "Package not installed.");
-
     declare_err!(EREMOTE, "Object is remote.");
-
     declare_err!(ENOLINK, "Link has been severed.");
-
     declare_err!(EADV, "Advertise error.");
-
     declare_err!(ESRMNT, "Srmount error.");
-
     declare_err!(ECOMM, "Communication error on send.");
-
     declare_err!(EPROTO, "Protocol error.");
-
     declare_err!(EMULTIHOP, "Multihop attempted.");
-
     declare_err!(EDOTDOT, "RFS specific error.");
-
     declare_err!(EBADMSG, "Not a data message.");
-
     declare_err!(EOVERFLOW, "Value too large for defined data type.");
-
     declare_err!(ENOTUNIQ, "Name not unique on network.");
-
     declare_err!(EBADFD, "File descriptor in bad state.");
-
     declare_err!(EREMCHG, "Remote address changed.");
-
     declare_err!(ELIBACC, "Can not access a needed shared library.");
-
     declare_err!(ELIBBAD, "Accessing a corrupted shared library.");
-
     declare_err!(ELIBSCN, ".lib section in a.out corrupted.");
-
     declare_err!(ELIBMAX, "Attempting to link in too many shared libraries.");
-
     declare_err!(ELIBEXEC, "Cannot exec a shared library directly.");
-
     declare_err!(EILSEQ, "Illegal byte sequence.");
-
     declare_err!(ERESTART, "Interrupted system call should be restarted.");
-
     declare_err!(ESTRPIPE, "Streams pipe error.");
-
     declare_err!(EUSERS, "Too many users.");
-
     declare_err!(ENOTSOCK, "Socket operation on non-socket.");
-
     declare_err!(EDESTADDRREQ, "Destination address required.");
-
     declare_err!(EMSGSIZE, "Message too long.");
-
     declare_err!(EPROTOTYPE, "Protocol wrong type for socket.");
-
     declare_err!(ENOPROTOOPT, "Protocol not available.");
-
     declare_err!(EPROTONOSUPPORT, "Protocol not supported.");
-
     declare_err!(ESOCKTNOSUPPORT, "Socket type not supported.");
-
     declare_err!(EOPNOTSUPP, "Operation not supported on transport endpoint.");
-
     declare_err!(EPFNOSUPPORT, "Protocol family not supported.");
-
     declare_err!(EAFNOSUPPORT, "Address family not supported by protocol.");
-
     declare_err!(EADDRINUSE, "Address already in use.");
-
     declare_err!(EADDRNOTAVAIL, "Cannot assign requested address.");
-
     declare_err!(ENETDOWN, "Network is down.");
-
     declare_err!(ENETUNREACH, "Network is unreachable.");
-
     declare_err!(ENETRESET, "Network dropped connection because of reset.");
-
     declare_err!(ECONNABORTED, "Software caused connection abort.");
-
     declare_err!(ECONNRESET, "Connection reset by peer.");
-
     declare_err!(ENOBUFS, "No buffer space available.");
-
     declare_err!(EISCONN, "Transport endpoint is already connected.");
-
     declare_err!(ENOTCONN, "Transport endpoint is not connected.");
-
     declare_err!(ESHUTDOWN, "Cannot send after transport endpoint shutdown.");
-
     declare_err!(ETOOMANYREFS, "Too many references: cannot splice.");
-
     declare_err!(ETIMEDOUT, "Connection timed out.");
-
     declare_err!(ECONNREFUSED, "Connection refused.");
-
     declare_err!(EHOSTDOWN, "Host is down.");
-
     declare_err!(EHOSTUNREACH, "No route to host.");
-
     declare_err!(EALREADY, "Operation already in progress.");
-
     declare_err!(EINPROGRESS, "Operation now in progress.");
-
     declare_err!(ESTALE, "Stale file handle.");
-
     declare_err!(EUCLEAN, "Structure needs cleaning.");
-
     declare_err!(ENOTNAM, "Not a XENIX named type file.");
-
     declare_err!(ENAVAIL, "No XENIX semaphores available.");
-
     declare_err!(EISNAM, "Is a named type file.");
-
     declare_err!(EREMOTEIO, "Remote I/O error.");
-
     declare_err!(EDQUOT, "Quota exceeded.");
-
     declare_err!(ENOMEDIUM, "No medium found.");
-
     declare_err!(EMEDIUMTYPE, "Wrong medium type.");
-
     declare_err!(ECANCELED, "Operation Canceled.");
-
     declare_err!(ENOKEY, "Required key not available.");
-
     declare_err!(EKEYEXPIRED, "Key has expired.");
-
     declare_err!(EKEYREVOKED, "Key has been revoked.");
-
     declare_err!(EKEYREJECTED, "Key was rejected by service.");
-
     declare_err!(EOWNERDEAD, "Owner died.", "", "For robust mutexes.");
-
     declare_err!(ENOTRECOVERABLE, "State not recoverable.");
-
     declare_err!(ERFKILL, "Operation not possible due to RF-kill.");
-
     declare_err!(EHWPOISON, "Memory page has hardware error.");
-
     declare_err!(ERESTARTSYS, "Restart the system call.");
-
     declare_err!(ENOTSUPP, "Operation is not supported.");
-
     declare_err!(ENOPARAM, "Parameter not supported.");
 }
 

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -117,7 +117,7 @@ use core::marker::PhantomData;
 /// [`PAGE_SHIFT`]: ../../../include/asm-generic/page.h
 pub const PAGE_SIZE: usize = 1 << bindings::PAGE_SHIFT;
 
-/// Prefix to appear before log messages printed from within the kernel crate.
+/// Prefix to appear before log messages printed from within the `kernel` crate.
 const __LOG_PREFIX: &[u8] = b"rust_kernel\0";
 
 /// The top level entrypoint to implementing a kernel module.

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -34,10 +34,19 @@ compile_error!("Missing kernel configuration for conditional compilation");
 #[cfg(not(test))]
 #[cfg(not(testlib))]
 mod allocator;
+mod build_assert;
+pub mod error;
+pub mod prelude;
+pub mod print;
+mod static_assert;
+#[doc(hidden)]
+pub mod std_vendor;
+pub mod str;
+pub mod sync;
+pub mod types;
 
 #[doc(hidden)]
 pub use bindings;
-
 pub use macros;
 
 #[cfg(CONFIG_ARM_AMBA)]
@@ -49,7 +58,6 @@ pub mod cred;
 pub mod delay;
 pub mod device;
 pub mod driver;
-pub mod error;
 pub mod file;
 pub mod fs;
 pub mod gpio;
@@ -64,7 +72,6 @@ pub mod pages;
 pub mod power;
 pub mod revocable;
 pub mod security;
-pub mod str;
 pub mod task;
 pub mod workqueue;
 
@@ -76,14 +83,7 @@ pub mod unsafe_list;
 #[doc(hidden)]
 pub mod module_param;
 
-mod build_assert;
-pub mod prelude;
-pub mod print;
 pub mod random;
-mod static_assert;
-#[doc(hidden)]
-pub mod std_vendor;
-pub mod sync;
 
 #[cfg(any(CONFIG_SYSCTL, doc))]
 #[doc(cfg(CONFIG_SYSCTL))]
@@ -95,7 +95,6 @@ pub mod io_mem;
 pub mod iov_iter;
 pub mod of;
 pub mod platform;
-mod types;
 pub mod user_ptr;
 
 #[cfg(CONFIG_KUNIT)]

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -11,16 +11,22 @@
 //! use kernel::prelude::*;
 //! ```
 
+#[doc(no_inline)]
 pub use core::pin::Pin;
 
+#[doc(no_inline)]
 pub use alloc::{boxed::Box, string::String, vec::Vec};
 
+#[doc(no_inline)]
 pub use macros::{module, vtable};
 
 pub use super::build_assert;
 
+// `super::std_vendor` is hidden, which makes the macro inline for some reason.
+#[doc(no_inline)]
+pub use super::dbg;
 pub use super::{
-    dbg, dev_alert, dev_crit, dev_dbg, dev_emerg, dev_err, dev_info, dev_notice, dev_warn, fmt,
+    dev_alert, dev_crit, dev_dbg, dev_emerg, dev_err, dev_info, dev_notice, dev_warn, fmt,
     pr_alert, pr_crit, pr_debug, pr_emerg, pr_err, pr_info, pr_notice, pr_warn,
 };
 

--- a/rust/kernel/prelude.rs
+++ b/rust/kernel/prelude.rs
@@ -37,6 +37,6 @@ pub use super::module_amba_driver;
 
 pub use super::static_assert;
 
-pub use super::{error::code::*, Error, Result};
+pub use super::error::{code::*, Error, Result};
 
 pub use super::{str::CStr, ARef, ThisModule};

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -142,17 +142,24 @@ pub fn call_printk_cont(args: fmt::Arguments<'_>) {
 macro_rules! print_macro (
     // The non-continuation cases (most of them, e.g. `INFO`).
     ($format_string:path, false, $($arg:tt)+) => (
-        // SAFETY: This hidden macro should only be called by the documented
-        // printing macros which ensure the format string is one of the fixed
-        // ones. All `__LOG_PREFIX`s are null-terminated as they are generated
-        // by the `module!` proc macro or fixed values defined in a kernel
-        // crate.
-        unsafe {
-            $crate::print::call_printk(
-                &$format_string,
-                crate::__LOG_PREFIX,
-                format_args!($($arg)+),
-            );
+        // To remain sound, `arg`s must be expanded outside the `unsafe` block.
+        // Typically one would use a `let` binding for that; however, `format_args!`
+        // takes borrows on the arguments, but does not extend the scope of temporaries.
+        // Therefore, a `match` expression is used to keep them around, since
+        // the scrutinee is kept until the end of the `match`.
+        match format_args!($($arg)+) {
+            // SAFETY: This hidden macro should only be called by the documented
+            // printing macros which ensure the format string is one of the fixed
+            // ones. All `__LOG_PREFIX`s are null-terminated as they are generated
+            // by the `module!` proc macro or fixed values defined in a kernel
+            // crate.
+            args => unsafe {
+                $crate::print::call_printk(
+                    &$format_string,
+                    crate::__LOG_PREFIX,
+                    args,
+                );
+            }
         }
     );
 

--- a/rust/kernel/std_vendor.rs
+++ b/rust/kernel/std_vendor.rs
@@ -101,7 +101,6 @@
 ///
 /// The `dbg!(..)` macro moves the input:
 ///
-// TODO: Could be `compile_fail` when supported.
 /// ```ignore
 /// /// A wrapper around `usize` which importantly is not Copyable.
 /// #[derive(Debug)]

--- a/rust/kernel/std_vendor.rs
+++ b/rust/kernel/std_vendor.rs
@@ -35,9 +35,12 @@
 /// This is useful when debugging issues that only occur in release
 /// builds or when debugging in release mode is significantly faster.
 ///
-/// Note that the macro is intended as a debugging tool and therefore you
-/// should avoid having uses of it in version control for long periods
-/// (other than in tests and similar).
+/// Note that the macro is intended as a temporary debugging tool to be
+/// used during development. Therefore, avoid committing `dbg!` macro
+/// invocations into the kernel tree.
+///
+/// For debug output that is intended to be kept in the kernel tree,
+/// use [`pr_debug`] and similar facilities instead.
 ///
 /// # Stability
 ///
@@ -134,6 +137,7 @@
 ///
 /// [`std::dbg`]: https://doc.rust-lang.org/std/macro.dbg.html
 /// [`pr_info`]: crate::pr_info
+/// [`pr_debug`]: crate::pr_debug
 /// [`eprintln`]: https://doc.rust-lang.org/std/macro.eprintln.html
 /// [`printk`]: https://www.kernel.org/doc/html/latest/core-api/printk-basics.html
 #[macro_export]

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -6,7 +6,10 @@ use alloc::vec::Vec;
 use core::fmt::{self, Write};
 use core::ops::{self, Deref, Index};
 
-use crate::{bindings, error::code::*, Error};
+use crate::{
+    bindings,
+    error::{code::*, Error},
+};
 
 /// Byte string without UTF-8 validity guarantee.
 ///

--- a/rust/kernel/sync.rs
+++ b/rust/kernel/sync.rs
@@ -3,7 +3,7 @@
 //! Synchronisation primitives.
 //!
 //! This module contains the kernel APIs related to synchronisation that have been ported or
-//! wrapped for usage by Rust code in the kernel and is shared by all of them.
+//! wrapped for usage by Rust code in the kernel.
 //!
 //! # Examples
 //!

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -518,7 +518,7 @@ impl<T: ?Sized> Deref for ArcBorrow<'_, T> {
 ///     Ok(x.into())
 /// }
 ///
-/// # test();
+/// # test().unwrap();
 /// ```
 ///
 /// In the following example we first allocate memory for a ref-counted `Example` but we don't
@@ -539,7 +539,7 @@ impl<T: ?Sized> Deref for ArcBorrow<'_, T> {
 ///     Ok(x.write(Example { a: 10, b: 20 }).into())
 /// }
 ///
-/// # test();
+/// # test().unwrap();
 /// ```
 ///
 /// In the last example below, the caller gets a pinned instance of `Example` while converting to
@@ -561,7 +561,7 @@ impl<T: ?Sized> Deref for ArcBorrow<'_, T> {
 ///     Ok(pinned.into())
 /// }
 ///
-/// # test();
+/// # test().unwrap();
 /// ```
 pub struct UniqueArc<T: ?Sized> {
     inner: Arc<T>,

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -130,9 +130,6 @@ struct ArcInner<T: ?Sized> {
 // This is to allow [`Arc`] (and variants) to be used as the type of `self`.
 impl<T: ?Sized> core::ops::Receiver for Arc<T> {}
 
-// This is to allow [`ArcBorrow`] (and variants) to be used as the type of `self`.
-impl<T: ?Sized> core::ops::Receiver for ArcBorrow<'_, T> {}
-
 // This is to allow coercion from `Arc<T>` to `Arc<U>` if `T` can be converted to the
 // dynamically-sized type (DST) `U`.
 impl<T: ?Sized + Unsize<U>, U: ?Sized> core::ops::CoerceUnsized<Arc<U>> for Arc<T> {}
@@ -435,6 +432,9 @@ pub struct ArcBorrow<'a, T: ?Sized + 'a> {
     inner: NonNull<ArcInner<T>>,
     _p: PhantomData<&'a ()>,
 }
+
+// This is to allow [`ArcBorrow`] (and variants) to be used as the type of `self`.
+impl<T: ?Sized> core::ops::Receiver for ArcBorrow<'_, T> {}
 
 impl<T: ?Sized> Clone for ArcBorrow<'_, T> {
     fn clone(&self) -> Self {

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -370,14 +370,6 @@ impl<T: ?Sized> From<UniqueArc<T>> for Arc<T> {
     }
 }
 
-impl<T: ?Sized> From<UniqueArc<T>> for Pin<UniqueArc<T>> {
-    fn from(obj: UniqueArc<T>) -> Self {
-        // SAFETY: It is not possible to move/replace `T` inside a `Pin<UniqueArc<T>>` (unless `T`
-        // is `Unpin`), so it is ok to convert it to `Pin<UniqueArc<T>>`.
-        unsafe { Pin::new_unchecked(obj) }
-    }
-}
-
 impl<T: ?Sized> From<Pin<UniqueArc<T>>> for Arc<T> {
     fn from(item: Pin<UniqueArc<T>>) -> Self {
         // SAFETY: The type invariants of `Arc` guarantee that the data is pinned.
@@ -548,6 +540,14 @@ impl<T> UniqueArc<MaybeUninit<T>> {
             // dropped). The types are compatible because `MaybeUninit<T>` is compatible with `T`.
             inner: unsafe { Arc::from_inner(inner.cast()) },
         }
+    }
+}
+
+impl<T: ?Sized> From<UniqueArc<T>> for Pin<UniqueArc<T>> {
+    fn from(obj: UniqueArc<T>) -> Self {
+        // SAFETY: It is not possible to move/replace `T` inside a `Pin<UniqueArc<T>>` (unless `T`
+        // is `Unpin`), so it is ok to convert it to `Pin<UniqueArc<T>>`.
+        unsafe { Pin::new_unchecked(obj) }
     }
 }
 

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -436,6 +436,13 @@ pub struct ArcBorrow<'a, T: ?Sized + 'a> {
 // This is to allow [`ArcBorrow`] (and variants) to be used as the type of `self`.
 impl<T: ?Sized> core::ops::Receiver for ArcBorrow<'_, T> {}
 
+// This is to allow `ArcBorrow<U>` to be dispatched on when `ArcBorrow<T>` can be coerced into
+// `ArcBorrow<U>`.
+impl<T: ?Sized + Unsize<U>, U: ?Sized> core::ops::DispatchFromDyn<ArcBorrow<'_, U>>
+    for ArcBorrow<'_, T>
+{
+}
+
 impl<T: ?Sized> Clone for ArcBorrow<'_, T> {
     fn clone(&self) -> Self {
         *self

--- a/rust/kernel/sync/arc.rs
+++ b/rust/kernel/sync/arc.rs
@@ -67,6 +67,8 @@ use core::{
 /// assert_eq!(cloned.b, 20);
 ///
 /// // The refcount drops to zero when `cloned` goes out of scope, and the memory is freed.
+///
+/// # Ok::<(), Error>(())
 /// ```
 ///
 /// Using `Arc<T>` as the type of `self`:
@@ -92,6 +94,8 @@ use core::{
 /// let obj = Arc::try_new(Example { a: 10, b: 20 })?;
 /// obj.use_reference();
 /// obj.take_over();
+///
+/// # Ok::<(), Error>(())
 /// ```
 ///
 /// Coercion from `Arc<Example>` to `Arc<dyn MyTrait>`:
@@ -115,6 +119,8 @@ use core::{
 ///
 /// // `coerced` has type `Arc<dyn MyTrait>`.
 /// let coerced: Arc<dyn MyTrait> = obj;
+///
+/// # Ok::<(), Error>(())
 /// ```
 pub struct Arc<T: ?Sized> {
     ptr: NonNull<ArcInner<T>>,
@@ -394,7 +400,7 @@ impl<T: ?Sized> From<Pin<UniqueArc<T>>> for Arc<T> {
 /// # Example
 ///
 /// ```
-/// use crate::sync::{Arc, ArcBorrow};
+/// use kernel::sync::{Arc, ArcBorrow};
 ///
 /// struct Example;
 ///
@@ -407,12 +413,14 @@ impl<T: ?Sized> From<Pin<UniqueArc<T>>> for Arc<T> {
 ///
 /// // Assert that both `obj` and `cloned` point to the same underlying object.
 /// assert!(core::ptr::eq(&*obj, &*cloned));
+///
+/// # Ok::<(), Error>(())
 /// ```
 ///
 /// Using `ArcBorrow<T>` as the type of `self`:
 ///
 /// ```
-/// use crate::sync::{Arc, ArcBorrow};
+/// use kernel::sync::{Arc, ArcBorrow};
 ///
 /// struct Example {
 ///     a: u32,
@@ -427,6 +435,8 @@ impl<T: ?Sized> From<Pin<UniqueArc<T>>> for Arc<T> {
 ///
 /// let obj = Arc::try_new(Example { a: 10, b: 20 })?;
 /// obj.as_arc_borrow().use_reference();
+///
+/// # Ok::<(), Error>(())
 /// ```
 pub struct ArcBorrow<'a, T: ?Sized + 'a> {
     inner: NonNull<ArcInner<T>>,

--- a/rust/macros/concat_idents.rs
+++ b/rust/macros/concat_idents.rs
@@ -18,6 +18,6 @@ pub(crate) fn concat_idents(ts: TokenStream) -> TokenStream {
     assert_eq!(expect_punct(&mut it), ',');
     let b = expect_ident(&mut it);
     assert!(it.next().is_none(), "only two idents can be concatenated");
-    let res = Ident::new(&(a.to_string() + &b.to_string()), b.span());
+    let res = Ident::new(&format!("{a}{b}"), b.span());
     TokenStream::from_iter([TokenTree::Ident(res)])
 }


### PR DESCRIPTION
This is part of the effort to minimize the differences of the `rust` branch with respect to mainline in order to eventually drop it.

I have split the changes into small commits to make it a bit easier to see what is going on, but note that they aren't "proper" commits (e.g. authorship properly kept etc.). The branch will eventually go away, thus it is not super important.