### PR TITLE
Switch to CoercePointee macro, with examples

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1978,6 +1978,9 @@ config RUST
 
 	  If unsure, say N.
 
+config RUST_COERCE_POINTEE
+	def_bool y if RUSTC_VERSION >= 108300
+
 config RUSTC_VERSION_TEXT
 	string
 	depends on RUST

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -13,11 +13,12 @@
 
 #![no_std]
 #![feature(arbitrary_self_types)]
-#![feature(coerce_unsized)]
-#![feature(dispatch_from_dyn)]
+#![cfg_attr(CONFIG_RUST_COERCE_POINTEE, feature(derive_coerce_pointee))]
+#![cfg_attr(not(CONFIG_RUST_COERCE_POINTEE), feature(coerce_unsized))]
+#![cfg_attr(not(CONFIG_RUST_COERCE_POINTEE), feature(dispatch_from_dyn))]
+#![cfg_attr(not(CONFIG_RUST_COERCE_POINTEE), feature(unsize))]
 #![feature(inline_const)]
 #![feature(lint_reasons)]
-#![feature(unsize)]
 
 // Ensure conditional compilation based on the kernel configuration works;
 // otherwise we may silently break things like initcall handling.

--- a/rust/kernel/list/arc.rs
+++ b/rust/kernel/list/arc.rs
@@ -7,7 +7,7 @@
 use crate::alloc::{AllocError, Flags};
 use crate::prelude::*;
 use crate::sync::{Arc, ArcBorrow, UniqueArc};
-use core::marker::{PhantomPinned, Unsize};
+use core::marker::PhantomPinned;
 use core::ops::Deref;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -159,6 +159,7 @@ pub use impl_list_arc_safe;
 ///
 /// [`List`]: crate::list::List
 #[repr(transparent)]
+#[cfg_attr(CONFIG_RUST_COERCE_POINTEE, derive(core::marker::CoercePointee))]
 pub struct ListArc<T, const ID: u64 = 0>
 where
     T: ListArcSafe<ID> + ?Sized,
@@ -443,18 +444,20 @@ where
 
 // This is to allow coercion from `ListArc<T>` to `ListArc<U>` if `T` can be converted to the
 // dynamically-sized type (DST) `U`.
+#[cfg(not(CONFIG_RUST_COERCE_POINTEE))]
 impl<T, U, const ID: u64> core::ops::CoerceUnsized<ListArc<U, ID>> for ListArc<T, ID>
 where
-    T: ListArcSafe<ID> + Unsize<U> + ?Sized,
+    T: ListArcSafe<ID> + core::marker::Unsize<U> + ?Sized,
     U: ListArcSafe<ID> + ?Sized,
 {
 }
 
 // This is to allow `ListArc<U>` to be dispatched on when `ListArc<T>` can be coerced into
 // `ListArc<U>`.
+#[cfg(not(CONFIG_RUST_COERCE_POINTEE))]
 impl<T, U, const ID: u64> core::ops::DispatchFromDyn<ListArc<U, ID>> for ListArc<T, ID>
 where
-    T: ListArcSafe<ID> + Unsize<U> + ?Sized,
+    T: ListArcSafe<ID> + core::marker::Unsize<U> + ?Sized,
     U: ListArcSafe<ID> + ?Sized,
 {
 }

--- a/samples/rust/rust_print_main.rs
+++ b/samples/rust/rust_print_main.rs
@@ -34,6 +34,21 @@ fn arc_print() -> Result {
     // Uses `dbg` to print, will move `c` (for temporary debugging purposes).
     dbg!(c);
 
+    {
+        use core::fmt::Display;
+        fn arc_dyn_print(arc: &Arc<dyn Display>) {
+            pr_info!("Arc<dyn Display> says {arc}");
+        }
+        // `Arc` can be used to delegate dynamic dispatch and the following is an example.
+        // Both `i32` and `&str` implements `Display`.
+        // This enables us to express a unified behaviour, contract or protocol
+        // on both `i32` and `&str` into a single `Arc` type `Arc<dyn Display>`.
+        let a_i32_display: Arc<dyn Display> = Arc::new(42i32, GFP_KERNEL)?;
+        let a_str_display: Arc<dyn Display> = a.clone();
+        arc_dyn_print(&a_i32_display);
+        arc_dyn_print(&a_str_display);
+    }
+
     // Pretty-prints the debug formatting with lower-case hexadecimal integers.
     pr_info!("{:#x?}", a);
 


### PR DESCRIPTION
*Target audience: first timers to build kernel with Rust support*

This patch demonstrates the new capability from the current Rust Nightly, which now supports the `#[derive(CoercePointee)]` macro to derive the key trait implementations, in place of use of unstable language features such as `Unsize` and `DispatchFromDyn`.

An illustrative example is attached for more details in the Rust sample kernel module.

## How to test this

As usual, you shall follow the guide to set up the toolchain: https://docs.kernel.org/rust/quick-start.html. This demonstration can be executed through virtualization. In this case, during configuration through *make LLVM=1 menuconfig*, be sure to select *Enable Paravirtualization code* and *KVM Guest support* under *Processor type and features*/*Linux guest support*; also select *Printing Macros* as modularised under *Kernel hacking*/*Sample kernel code*/*Rust samples*. Initiate build with *make LLVM=1* optionally with *-j* for parallelism.

Meanwhile, you will need busybox from https://www.busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox. I am running a x86_64 box, so the demo uses *qemu-system-x86_64* as the emulator. I will use the *usr/gen_init_cpio* script for generating the initramfs image *initram.img*. Here is the description I used.

```
dir     /bin                                          0755 0 0
dir     /sys                                          0755 0 0
dir     /dev                                          0755 0 0
file    /bin/busybox  <path to busybox>                         0755 0 0
slink   /bin/sh       /bin/busybox                    0755 0 0
slink   /bin/mount    /bin/busybox                    0755 0 0
slink   /bin/insmod   /bin/busybox                    0755 0 0
slink   /bin/rmmod    /bin/busybox                    0755 0 0
slink   /bin/cut      /bin/busybox                    0755 0 0
slink   /bin/cat      /bin/busybox                    0755 0 0
slink   /bin/cd       /bin/busybox                    0755 0 0
slink   /bin/ls       /bin/busybox                    0755 0 0
file    /init         init                            0755 0 0
file    /rust_print.ko <path to linux>/linux/samples/rust/rust_print.ko 0755 0 0
```

I used this command to launch the emulation and it dropped to a shell.

```
qemu-system-x86_64 \
    -kernel arch/x86_64/boot/bzImage \
    -initrd <path to initram.img> \
    -M pc \
    -m 4G \
    -cpu Cascadelake-Server \
    -smp 4 \
    -nographic \
    -vga none \
    -no-reboot \
    -accel kvm \
    -append 'console=ttyS0'
```

In the shell I executed `insmod rust_print.ko`.

## What would you see

Upon successful launch, a quick `insmod rust_print.ko` will generate some kernel log. You may watch out for the following log stanza, especially the lines containing the text `Arc<dyn Display>`.

```
...
[   36.255440] rust_print: "hello, world"
[   36.255627] rust_print: [samples/rust/rust_print.rs:35:5] c = "hello, world"
[   36.256245] rust_print: Arc<dyn Display> says 42
[   36.256267] rust_print: Arc<dyn Display> says hello, world
[   36.256579] rust_print: "hello, world"
...
```

*TODO(@wieDasDing): work on the patch epilogue a bit more*