### PR TITLE
Split Rust arguments into a new `scripts/Makefile.rust`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,26 +452,12 @@ KBUILD_USERHOSTCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
 KBUILD_USERCFLAGS  := $(KBUILD_USERHOSTCFLAGS) $(USERCFLAGS)
 KBUILD_USERLDFLAGS := $(USERLDFLAGS)
 
-# These flags apply to all Rust code in the tree, including the kernel and
-# host programs.
-export rust_common_flags := --edition=2021 \
-			    -Zbinary_dep_depinfo=y \
-			    -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
-			    -Dunreachable_pub -Dnon_ascii_idents \
-			    -Wmissing_docs \
-			    -Drustdoc::missing_crate_level_docs \
-			    -Dclippy::correctness -Dclippy::style \
-			    -Dclippy::suspicious -Dclippy::complexity \
-			    -Dclippy::perf \
-			    -Dclippy::let_unit_value -Dclippy::mut_mut \
-			    -Dclippy::needless_bitwise_bool \
-			    -Dclippy::needless_continue \
-			    -Wclippy::dbg_macro
+# Include configuration for building with Rust
+include $(srctree)/scripts/Makefile.rust
 
 KBUILD_HOSTCFLAGS   := $(KBUILD_USERHOSTCFLAGS) $(HOST_LFS_CFLAGS) $(HOSTCFLAGS)
 KBUILD_HOSTCXXFLAGS := -Wall -O2 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS)
-KBUILD_HOSTRUSTFLAGS := $(rust_common_flags) -O -Cstrip=debuginfo \
-			-Zallow-features= $(HOSTRUSTFLAGS)
+KBUILD_HOSTRUSTFLAGS := $(rust_kbuild_host_flags)
 KBUILD_HOSTLDFLAGS  := $(HOST_LFS_LDFLAGS) $(HOSTLDFLAGS)
 KBUILD_HOSTLDLIBS   := $(HOST_LFS_LIBS) $(HOSTLDLIBS)
 
@@ -560,14 +546,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -Werror=return-type -Wno-format-security -funsigned-char \
 		   -std=gnu11
 KBUILD_CPPFLAGS := -D__KERNEL__
-KBUILD_RUSTFLAGS := $(rust_common_flags) \
-		    --target=$(objtree)/scripts/target.json \
-		    -Cpanic=abort -Cembed-bitcode=n -Clto=n \
-		    -Cforce-unwind-tables=n -Ccodegen-units=1 \
-		    -Csymbol-mangling-version=v0 \
-		    -Crelocation-model=static \
-		    -Zfunction-sections=n \
-		    -Dclippy::float_arithmetic
+KBUILD_RUSTFLAGS := $(rust_kbuild_flags)
 
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=

--- a/scripts/Makefile.rust
+++ b/scripts/Makefile.rust
@@ -1,0 +1,30 @@
+# Configuration of flags specific to Rust support
+
+# These flags apply to all Rust code in the tree, including the kernel and
+# host programs.
+export rust_common_flags := --edition=2021 \
+			    -Zbinary_dep_depinfo=y \
+			    -Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
+			    -Dunreachable_pub -Dnon_ascii_idents \
+			    -Wmissing_docs \
+			    -Drustdoc::missing_crate_level_docs \
+			    -Dclippy::correctness -Dclippy::style \
+			    -Dclippy::suspicious -Dclippy::complexity \
+			    -Dclippy::perf \
+			    -Dclippy::let_unit_value -Dclippy::mut_mut \
+			    -Dclippy::needless_bitwise_bool \
+			    -Dclippy::needless_continue \
+			    -Wclippy::dbg_macro
+
+export rust_kbuild_host_flags := $(rust_common_flags) \
+				 -O -Cstrip=debuginfo \
+				 -Zallow-features= $(HOSTRUSTFLAGS)
+
+export rust_kbuild_flags := $(rust_common_flags) \
+			    --target=$(objtree)/scripts/target.json \
+			    -Cpanic=abort -Cembed-bitcode=n -Clto=n \
+			    -Cforce-unwind-tables=n -Ccodegen-units=1 \
+			    -Csymbol-mangling-version=v0 \
+			    -Crelocation-model=static \
+			    -Zfunction-sections=n \
+			    -Dclippy::float_arithmetic


### PR DESCRIPTION
This follows the discussion at https://github.com/Rust-for-Linux/linux/pull/1025