### PR TITLE
rust: kernel: add a function that that returns a reference to the IoPort Resource

### DIFF
--- a/rust/kernel/io/resource.rs
+++ b/rust/kernel/io/resource.rs
@@ -18,6 +18,13 @@ use crate::types::Opaque;
 /// `CONFIG_PHYS_ADDR_T_64BIT`, and it can be a u64 even on 32-bit architectures.
 pub type ResourceSize = bindings::phys_addr_t;
 
+#[cfg(CONFIG_HAS_IOPORT)]
+/// Returns a reference to the global `ioport_resource` variable.
+pub fn ioport_resource() -> &'static Resource {
+    // SAFETY: `bindings::ioport_resoure` has global lifetime and is of type Resource.
+    unsafe { Resource::from_raw(&raw mut bindings::ioport_resource) }
+}
+
 /// A region allocated from a parent [`Resource`].
 ///
 /// # Invariants


### PR DESCRIPTION
This pull request adds a function to `kernel::io::resource` that returns a reference to a `Resource` that points to the kernel's IO Ports .

There does not seem to be any other way to reserve an IO Port range, as `Resource::from_raw` is private. This was inspired by https://github.com/AsahiLinux/linux/blob/5ce014f7fa18021227bf46bd155b4ccf375a9dd3/rust/kernel/io/resource.rs#L13-L18.

I am not sure that this is safe and any feedback is welcome.

Signed-off-by: Alexandru Radovici alexandru.radovici@wyliodrin.com