### PR TITLE
rust: correct documentation comment for RBTree cursor::peek_next method

### DIFF
--- a/rust/kernel/rbtree.rs
+++ b/rust/kernel/rbtree.rs
@@ -835,7 +835,7 @@ impl<'a, K, V> Cursor<'a, K, V> {
         self.peek(Direction::Prev)
     }
 
-    /// Access the previous node without moving the cursor.
+    /// Access the next node without moving the cursor.
     pub fn peek_next(&self) -> Option<(&K, &V)> {
         self.peek(Direction::Next)
     }


### PR DESCRIPTION
The peek_next method's doc comment incorrectly stated it accesses the "previous" node when it actually accesses the next node. This commit fixes the documentation to accurately reflect the method's behavior.
