### PR TITLE
rust: workqueue: fix safety comments in WorkItemPointer for Pin<KBox>

### DIFF
--- a/rust/kernel/workqueue.rs
+++ b/rust/kernel/workqueue.rs
@@ -890,9 +890,9 @@ where
     unsafe extern "C" fn run(ptr: *mut bindings::work_struct) {
         // The `__enqueue` method always uses a `work_struct` stored in a `Work<T, ID>`.
         let ptr = ptr.cast::<Work<T, ID>>();
-        // SAFETY: This computes the pointer that `__enqueue` got from `Arc::into_raw`.
+        // SAFETY: This computes the pointer that `__enqueue` got from `KBox::into_raw`.
         let ptr = unsafe { T::work_container_of(ptr) };
-        // SAFETY: This pointer comes from `Arc::into_raw` and we've been given back ownership.
+        // SAFETY: This pointer comes from `KBox::into_raw` and we've been given back ownership.
         let boxed = unsafe { KBox::from_raw(ptr) };
         // SAFETY: The box was already pinned when it was enqueued.
         let pinned = unsafe { Pin::new_unchecked(boxed) };


### PR DESCRIPTION
The safety comments in the impl WorkItemPointer for Pin<KBox> incorrectly
refer to Arc when they should refer to KBox, since this implementation uses
KBox instead of Arc.

Fix the safety comments to properly reference KBox.

Suggested-by: onur-ozkan <onur-ozkan@users.noreply.github.com>
Link: https://github.com/Rust-for-Linux/linux/issues/1233

This patch follows the kernel contribution guidelines and is signed off
under the Developer's Certificate of Origin.