### PR TITLE
ci: upgrade some actions to address deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,13 +95,13 @@ jobs:
 
     steps:
       # Setup: checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Setup: Store matrix name
       - run: echo 'MATRIX_NAME=${{ matrix.arch }}-${{ matrix.toolchain }}-${{ matrix.config }}' >> $GITHUB_ENV
 
       # Setup: Github cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: /root/.ccache
           key: ${{ env.MATRIX_NAME }}-ccache-${{ github.run_id }}


### PR DESCRIPTION
This addresses https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>