### PR TITLE
Platform Device improvements and Timer abstraction

### DIFF
--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -27,6 +27,7 @@
 #include <linux/netfilter_ipv4.h>
 #include <linux/netfilter_ipv6.h>
 #include <linux/of_platform.h>
+#include <linux/timer.h>
 #include <linux/platform_device.h>
 #include <linux/poll.h>
 #include <linux/random.h>

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -192,6 +192,14 @@ void rust_helper_memcpy_fromio(void *to, const volatile void __iomem *from, long
 }
 EXPORT_SYMBOL_GPL(rust_helper_memcpy_fromio);
 
+struct platform_device *
+rust_helper_platform_device_register_simple(const char *name, int id,
+					    const struct resource *res, unsigned int num)
+{
+	return platform_device_register_simple(name, id, res, num);
+}
+EXPORT_SYMBOL_GPL(rust_helper_platform_device_register_simple);
+
 void rust_helper___spin_lock_init(spinlock_t *lock, const char *name,
 				  struct lock_class_key *key)
 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -200,6 +200,12 @@ rust_helper_platform_device_register_simple(const char *name, int id,
 }
 EXPORT_SYMBOL_GPL(rust_helper_platform_device_register_simple);
 
+int rust_helper_dma_coerce_mask_and_coherent(struct device *dev, u64 mask)
+{
+	return dma_coerce_mask_and_coherent(dev, mask);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dma_coerce_mask_and_coherent);
+
 void rust_helper___spin_lock_init(spinlock_t *lock, const char *name,
 				  struct lock_class_key *key)
 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -30,6 +30,7 @@
 #include <linux/irqchip/chained_irq.h>
 #include <linux/irqdomain.h>
 #include <linux/irq.h>
+#include <linux/jiffies.h>
 #include <linux/mutex.h>
 #include <linux/netdevice.h>
 #include <linux/of_device.h>
@@ -37,6 +38,7 @@
 #include <linux/sched/signal.h>
 #include <linux/security.h>
 #include <linux/skbuff.h>
+#include <linux/timer.h>
 #include <linux/uaccess.h>
 #include <linux/uio.h>
 
@@ -375,6 +377,26 @@ void *rust_helper_amba_get_drvdata(struct amba_device *dev)
 	return amba_get_drvdata(dev);
 }
 EXPORT_SYMBOL_GPL(rust_helper_amba_get_drvdata);
+
+int rust_helper_del_timer_sync(struct timer_list *timer)
+{
+	return del_timer_sync(timer);
+}
+EXPORT_SYMBOL_GPL(rust_helper_del_timer_sync);
+
+void rust_helper_timer_setup(struct timer_list *timer,
+			     void (*callback)(struct timer_list *timer),
+			     u32 flags)
+{
+	timer_setup(timer, callback, flags);
+}
+EXPORT_SYMBOL_GPL(rust_helper_timer_setup);
+
+unsigned long rust_helper_msecs_to_jiffies(const unsigned int m)
+{
+	return msecs_to_jiffies(m);
+}
+EXPORT_SYMBOL_GPL(rust_helper_msecs_to_jiffies);
 
 void *
 rust_helper_platform_get_drvdata(const struct platform_device *pdev)

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -36,6 +36,7 @@ compile_error!("Missing kernel configuration for conditional compilation");
 mod allocator;
 mod build_assert;
 pub mod error;
+pub mod timer;
 pub mod prelude;
 pub mod print;
 mod static_assert;

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -166,6 +166,13 @@ pub struct Device {
     ptr: *mut bindings::platform_device,
 }
 
+// SAFETY: `Device` only holds a pointer to a C device, which is safe to be used from any thread.
+unsafe impl Send for Device {}
+
+// SAFETY: `Device` only holds a pointer to a C device, references to which are safe to be used
+// from any thread.
+unsafe impl Sync for Device {}
+
 impl Device {
     /// Creates a new device from the given pointer.
     ///

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -207,6 +207,12 @@ impl Device {
         // SAFETY: By the type invariants, we know that `self.ptr` is non-null and valid.
         unsafe { (*self.ptr).id }
     }
+
+    /// Similar to the above, except it deals with the case where the device
+    /// does not have dev->dma_mask appropriately setup.
+    pub fn coerse_dma_masks(&mut self, mask: u64) -> Result {
+        to_result(unsafe { bindings::dma_coerce_mask_and_coherent(&mut (*self.ptr).dev, mask) })
+    }
 }
 
 impl Drop for Device {

--- a/rust/kernel/timer.rs
+++ b/rust/kernel/timer.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+//! Timer abstraction.
+//!
+//! C header: [`include/linux/timer.h`](../../../../include/linux/timer.h)
+
+use crate::bindings;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::ptr::addr_of_mut;
+use core::time::Duration;
+
+/// Trait which must be implemented by driver-specific timer objects.
+pub trait TimerOps: Sized {
+    /// Type of the Inner data inside the Timer
+    type Inner;
+
+    /// Timer callback
+    fn timer_callback(timer: &UniqueTimer<Self, Self::Inner>);
+}
+
+unsafe extern "C" fn timer_callback<T: TimerOps<Inner = D>, D: Sized>(
+    timer: *mut bindings::timer_list,
+) {
+    let timer = crate::container_of!(timer, UniqueTimer<T, D>, timer) as *mut UniqueTimer<T, D>;
+
+    // SAFETY: The caller is responsible for passing a valid timer_list subtype
+    T::timer_callback(unsafe { &mut *timer });
+}
+
+/// A generic Timer Object
+///
+/// This object should be instantiated by the end user, as it holds
+/// a unique reference to the struct UniqueTimer. The UniqueTimer
+/// methods can be used through it.
+pub struct Timer<T: TimerOps<Inner = D>, D>(*mut UniqueTimer<T, D>);
+
+impl<T: TimerOps<Inner = D>, D> Timer<T, D> {
+    /// Create a timer for its first use
+    pub fn setup(inner: D) -> Self {
+        let t = unsafe {
+            bindings::krealloc(
+                core::ptr::null_mut(),
+                core::mem::size_of::<UniqueTimer<T, D>>(),
+                bindings::GFP_KERNEL | bindings::__GFP_ZERO,
+            ) as *mut UniqueTimer<T, D>
+        };
+
+        // SAFETY: The pointer is valid, so pointers to members are too.
+        // After this, all fields are initialized.
+        unsafe {
+            addr_of_mut!((*t).inner).write(inner);
+            bindings::timer_setup(addr_of_mut!((*t).timer), Some(timer_callback::<T, D>), 0)
+        };
+
+        Self(t)
+    }
+}
+
+impl<T: TimerOps<Inner = D>, D> Drop for Timer<T, D> {
+    fn drop(&mut self) {
+        // SAFETY: inner is never used after this
+        unsafe {
+            core::ptr::drop_in_place(&mut (*self.0).inner);
+        }
+
+        // SAFETY: All of our timers are allocated using kmalloc, so this is safe.
+        unsafe { bindings::del_timer_sync(self.raw()) };
+    }
+}
+
+impl<T: TimerOps<Inner = D>, D> Deref for Timer<T, D> {
+    type Target = UniqueTimer<T, D>;
+
+    fn deref(&self) -> &UniqueTimer<T, D> {
+        unsafe { &*self.0 }
+    }
+}
+
+impl<T: TimerOps<Inner = D>, D> DerefMut for Timer<T, D> {
+    fn deref_mut(&mut self) -> &mut UniqueTimer<T, D> {
+        unsafe { &mut *self.0 }
+    }
+}
+
+/// A driver-specific Timer Object
+///
+/// # Invariants
+/// timer is a valid pointer to a struct timer_list and we own a reference to it.
+#[repr(C)]
+pub struct UniqueTimer<T: TimerOps<Inner = D>, D> {
+    timer: bindings::timer_list,
+    inner: D,
+    _p: PhantomData<T>,
+}
+
+impl<T: TimerOps<Inner = D>, D> UniqueTimer<T, D> {
+    /// Modify a timer's timeout
+    pub fn modify(&self, duration: Duration) {
+        let duration =
+            unsafe { bindings::msecs_to_jiffies(duration.as_millis().try_into().unwrap()) };
+
+        // SAFETY: As defined in the invariants, timer is a valid pointer.
+        unsafe { bindings::mod_timer(self.raw(), bindings::jiffies + duration) };
+    }
+
+    /// Returns the inner value of timer
+    pub fn inner(&self) -> &D {
+        &self.inner
+    }
+
+    /// Returns the raw `struct timer_list` pointer.
+    pub fn raw(&self) -> *mut bindings::timer_list {
+        &self.timer as *const _ as *mut _
+    }
+}


### PR DESCRIPTION
Hi folks,

This PR is a collection of some abstractions that I wrote while developing the VGEM driver in Rust. So, they are dependencies of the driver itself. The complete driver can be seen in this [PR](https://github.com/mairacanal/linux/pull/11), which is rebased on top of Lina's DRM abstractions branch. Also, there is a [blog post](https://mairacanal.github.io/rust-for-vgem/) describing a bit more of the idea of the project.

Unfortunately, this PR cannot be rebased on top of rust-next, because it depends on the Platform Device abstraction. As this is my first time writing safe abstractions, I would like to hear your feedback on the abstractions, especially the Timer abstraction.

Thanks for your attention!