### PR TITLE
Improved error message for expect_string[_ascii].

### DIFF
--- a/rust/macros/helpers.rs
+++ b/rust/macros/helpers.rs
@@ -73,7 +73,7 @@ pub(crate) fn expect_string(it: &mut token_stream::IntoIter) -> String {
 }
 
 pub(crate) fn expect_string_ascii(it: &mut token_stream::IntoIter) -> String {
-    let string = try_string(it).expect("Expected string");
+    let string = try_string(it).expect("Expected string, maybe you used a byte string");
     assert!(string.is_ascii(), "Expected ASCII string");
     string
 }

--- a/rust/macros/helpers.rs
+++ b/rust/macros/helpers.rs
@@ -69,7 +69,7 @@ pub(crate) fn expect_group(it: &mut token_stream::IntoIter) -> Group {
 }
 
 pub(crate) fn expect_string(it: &mut token_stream::IntoIter) -> String {
-    try_string(it).expect("Expected string")
+    try_string(it).expect("Expected string, maybe you used a byte string")
 }
 
 pub(crate) fn expect_string_ascii(it: &mut token_stream::IntoIter) -> String {


### PR DESCRIPTION
If a string is expected, but a byte string was provided, the error message now clearly states how to fix the issue.