### PR TITLE
rust: kernel: uaccess: mark UserSliceReader methods inline

### DIFF
--- a/rust/kernel/uaccess.rs
+++ b/rust/kernel/uaccess.rs
@@ -218,6 +218,7 @@ impl UserSliceReader {
     /// # Guarantees
     ///
     /// After a successful call to this method, all bytes in `out` are initialized.
+    #[inline]
     pub fn read_raw(&mut self, out: &mut [MaybeUninit<u8>]) -> Result {
         let len = out.len();
         let out_ptr = out.as_mut_ptr().cast::<c_void>();
@@ -239,6 +240,7 @@ impl UserSliceReader {
     ///
     /// Fails with [`EFAULT`] if the read happens on a bad address, or if the read goes out of
     /// bounds of this [`UserSliceReader`]. This call may modify `out` even if it returns an error.
+    #[inline]
     pub fn read_slice(&mut self, out: &mut [u8]) -> Result {
         // SAFETY: The types are compatible and `read_raw` doesn't write uninitialized bytes to
         // `out`.


### PR DESCRIPTION

When you build the kernel using the llvm-19.1.4-rust-1.83.0-x86_64
toolchain provided by kernel.org with ARCH=x86_64, the following symbols
are generated:

$nm vmlinux | grep ' _R'.*UserSliceReader | rustfilt
ffffffff817c3320 T <kernel::uaccess::UserSliceReader>::read_slice
ffffffff817c32b0 T <kernel::uaccess::UserSliceReader>::read_raw

However, these Rust symbols are trivial wrappers around the functions
copy_from_user, _copy_from_user respectively. It doesn't
make sense to go through a trivial wrapper for these functions, so mark
them inline.

After applying this patch, the above command will produce no output.