### PR TITLE
rust: Eschew `Box<MaybeUninit<T>>::write`

### DIFF
--- a/rust/kernel/alloc/box_ext.rs
+++ b/rust/kernel/alloc/box_ext.rs
@@ -37,8 +37,10 @@ pub trait BoxExt<T>: Sized {
 
 impl<T> BoxExt<T> for Box<T> {
     fn new(x: T, flags: Flags) -> Result<Self, AllocError> {
-        let b = <Self as BoxExt<_>>::new_uninit(flags)?;
-        Ok(Box::write(b, x))
+        let mut b = <Self as BoxExt<_>>::new_uninit(flags)?;
+        b.write(x);
+        // SAFETY: We just wrote to it.
+        Ok(unsafe { b.assume_init() })
     }
 
     #[cfg(any(test, testlib))]


### PR DESCRIPTION
T-libs-api has consensus for stabilizing some of `feature(new_uninit)`, but not for `Box<MaybeUninit<T>>::write`. The replacement is trivial, so let's just do that, and RfL can simply move off the feature after it is stabilized. That will happen immediately after this unblocks Rust CI, as the relevant FCP has completed:

https://github.com/rust-lang/rust/issues/63291#issuecomment-2183022955

This is required in advance of the stabilization because any remaining unstable API will be carved up into subfeatures as a direct result of stabilizing the majority of it. This code doesn't know about those yet. It can't, as they haven't landed, as building this code blocks Rust's CI but the expected-to-be-stabilized API can't be stabilized as long as this code requires that feature.